### PR TITLE
fix: nested object models are not split

### DIFF
--- a/test/interpreter/PostInterpreter.spec.ts
+++ b/test/interpreter/PostInterpreter.spec.ts
@@ -30,6 +30,53 @@ describe('PostInterpreter', () => {
       expect(postProcessedModels).toHaveLength(1);
       expect(postProcessedModels[0]).toMatchObject(expectedSchema1Model);
     });
+    test('should split models when nested models occur', () => {
+      const rawModel = {
+        $id: 'schema1',
+        properties: {
+          testProp: {
+            type: 'array',
+            items: {
+              $id: 'schema2',
+              type: 'object'
+            }
+          }
+        }
+      };
+      const model = CommonModel.toCommonModel(rawModel);
+      (isModelObject as jest.Mock)
+        .mockReturnValueOnce(false)
+        .mockReturnValueOnce(true);
+
+      const postProcessedModels = postInterpretModel(model);
+
+      const expectedSchema1Model = CommonModel.toCommonModel({
+        $id: 'schema1',
+        properties: {
+          testProp: {
+            type: 'array',
+            items: {
+              $ref: 'schema2'
+            }
+          }
+        }
+      });
+      const expectedSchema2Model = CommonModel.toCommonModel({
+        $id: 'schema2',
+        type: 'object'
+      });
+
+      expect(postProcessedModels).toHaveLength(2);
+      expect(isModelObject).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        type: 'array'
+      }));
+      expect(isModelObject).toHaveBeenNthCalledWith(2, {
+        $id: 'schema2',
+        type: 'object'
+      });
+      expect(postProcessedModels[0]).toMatchObject(expectedSchema1Model);
+      expect(postProcessedModels[1]).toMatchObject(expectedSchema2Model);
+    });
     test('should split models if properties contains model object', () => {
       const rawModel = {
         $id: 'schema1',


### PR DESCRIPTION
**Description**
This PR fixes a bug where nested models (i.e. first encountered model is not an object model but the nested one is) are not split.
