### PR TITLE
feat: add namingConvention option and pass generator to renderers

### DIFF
--- a/docs/generators.md
+++ b/docs/generators.md
@@ -25,6 +25,9 @@ Default options contain:
 | `indentation` | Object | Options for indentation. | - |
 | `indentation.type` | String | Type of indentation. Its value can be either `SPACES` or `TABS`. | `SPACES` |
 | `indentation.size` | String | Size of indentation. | 2 |
+| `namingConvention` | Object | Options for naming conventions. | - |
+| `namingConvention.type` | Function | A function that returns the format of the type. | _Returns pascal cased name_ |
+| `namingConvention.property` | Function | A function that returns the format of the property. | _Returns camel cased name_ |
 | `defaultPreset` | Object | Default preset for generator. For more information, read [customization](./customization.md) document. | _Implemented by generator_ |
 | `presets` | Array | Array contains **presets**. For more information, read [customization](./customization.md) document. | `[]` |
 
@@ -36,6 +39,12 @@ Below is a list of additional options available for a given generator.
 |---|---|---|---|
 | `renderTypes` | Boolean | Render signature for types. | `true` |
 | `modelType` | String | It indicates which model type should be rendered for the `object` type. Its value can be either `interface` or `class`. | `class` |
+
+### [Java](../src/generators/java/JavaGenerator.ts)
+
+| Option | Type | Description | Default value |
+|---|---|---|---|
+| `collectionType` | String | It indicates with which signature should be rendered the `array` type. Its value can be either `List` (`List<{type}>`) or `Array` (`{type}[]`). | `List` |
 
 ## Custom generator
 

--- a/src/generators/AbstractGenerator.ts
+++ b/src/generators/AbstractGenerator.ts
@@ -1,6 +1,6 @@
 import { CommonInputModel, CommonModel, OutputModel, Preset, Presets } from '../models';
 import { InputProcessor } from '../processors';
-import { IndentationTypes } from '../helpers';
+import { FormatHelpers, IndentationTypes } from '../helpers';
 import { isPresetWithOptions } from '../utils';
 
 export interface CommonGeneratorOptions<P extends Preset = Preset> {
@@ -8,15 +8,29 @@ export interface CommonGeneratorOptions<P extends Preset = Preset> {
     type: IndentationTypes;
     size: number;
   };
+  namingConvention?: {
+    type?: (name: string | undefined, ctx: { model: CommonModel, inputModel: CommonInputModel }) => string;
+    property?: (name: string | undefined, ctx: { model: CommonModel, inputModel: CommonInputModel, property?: CommonModel }) => string;
+  };
   defaultPreset?: P;
   presets?: Presets<P>;
 }
 
-export const defaultGeneratorOptions = {
+export const defaultGeneratorOptions: CommonGeneratorOptions = {
   indentation: {
     type: IndentationTypes.SPACES,
     size: 2,
   },
+  namingConvention: {
+    type: (name: string | undefined) => {
+      if (!name) return '';
+      return FormatHelpers.toPascalCase(name);
+    },
+    property: (name: string | undefined) => {
+      if (!name) return '';
+      return FormatHelpers.toCamelCase(name);
+    }
+  }
 };
 
 /**
@@ -87,6 +101,11 @@ export abstract class AbstractGenerator<Options extends CommonGeneratorOptions =
       ...defaultGeneratorOptions,
       ...defaultOptions,
       ...passedOptions,
+      namingConvention: {
+        ...(defaultGeneratorOptions.namingConvention || {}),
+        ...(defaultOptions.namingConvention || {}),
+        ...(passedOptions.namingConvention || {}),
+      }
     };
   }
 }

--- a/src/generators/AbstractRenderer.ts
+++ b/src/generators/AbstractRenderer.ts
@@ -1,16 +1,20 @@
-import { CommonGeneratorOptions } from './AbstractGenerator';
+import { AbstractGenerator, CommonGeneratorOptions } from './AbstractGenerator';
 import { CommonModel, CommonInputModel, Preset } from '../models';
 import { FormatHelpers, IndentationTypes } from '../helpers';
 
 /**
  * Abstract renderer with common helper methods
  */
-export abstract class AbstractRenderer<O extends CommonGeneratorOptions = CommonGeneratorOptions> {
+export abstract class AbstractRenderer<
+  O extends CommonGeneratorOptions = CommonGeneratorOptions,
+  G extends AbstractGenerator = AbstractGenerator,
+> {
   constructor(
     protected readonly options: O,
     protected readonly presets: Array<[Preset, unknown]>,
     protected readonly model: CommonModel, 
     protected readonly inputModel: CommonInputModel,
+    protected readonly _generator?: G,
   ) {}
 
   renderLine(line: string): string {
@@ -30,6 +34,24 @@ export abstract class AbstractRenderer<O extends CommonGeneratorOptions = Common
     size = size || this.options.indentation?.size;
     type = type || this.options.indentation?.type;
     return FormatHelpers.indent(content, size, type);
+  }
+
+  nameType(name: string | undefined): string {
+    if (!name) return '';
+    return this.options?.namingConvention?.type 
+      ? this.options.namingConvention.type(name, { model: this.model, inputModel: this.inputModel })
+      : name;
+  }
+
+  nameProperty(name: string | undefined, property?: CommonModel): string {
+    if (!name) return '';
+    return this.options?.namingConvention?.property 
+      ? this.options.namingConvention.property(name, { model: this.model, inputModel: this.inputModel, property })
+      : name;
+  }
+
+  getGenerator() {
+    return this._generator;
   }
 
   async runSelfPreset(): Promise<string> {

--- a/src/generators/AbstractRenderer.ts
+++ b/src/generators/AbstractRenderer.ts
@@ -36,15 +36,15 @@ export abstract class AbstractRenderer<
     return FormatHelpers.indent(content, size, type);
   }
 
-  nameType(name: string | undefined): string {
-    if (!name) return '';
+  nameType(name: string | undefined, model?: CommonModel): string {
+    name = name || '';
     return this.options?.namingConvention?.type 
-      ? this.options.namingConvention.type(name, { model: this.model, inputModel: this.inputModel })
+      ? this.options.namingConvention.type(name, { model: model || this.model, inputModel: this.inputModel })
       : name;
   }
 
   nameProperty(name: string | undefined, property?: CommonModel): string {
-    if (!name) return '';
+    name = name || '';
     return this.options?.namingConvention?.property 
       ? this.options.namingConvention.property(name, { model: this.model, inputModel: this.inputModel, property })
       : name;

--- a/src/generators/AbstractRenderer.ts
+++ b/src/generators/AbstractRenderer.ts
@@ -11,10 +11,10 @@ export abstract class AbstractRenderer<
 > {
   constructor(
     protected readonly options: O,
+    protected readonly generator: G,
     protected readonly presets: Array<[Preset, unknown]>,
     protected readonly model: CommonModel, 
     protected readonly inputModel: CommonInputModel,
-    protected readonly _generator?: G,
   ) {}
 
   renderLine(line: string): string {
@@ -48,10 +48,6 @@ export abstract class AbstractRenderer<
     return this.options?.namingConvention?.property 
       ? this.options.namingConvention.property(name, { model: this.model, inputModel: this.inputModel, property })
       : name;
-  }
-
-  getGenerator() {
-    return this._generator;
   }
 
   async runSelfPreset(): Promise<string> {

--- a/src/generators/AbstractRenderer.ts
+++ b/src/generators/AbstractRenderer.ts
@@ -10,8 +10,8 @@ export abstract class AbstractRenderer<
   G extends AbstractGenerator = AbstractGenerator,
 > {
   constructor(
-    protected readonly options: O,
-    protected readonly generator: G,
+    readonly options: O,
+    readonly generator: G,
     protected readonly presets: Array<[Preset, unknown]>,
     protected readonly model: CommonModel, 
     protected readonly inputModel: CommonInputModel,

--- a/src/generators/java/JavaGenerator.ts
+++ b/src/generators/java/JavaGenerator.ts
@@ -37,13 +37,13 @@ export class JavaGenerator extends AbstractGenerator<JavaOptions> {
 
   async renderClass(model: CommonModel, inputModel: CommonInputModel): Promise<string> {
     const presets = this.getPresets('class');
-    const renderer = new ClassRenderer(this.options, presets, model, inputModel);
+    const renderer = new ClassRenderer(this.options, presets, model, inputModel, this);
     return renderer.runSelfPreset();
   }
 
   async renderEnum(model: CommonModel, inputModel: CommonInputModel): Promise<string> {
     const presets = this.getPresets('enum'); 
-    const renderer = new EnumRenderer(this.options, presets, model, inputModel);
+    const renderer = new EnumRenderer(this.options, presets, model, inputModel, this);
     return renderer.runSelfPreset();
   }
 }

--- a/src/generators/java/JavaGenerator.ts
+++ b/src/generators/java/JavaGenerator.ts
@@ -37,13 +37,13 @@ export class JavaGenerator extends AbstractGenerator<JavaOptions> {
 
   async renderClass(model: CommonModel, inputModel: CommonInputModel): Promise<string> {
     const presets = this.getPresets('class');
-    const renderer = new ClassRenderer(this.options, presets, model, inputModel, this);
+    const renderer = new ClassRenderer(this.options, this, presets, model, inputModel);
     return renderer.runSelfPreset();
   }
 
   async renderEnum(model: CommonModel, inputModel: CommonInputModel): Promise<string> {
     const presets = this.getPresets('enum'); 
-    const renderer = new EnumRenderer(this.options, presets, model, inputModel, this);
+    const renderer = new EnumRenderer(this.options, this, presets, model, inputModel);
     return renderer.runSelfPreset();
   }
 }

--- a/src/generators/java/JavaGenerator.ts
+++ b/src/generators/java/JavaGenerator.ts
@@ -11,12 +11,15 @@ import { JavaPreset, JAVA_DEFAULT_PRESET } from './JavaPreset';
 import { ClassRenderer } from './renderers/ClassRenderer';
 import { EnumRenderer } from './renderers/EnumRenderer';
 
-export type JavaOptions = CommonGeneratorOptions<JavaPreset>
+export interface JavaOptions extends CommonGeneratorOptions<JavaPreset> {
+  collectionType?: 'List' | 'Array';
+}
 
 export class JavaGenerator extends AbstractGenerator<JavaOptions> {
   static defaultOptions: JavaOptions = {
     ...defaultGeneratorOptions,
     defaultPreset: JAVA_DEFAULT_PRESET,
+    collectionType: 'List',
   };
 
   constructor(

--- a/src/generators/java/JavaRenderer.ts
+++ b/src/generators/java/JavaRenderer.ts
@@ -2,7 +2,7 @@ import { AbstractRenderer } from '../AbstractRenderer';
 import { JavaOptions, JavaGenerator } from './JavaGenerator';
 
 import { CommonModel, CommonInputModel, Preset } from '../../models';
-import { FormatHelpers } from '../../helpers';
+import { TypeHelpers, ModelKind, FormatHelpers } from '../../helpers';
 
 /**
  * Common renderer for Java types
@@ -25,10 +25,16 @@ export abstract class JavaRenderer extends AbstractRenderer<JavaOptions, JavaGen
       return 'Object'; // fallback
     }
     if (model.$ref !== undefined) {
-      return this.nameType(model.$ref);
+      return this.nameType(model.$ref, model);
     }
-    const format = model.getFromSchema('format');
-    return this.toClassType(this.toJavaType(format || model.type, model));
+    if (
+      TypeHelpers.extractKind(model) === ModelKind.PRIMITIVE ||
+      TypeHelpers.extractKind(model) === ModelKind.ARRAY
+    ) {
+      const format = model.getFromSchema('format');
+      return this.toClassType(this.toJavaType(format || model.type, model));
+    }
+    return this.nameType(model.$id, model);
   }
 
   toJavaType(type: string | undefined, model: CommonModel): string {

--- a/src/generators/java/JavaRenderer.ts
+++ b/src/generators/java/JavaRenderer.ts
@@ -66,7 +66,10 @@ export abstract class JavaRenderer extends AbstractRenderer<JavaOptions, JavaGen
     case 'binary':
       return 'byte[]';
     case 'array': {
-      const type = model?.items ? this.renderType(model.items) : 'Object';
+      const type = model.items ? this.renderType(model.items) : 'Object';
+      if (this.options.collectionType && this.options.collectionType === 'List') {
+        return `List<${type}>`;
+      }
       return `${type}[]`;
     }
     default:

--- a/src/generators/java/JavaRenderer.ts
+++ b/src/generators/java/JavaRenderer.ts
@@ -1,5 +1,5 @@
 import { AbstractRenderer } from '../AbstractRenderer';
-import { JavaOptions } from './JavaGenerator';
+import { JavaOptions, JavaGenerator } from './JavaGenerator';
 
 import { CommonModel, CommonInputModel, Preset } from '../../models';
 import { FormatHelpers } from '../../helpers';
@@ -9,14 +9,15 @@ import { FormatHelpers } from '../../helpers';
  * 
  * @extends AbstractRenderer
  */
-export abstract class JavaRenderer extends AbstractRenderer<JavaOptions> {
+export abstract class JavaRenderer extends AbstractRenderer<JavaOptions, JavaGenerator> {
   constructor(
     options: JavaOptions,
     presets: Array<[Preset, unknown]>,
     model: CommonModel, 
     inputModel: CommonInputModel,
+    generator: JavaGenerator,
   ) {
-    super(options, presets, model, inputModel);
+    super(options, presets, model, inputModel, generator);
   }
 
   renderType(model: CommonModel | CommonModel[]): string {
@@ -24,7 +25,7 @@ export abstract class JavaRenderer extends AbstractRenderer<JavaOptions> {
       return 'Object'; // fallback
     }
     if (model.$ref !== undefined) {
-      return model.$ref;
+      return this.nameType(model.$ref);
     }
     const format = model.getFromSchema('format');
     return this.toClassType(this.toJavaType(format || model.type, model));

--- a/src/generators/java/JavaRenderer.ts
+++ b/src/generators/java/JavaRenderer.ts
@@ -12,12 +12,12 @@ import { FormatHelpers } from '../../helpers';
 export abstract class JavaRenderer extends AbstractRenderer<JavaOptions, JavaGenerator> {
   constructor(
     options: JavaOptions,
+    generator: JavaGenerator,
     presets: Array<[Preset, unknown]>,
     model: CommonModel, 
     inputModel: CommonInputModel,
-    generator: JavaGenerator,
   ) {
-    super(options, presets, model, inputModel, generator);
+    super(options, generator, presets, model, inputModel);
   }
 
   renderType(model: CommonModel | CommonModel[]): string {

--- a/src/generators/java/presets/CommonPreset.ts
+++ b/src/generators/java/presets/CommonPreset.ts
@@ -19,7 +19,7 @@ function renderEqual({ renderer, model }: {
   renderer: JavaRenderer,
   model: CommonModel,
 }): string {
-  const formattedModelName = model.$id && FormatHelpers.toPascalCase(model.$id);
+  const formattedModelName = renderer.nameType(model.$id);
   const properties = model.properties || {};
   const equalProperties = Object.keys(properties).map(prop => {
     const camelCasedProp = FormatHelpers.toCamelCase(prop);
@@ -67,10 +67,10 @@ function renderToString({ renderer, model }: {
   renderer: JavaRenderer,
   model: CommonModel,
 }): string {
-  const formattedModelName = model.$id && FormatHelpers.toPascalCase(model.$id);
+  const formattedModelName = renderer.nameType(model.$id);
   const properties = model.properties || {};
   const toStringProperties = Object.keys(properties).map(prop => 
-    `"    ${prop}: " + toIndentedString(${FormatHelpers.toCamelCase(prop)}) + "\\n" +`
+    `"    ${renderer.nameProperty(prop)}: " + toIndentedString(${FormatHelpers.toCamelCase(prop)}) + "\\n" +`
   );
 
   return `${renderer.renderAnnotation('Override')}

--- a/src/generators/java/renderers/ClassRenderer.ts
+++ b/src/generators/java/renderers/ClassRenderer.ts
@@ -17,7 +17,7 @@ export class ClassRenderer extends JavaRenderer {
       await this.runAdditionalContentPreset(),
     ];
 
-    const formattedName = this.model.$id && FormatHelpers.toPascalCase(this.model.$id);
+    const formattedName = this.nameType(this.model.$id);
     return `public class ${formattedName} {
 ${this.indent(this.renderBlock(content, 2))}
 }`;
@@ -70,19 +70,19 @@ export const JAVA_DEFAULT_CLASS_PRESET: ClassPreset<ClassRenderer> = {
     return renderer.defaultSelf();
   },
   property({ renderer, propertyName, property }) {
-    propertyName = FormatHelpers.toCamelCase(propertyName);
-    return `private ${renderer.renderType(property)} ${propertyName};`;
+    const formattedName = renderer.nameProperty(propertyName, property);
+    return `private ${renderer.renderType(property)} ${formattedName};`;
   },
   getter({ renderer, propertyName, property }) {
-    propertyName = FormatHelpers.toCamelCase(propertyName);
     const getterName = FormatHelpers.toPascalCase(propertyName);
     const type = renderer.renderType(property);
-    return `public ${type} get${getterName}() { return this.${propertyName}; }`;
+    const formattedName = renderer.nameProperty(propertyName, property);
+    return `public ${type} get${getterName}() { return this.${formattedName}; }`;
   },
   setter({ renderer, propertyName, property }) {
-    propertyName = FormatHelpers.toCamelCase(propertyName);
     const setterName = FormatHelpers.toPascalCase(propertyName);
     const type = renderer.renderType(property);
-    return `public void set${setterName}(${type} ${propertyName}) { this.${propertyName} = ${propertyName}; }`;
+    const formattedName = renderer.nameProperty(propertyName, property);
+    return `public void set${setterName}(${type} ${formattedName}) { this.${formattedName} = ${formattedName}; }`;
   },
 };

--- a/src/generators/java/renderers/EnumRenderer.ts
+++ b/src/generators/java/renderers/EnumRenderer.ts
@@ -15,7 +15,7 @@ export class EnumRenderer extends JavaRenderer {
       await this.runAdditionalContentPreset(),
     ];
 
-    const formattedName = this.model.$id && FormatHelpers.toPascalCase(this.model.$id);
+    const formattedName = this.nameType(this.model.$id);
     return `public enum ${formattedName} {
 ${this.indent(this.renderBlock(content, 2))}
 }`;
@@ -71,7 +71,7 @@ export const JAVA_DEFAULT_ENUM_PRESET: EnumPreset<EnumRenderer> = {
     return `${key}(${value})`;
   },
   additionalContent({ renderer, model }) {
-    const enumName = model.$id;
+    const enumName = renderer.nameType(model.$id);
     const type = Array.isArray(model.type) ? 'Object' : model.type;
     const classType = renderer.toClassType(renderer.toJavaType(type, model));
 

--- a/src/generators/javascript/JavaScriptGenerator.ts
+++ b/src/generators/javascript/JavaScriptGenerator.ts
@@ -39,7 +39,7 @@ export class JavaScriptGenerator extends AbstractGenerator<JavaScriptOptions> {
 
   async renderClass(model: CommonModel, inputModel: CommonInputModel): Promise<string> {
     const presets = this.getPresets('class'); 
-    const renderer = new ClassRenderer(this.options, presets, model, inputModel);
+    const renderer = new ClassRenderer(this.options, presets, model, inputModel, this);
     return renderer.runSelfPreset();
   }
 }

--- a/src/generators/javascript/JavaScriptGenerator.ts
+++ b/src/generators/javascript/JavaScriptGenerator.ts
@@ -39,7 +39,7 @@ export class JavaScriptGenerator extends AbstractGenerator<JavaScriptOptions> {
 
   async renderClass(model: CommonModel, inputModel: CommonInputModel): Promise<string> {
     const presets = this.getPresets('class'); 
-    const renderer = new ClassRenderer(this.options, presets, model, inputModel, this);
+    const renderer = new ClassRenderer(this.options, this, presets, model, inputModel);
     return renderer.runSelfPreset();
   }
 }

--- a/src/generators/javascript/JavaScriptRenderer.ts
+++ b/src/generators/javascript/JavaScriptRenderer.ts
@@ -12,12 +12,12 @@ import { CommonModel, CommonInputModel, Preset } from '../../models';
 export abstract class JavaScriptRenderer extends AbstractRenderer<JavaScriptOptions, JavaScriptGenerator> {
   constructor(
     options: JavaScriptOptions,
+    generator: JavaScriptGenerator,
     presets: Array<[Preset, unknown]>,
     model: CommonModel, 
     inputModel: CommonInputModel,
-    generator: JavaScriptGenerator,
   ) {
-    super(options, presets, model, inputModel, generator);
+    super(options, generator, presets, model, inputModel);
   }
 
   renderComments(lines: string | string[]): string {

--- a/src/generators/javascript/JavaScriptRenderer.ts
+++ b/src/generators/javascript/JavaScriptRenderer.ts
@@ -1,5 +1,5 @@
 import { AbstractRenderer } from '../AbstractRenderer';
-import { JavaScriptOptions } from './JavaScriptGenerator';
+import { JavaScriptOptions, JavaScriptGenerator } from './JavaScriptGenerator';
 
 import { FormatHelpers } from '../../helpers';
 import { CommonModel, CommonInputModel, Preset } from '../../models';
@@ -9,14 +9,15 @@ import { CommonModel, CommonInputModel, Preset } from '../../models';
  * 
  * @extends AbstractRenderer
  */
-export abstract class JavaScriptRenderer extends AbstractRenderer<JavaScriptOptions> {
+export abstract class JavaScriptRenderer extends AbstractRenderer<JavaScriptOptions, JavaScriptGenerator> {
   constructor(
     options: JavaScriptOptions,
     presets: Array<[Preset, unknown]>,
     model: CommonModel, 
     inputModel: CommonInputModel,
+    generator: JavaScriptGenerator,
   ) {
-    super(options, presets, model, inputModel);
+    super(options, presets, model, inputModel, generator);
   }
 
   renderComments(lines: string | string[]): string {

--- a/src/generators/javascript/renderers/ClassRenderer.ts
+++ b/src/generators/javascript/renderers/ClassRenderer.ts
@@ -1,7 +1,6 @@
 import { JavaScriptRenderer } from '../JavaScriptRenderer';
 
 import { CommonModel, ClassPreset } from '../../../models';
-import { FormatHelpers } from '../../../helpers';
 
 /**
  * Renderer for JavaScript's `class` type
@@ -17,7 +16,7 @@ export class ClassRenderer extends JavaScriptRenderer {
       await this.runAdditionalContentPreset(),
     ];
 
-    const formattedName = this.model.$id && FormatHelpers.toPascalCase(this.model.$id);
+    const formattedName = this.nameType(this.model.$id);
     return `class ${formattedName} {
 ${this.indent(this.renderBlock(content, 2))}
 }`;
@@ -55,9 +54,9 @@ export const JS_DEFAULT_CLASS_PRESET: ClassPreset<ClassRenderer> = {
   },
   ctor({ renderer, model }) {
     const properties = model.properties || {};
-    const assigments = Object.keys(properties).map(property => {
-      property = FormatHelpers.toCamelCase(property);
-      return `this.${property} = input.${property};`;
+    const assigments = Object.entries(properties).map(([propertyName, property]) => {
+      propertyName = renderer.nameProperty(propertyName, property);
+      return `this.${propertyName} = input.${propertyName};`;
     });
     const body = renderer.renderBlock(assigments);
 
@@ -65,16 +64,16 @@ export const JS_DEFAULT_CLASS_PRESET: ClassPreset<ClassRenderer> = {
 ${renderer.indent(body)}
 }`;
   },
-  property({ propertyName }) {
-    propertyName = FormatHelpers.toCamelCase(propertyName);
-    return `${propertyName};`;
+  property({ renderer, propertyName, property }) {
+    const formattedName = renderer.nameProperty(propertyName, property);
+    return `${formattedName};`;
   },
-  getter({ propertyName }) {
-    propertyName = FormatHelpers.toCamelCase(propertyName);
-    return `get ${propertyName}() { return this.${propertyName}; }`;
+  getter({ renderer, propertyName, property }) {
+    const formattedName = renderer.nameProperty(propertyName, property);
+    return `get ${formattedName}() { return this.${formattedName}; }`;
   },
-  setter({ propertyName }) {
-    propertyName = FormatHelpers.toCamelCase(propertyName);
-    return `set ${propertyName}(${propertyName}) { this.${propertyName} = ${propertyName}; }`;
+  setter({ renderer, propertyName, property }) {
+    const formattedName = renderer.nameProperty(propertyName, property);
+    return `set ${formattedName}(${formattedName}) { this.${formattedName} = ${formattedName}; }`;
   },
 };

--- a/src/generators/typescript/TypeScriptGenerator.ts
+++ b/src/generators/typescript/TypeScriptGenerator.ts
@@ -50,25 +50,25 @@ export class TypeScriptGenerator extends AbstractGenerator<TypeScriptOptions> {
 
   async renderClass(model: CommonModel, inputModel: CommonInputModel): Promise<string> {
     const presets = this.getPresets('class'); 
-    const renderer = new ClassRenderer(this.options, presets, model, inputModel, this);
+    const renderer = new ClassRenderer(this.options, this, presets, model, inputModel);
     return renderer.runSelfPreset();
   }
 
   async renderInterface(model: CommonModel, inputModel: CommonInputModel): Promise<string> {
     const presets = this.getPresets('interface'); 
-    const renderer = new InterfaceRenderer(this.options, presets, model, inputModel, this);
+    const renderer = new InterfaceRenderer(this.options, this, presets, model, inputModel);
     return renderer.runSelfPreset();
   }
 
   async renderEnum(model: CommonModel, inputModel: CommonInputModel): Promise<string> {
     const presets = this.getPresets('enum'); 
-    const renderer = new EnumRenderer(this.options, presets, model, inputModel, this);
+    const renderer = new EnumRenderer(this.options, this, presets, model, inputModel);
     return renderer.runSelfPreset();
   }
 
   async renderType(model: CommonModel, inputModel: CommonInputModel): Promise<string> {
     const presets = this.getPresets('type'); 
-    const renderer = new TypeRenderer(this.options, presets, model, inputModel, this);
+    const renderer = new TypeRenderer(this.options, this, presets, model, inputModel);
     return renderer.runSelfPreset();
   }
 

--- a/src/generators/typescript/TypeScriptGenerator.ts
+++ b/src/generators/typescript/TypeScriptGenerator.ts
@@ -50,25 +50,25 @@ export class TypeScriptGenerator extends AbstractGenerator<TypeScriptOptions> {
 
   async renderClass(model: CommonModel, inputModel: CommonInputModel): Promise<string> {
     const presets = this.getPresets('class'); 
-    const renderer = new ClassRenderer(this.options, presets, model, inputModel);
+    const renderer = new ClassRenderer(this.options, presets, model, inputModel, this);
     return renderer.runSelfPreset();
   }
 
   async renderInterface(model: CommonModel, inputModel: CommonInputModel): Promise<string> {
     const presets = this.getPresets('interface'); 
-    const renderer = new InterfaceRenderer(this.options, presets, model, inputModel);
+    const renderer = new InterfaceRenderer(this.options, presets, model, inputModel, this);
     return renderer.runSelfPreset();
   }
 
   async renderEnum(model: CommonModel, inputModel: CommonInputModel): Promise<string> {
     const presets = this.getPresets('enum'); 
-    const renderer = new EnumRenderer(this.options, presets, model, inputModel);
+    const renderer = new EnumRenderer(this.options, presets, model, inputModel, this);
     return renderer.runSelfPreset();
   }
 
   async renderType(model: CommonModel, inputModel: CommonInputModel): Promise<string> {
     const presets = this.getPresets('type'); 
-    const renderer = new TypeRenderer(this.options, presets, model, inputModel);
+    const renderer = new TypeRenderer(this.options, presets, model, inputModel, this);
     return renderer.runSelfPreset();
   }
 

--- a/src/generators/typescript/TypeScriptRenderer.ts
+++ b/src/generators/typescript/TypeScriptRenderer.ts
@@ -1,5 +1,5 @@
 import { AbstractRenderer } from '../AbstractRenderer';
-import { TypeScriptOptions } from './TypeScriptGenerator';
+import { TypeScriptOptions, TypeScriptGenerator } from './TypeScriptGenerator';
 
 import { FormatHelpers } from '../../helpers';
 import { CommonModel, CommonInputModel, Preset } from '../../models';
@@ -9,14 +9,15 @@ import { CommonModel, CommonInputModel, Preset } from '../../models';
  * 
  * @extends AbstractRenderer
  */
-export abstract class TypeScriptRenderer extends AbstractRenderer<TypeScriptOptions> {
+export abstract class TypeScriptRenderer extends AbstractRenderer<TypeScriptOptions, TypeScriptGenerator> {
   constructor(
     options: TypeScriptOptions,
     presets: Array<[Preset, unknown]>,
     model: CommonModel, 
     inputModel: CommonInputModel,
+    generator: TypeScriptGenerator,
   ) {
-    super(options, presets, model, inputModel);
+    super(options, presets, model, inputModel, generator);
   }
 
   renderType(model: CommonModel | CommonModel[]): string {
@@ -24,7 +25,7 @@ export abstract class TypeScriptRenderer extends AbstractRenderer<TypeScriptOpti
       return model.map(t => this.renderType(t)).join(' | ');
     }
     if (model.$ref !== undefined) {
-      return model.$ref;
+      return this.nameType(model.$ref);
     }
     if (Array.isArray(model.type)) {
       return model.type.map(t => this.toTsType(t, model)).join(' | ');
@@ -90,7 +91,7 @@ ${lines.map(line => ` * ${line}`).join('\n')}
   }
 
   renderProperty(propertyName: string, property: CommonModel): string {
-    const name = FormatHelpers.toCamelCase(propertyName);
+    const name = this.nameProperty(propertyName, property);
     const signature = this.renderTypeSignature(property, { isRequired: this.model.isRequired(propertyName) });
     return `${name}${signature};`;
   }

--- a/src/generators/typescript/TypeScriptRenderer.ts
+++ b/src/generators/typescript/TypeScriptRenderer.ts
@@ -12,12 +12,12 @@ import { CommonModel, CommonInputModel, Preset } from '../../models';
 export abstract class TypeScriptRenderer extends AbstractRenderer<TypeScriptOptions, TypeScriptGenerator> {
   constructor(
     options: TypeScriptOptions,
+    generator: TypeScriptGenerator,
     presets: Array<[Preset, unknown]>,
     model: CommonModel, 
     inputModel: CommonInputModel,
-    generator: TypeScriptGenerator,
   ) {
-    super(options, presets, model, inputModel, generator);
+    super(options, generator, presets, model, inputModel);
   }
 
   renderType(model: CommonModel | CommonModel[]): string {

--- a/src/generators/typescript/renderers/EnumRenderer.ts
+++ b/src/generators/typescript/renderers/EnumRenderer.ts
@@ -15,7 +15,7 @@ export class EnumRenderer extends TypeScriptRenderer {
       await this.runAdditionalContentPreset(),
     ];
 
-    const formattedName = this.model.$id && FormatHelpers.toPascalCase(this.model.$id);
+    const formattedName = this.nameType(this.model.$id);
     return `enum ${formattedName} {
 ${this.indent(this.renderBlock(content, 2))}
 }`;

--- a/src/generators/typescript/renderers/InterfaceRenderer.ts
+++ b/src/generators/typescript/renderers/InterfaceRenderer.ts
@@ -15,7 +15,7 @@ export class InterfaceRenderer extends TypeScriptRenderer {
       await this.runAdditionalContentPreset(),
     ];
 
-    const formattedName = this.model.$id && FormatHelpers.toPascalCase(this.model.$id);
+    const formattedName = this.nameType(this.model.$id);
     return `interface ${formattedName} {
 ${this.indent(this.renderBlock(content, 2))}
 }`;

--- a/src/generators/typescript/renderers/InterfaceRenderer.ts
+++ b/src/generators/typescript/renderers/InterfaceRenderer.ts
@@ -1,7 +1,6 @@
 import { TypeScriptRenderer } from '../TypeScriptRenderer';
 
 import { InterfacePreset } from '../../../models';
-import { FormatHelpers } from '../../../helpers';
 
 /**
  * Renderer for TypeScript's `interface` type

--- a/src/generators/typescript/renderers/TypeRenderer.ts
+++ b/src/generators/typescript/renderers/TypeRenderer.ts
@@ -1,7 +1,7 @@
 import { TypeScriptRenderer } from '../TypeScriptRenderer';
 
 import { TypePreset } from '../TypeScriptPreset';
-import { FormatHelpers, TypeHelpers, ModelKind } from '../../../helpers';
+import { TypeHelpers, ModelKind } from '../../../helpers';
 
 /**
  * Renderer for TypeScript's `type` type

--- a/src/generators/typescript/renderers/TypeRenderer.ts
+++ b/src/generators/typescript/renderers/TypeRenderer.ts
@@ -11,7 +11,7 @@ import { FormatHelpers, TypeHelpers, ModelKind } from '../../../helpers';
 export class TypeRenderer extends TypeScriptRenderer {
   async defaultSelf(): Promise<string> {
     const body = await this.renderTypeBody();
-    const formattedName = this.model.$id && FormatHelpers.toPascalCase(this.model.$id);
+    const formattedName = this.nameType(this.model.$id);
     return `type ${formattedName} = ${body};`;
   }
 

--- a/test/generators/AbstractGenerator.spec.ts
+++ b/test/generators/AbstractGenerator.spec.ts
@@ -1,17 +1,17 @@
 import { AbstractGenerator } from '../../src/generators'; 
 import { CommonInputModel, CommonModel } from '../../src/models';
 
-describe('AbstractGenerator', function() {
-  class TestGenerator extends AbstractGenerator {
-    constructor() {
-      super("TestGenerator", {});
-    }
-
-    render(model: CommonModel, inputModel: CommonInputModel): any {
-      return model.$id || "rendered content";
-    }
+export class TestGenerator extends AbstractGenerator {
+  constructor() {
+    super("TestGenerator", {});
   }
 
+  render(model: CommonModel, inputModel: CommonInputModel): any {
+    return model.$id || "rendered content";
+  }
+}
+
+describe('AbstractGenerator', function() {
   let generator: TestGenerator;
   beforeEach(() => {
     generator = new TestGenerator();

--- a/test/generators/AbstractGenerator.spec.ts
+++ b/test/generators/AbstractGenerator.spec.ts
@@ -1,9 +1,24 @@
 import { AbstractGenerator } from '../../src/generators'; 
+import { IndentationTypes } from '../../src/helpers';
 import { CommonInputModel, CommonModel } from '../../src/models';
 
+export const testOptions = {
+  indentation: {
+    type: IndentationTypes.SPACES,
+    size: 2,
+  },
+  namingConvention: {
+    type: (name: string | undefined) => {
+      return `type__${name || ''}`;
+    },
+    property: (name: string | undefined) => {
+      return `property__${name || ''}`;
+    }
+  }
+};
 export class TestGenerator extends AbstractGenerator {
   constructor() {
-    super("TestGenerator", {});
+    super("TestGenerator", testOptions);
   }
 
   render(model: CommonModel, inputModel: CommonInputModel): any {

--- a/test/generators/AbstractRenderer.spec.ts
+++ b/test/generators/AbstractRenderer.spec.ts
@@ -2,25 +2,12 @@ import { AbstractRenderer } from '../../src/generators';
 import { IndentationTypes } from '../../src/helpers';
 import { CommonInputModel, CommonModel } from '../../src/models';
 
-import { TestGenerator } from './AbstractGenerator.spec';
+import { TestGenerator, testOptions } from './AbstractGenerator.spec';
 
 describe('AbstractRenderer', function() {
   class TestRenderer extends AbstractRenderer {
     constructor() {
-      super({
-        indentation: {
-          type: IndentationTypes.SPACES,
-          size: 2,
-        },
-        namingConvention: {
-          type: (name: string | undefined) => {
-            return `type__${name || ''}`;
-          },
-          property: (name: string | undefined) => {
-            return `property__${name || ''}`;
-          }
-        }
-      }, new TestGenerator(), [], new CommonModel(), new CommonInputModel());
+      super(testOptions, new TestGenerator(), [], new CommonModel(), new CommonInputModel());
     }
     render() { return "" }
   }
@@ -38,6 +25,14 @@ describe('AbstractRenderer', function() {
   test('renderBlock function should render multiple lines', async function() {
     const content = renderer.renderBlock(['Test1', 'Test2']);
     expect(content).toEqual('Test1\nTest2');
+  });
+
+  test('can use generator inside renderer', async function() {
+    const generator = renderer.generator;
+    const doc: any = { $id: 'test' };
+    const outputModels = await generator.generate(doc);
+
+    expect(outputModels[0].result).toEqual('test');
   });
 
   describe('indent()', function() {

--- a/test/generators/AbstractRenderer.spec.ts
+++ b/test/generators/AbstractRenderer.spec.ts
@@ -2,6 +2,8 @@ import { AbstractRenderer } from '../../src/generators';
 import { IndentationTypes } from '../../src/helpers';
 import { CommonInputModel, CommonModel } from '../../src/models';
 
+import { TestGenerator } from './AbstractGenerator.spec';
+
 describe('AbstractRenderer', function() {
   class TestRenderer extends AbstractRenderer {
     constructor() {
@@ -18,7 +20,7 @@ describe('AbstractRenderer', function() {
             return `property__${name || ''}`;
           }
         }
-      }, [], new CommonModel(), new CommonInputModel());
+      }, new TestGenerator(), [], new CommonModel(), new CommonInputModel());
     }
     render() { return "" }
   }

--- a/test/generators/AbstractRenderer.spec.ts
+++ b/test/generators/AbstractRenderer.spec.ts
@@ -10,6 +10,14 @@ describe('AbstractRenderer', function() {
           type: IndentationTypes.SPACES,
           size: 2,
         },
+        namingConvention: {
+          type: (name: string | undefined) => {
+            return `type__${name || ''}`;
+          },
+          property: (name: string | undefined) => {
+            return `property__${name || ''}`;
+          }
+        }
       }, [], new CommonModel(), new CommonInputModel());
     }
     render() { return "" }
@@ -38,6 +46,20 @@ describe('AbstractRenderer', function() {
     test('should render indentation  with options', function() {
       const content = renderer.indent('Test', 4, IndentationTypes.SPACES);
       expect(content).toEqual('    Test');
+    });
+  });
+
+  describe('nameType()', function() {
+    test('should name the type', function() {
+      const name = renderer.nameType('someType');
+      expect(name).toEqual('type__someType');
+    });
+  });
+
+  describe('nameProperty()', function() {
+    test('should name the property', function() {
+      const name = renderer.nameProperty('someProperty');
+      expect(name).toEqual('property__someProperty');
     });
   });
 });

--- a/test/generators/java/JavaGenerator.spec.ts
+++ b/test/generators/java/JavaGenerator.spec.ts
@@ -28,7 +28,7 @@ describe('JavaGenerator', function() {
   private Double houseNumber;
   private Boolean marriage;
   private Object members;
-  private Object[] arrayType;
+  private List<Object> arrayType;
 
   public String getStreetName() { return this.streetName; }
   public void setStreetName(String streetName) { this.streetName = streetName; }
@@ -48,8 +48,8 @@ describe('JavaGenerator', function() {
   public Object getMembers() { return this.members; }
   public void setMembers(Object members) { this.members = members; }
 
-  public Object[] getArrayType() { return this.arrayType; }
-  public void setArrayType(Object[] arrayType) { this.arrayType = arrayType; }
+  public List<Object> getArrayType() { return this.arrayType; }
+  public void setArrayType(List<Object> arrayType) { this.arrayType = arrayType; }
 }`;
 
     const inputModel = await generator.process(doc);
@@ -106,6 +106,30 @@ describe('JavaGenerator', function() {
     expect(classModel).toEqual(expected);
 
     classModel = await generator.render(model, inputModel);
+    expect(classModel).toEqual(expected);
+  });
+
+  test('should render Array type for collections', async function() {
+    const doc = {
+      $id: "CustomClass",
+      type: "object",
+      properties: {
+        arrayType: { type: "array" },
+      }
+    };
+    const expected = `public class CustomClass {
+  private Object[] arrayType;
+
+  public Object[] getArrayType() { return this.arrayType; }
+  public void setArrayType(Object[] arrayType) { this.arrayType = arrayType; }
+}`;
+
+    generator = new JavaGenerator({ collectionType: 'Array' });
+
+    const inputModel = await generator.process(doc);
+    const model = inputModel.models["CustomClass"];
+
+    let classModel = await generator.render(model, inputModel);
     expect(classModel).toEqual(expected);
   });
 

--- a/test/generators/java/JavaRenderer.spec.ts
+++ b/test/generators/java/JavaRenderer.spec.ts
@@ -1,13 +1,13 @@
-import { JavaGenerator, JAVA_DEFAULT_PRESET } from '../../../src/generators'; 
+import { JavaGenerator } from '../../../src/generators'; 
 import { JavaRenderer } from '../../../src/generators/java/JavaRenderer';
 import { CommonInputModel, CommonModel } from '../../../src/models';
-class MockJavaRenderer extends JavaRenderer {
 
-}
 describe('JavaRenderer', function() {
+  class MockJavaRenderer extends JavaRenderer {}
+
   let renderer: JavaRenderer;
   beforeEach(() => {
-    renderer = new MockJavaRenderer({}, [], new CommonModel(), new CommonInputModel());
+    renderer = new MockJavaRenderer({}, new JavaGenerator(), [], new CommonModel(), new CommonInputModel());
   });
 
   describe('toJavaType()', function() {

--- a/test/generators/java/presets/ConstraintsPreset.spec.ts
+++ b/test/generators/java/presets/ConstraintsPreset.spec.ts
@@ -1,6 +1,6 @@
 import { JavaGenerator, JAVA_CONSTRAINTS_PRESET } from '../../../../src/generators'; 
 
-describe('JAVA_DESCRIPTION_PRESET', function() {
+describe('JAVA_CONSTRAINTS_PRESET', function() {
   let generator: JavaGenerator;
   beforeEach(() => {
     generator = new JavaGenerator({ presets: [JAVA_CONSTRAINTS_PRESET] });
@@ -21,7 +21,7 @@ describe('JAVA_DESCRIPTION_PRESET', function() {
     const expected = `public class Clazz {
   private Double minNumberProp;
   private Double maxNumberProp;
-  private Object[] arrayProp;
+  private List<Object> arrayProp;
   private String stringProp;
 
   @NotNull
@@ -35,8 +35,8 @@ describe('JAVA_DESCRIPTION_PRESET', function() {
   public void setMaxNumberProp(Double maxNumberProp) { this.maxNumberProp = maxNumberProp; }
 
   @Size(min=2, max=3)
-  public Object[] getArrayProp() { return this.arrayProp; }
-  public void setArrayProp(Object[] arrayProp) { this.arrayProp = arrayProp; }
+  public List<Object> getArrayProp() { return this.arrayProp; }
+  public void setArrayProp(List<Object> arrayProp) { this.arrayProp = arrayProp; }
 
   @Pattern(regexp="^I_")
   @Size(min=3)

--- a/test/generators/java/presets/JacksonPreset.spec.ts
+++ b/test/generators/java/presets/JacksonPreset.spec.ts
@@ -1,6 +1,6 @@
 import { JavaGenerator, JAVA_JACKSON_PRESET } from '../../../../src/generators'; 
 
-describe('JAVA_DESCRIPTION_PRESET', function() {
+describe('JAVA_JACKSON_PRESET', function() {
   let generator: JavaGenerator;
   beforeEach(() => {
     generator = new JavaGenerator({ presets: [JAVA_JACKSON_PRESET] });

--- a/test/generators/javascript/JavaScriptRenderer.spec.ts
+++ b/test/generators/javascript/JavaScriptRenderer.spec.ts
@@ -1,12 +1,13 @@
+import { JavaScriptGenerator } from '../../../src/generators'; 
 import { JavaScriptRenderer } from '../../../src/generators/javascript/JavaScriptRenderer';
 import { CommonInputModel, CommonModel } from '../../../src/models';
-class MockJavaScriptRenderer extends JavaScriptRenderer {
 
-}
 describe('JavaScriptRenderer', function() {
+  class MockJavaScriptRenderer extends JavaScriptRenderer {}
+
   let renderer: JavaScriptRenderer;
   beforeEach(() => {
-    renderer = new MockJavaScriptRenderer({}, [], new CommonModel(), new CommonInputModel());
+    renderer = new MockJavaScriptRenderer({}, new JavaScriptGenerator(), [], new CommonModel(), new CommonInputModel());
   });
 
   describe('renderComments()', function() {

--- a/test/generators/typescript/TypeScriptRenderer.spec.ts
+++ b/test/generators/typescript/TypeScriptRenderer.spec.ts
@@ -1,12 +1,13 @@
+import { TypeScriptGenerator } from '../../../src/generators'; 
 import { TypeScriptRenderer } from '../../../src/generators/typescript/TypeScriptRenderer';
 import { CommonInputModel, CommonModel } from '../../../src/models';
-class MockTypeScriptRenderer extends TypeScriptRenderer {
 
-}
 describe('TypeScriptRenderer', function() {
+  class MockTypeScriptRenderer extends TypeScriptRenderer {}
+
   let renderer: TypeScriptRenderer;
   beforeEach(() => {
-    renderer = new MockTypeScriptRenderer({}, [], new CommonModel(), new CommonInputModel());
+    renderer = new MockTypeScriptRenderer({}, new TypeScriptGenerator(), [], new CommonModel(), new CommonInputModel());
   });
 
   describe('renderComments()', function() {
@@ -26,6 +27,7 @@ describe('TypeScriptRenderer', function() {
       expect(renderer.toTsType("number", new CommonModel())).toEqual(`number`);
     });
   });
+  
   describe('renderType()', function() {
     test('Should render array of CommonModels', function() {
       const model1 = new CommonModel();


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Add `namingConvention` option to options: naming for type and single property
- Pass `generator` to `renderers`
- Add `collectionType` option to Java generator to render `List<type>` or `type[]` signature for collections
- Add unit tests
- Update renderers and use `namingConvention` everywhere
- Update docs

**Related issue(s)**
Resolves https://github.com/asyncapi/generator-model-sdk/issues/124
Resolves https://github.com/asyncapi/generator-model-sdk/issues/126