### PR TITLE
feat: make it possible to add dependencies to rendering of models

### DIFF
--- a/docs/presets.md
+++ b/docs/presets.md
@@ -96,6 +96,18 @@ const generator = new TypeScriptGenerator({ presets: [
 ] });
 ```
 
+## Adding new dependencies
+Each preset hook has the possibility of adding its own dependencies that needs to be rendered. It can be done through the `renderer` argument.
+
+```ts
+...
+self({ renderer, content }) {
+  renderer.addDependency('import java.util.*;');
+  return content;
+}
+...
+```
+
 ## Overriding the default preset
 
 Each implemented generator for appropriate language must have defined the default preset. However, we can override it by passing it as the `defaultPreset` parameter in the generator options. Check the example for TypeScript generator:

--- a/docs/presets.md
+++ b/docs/presets.md
@@ -115,7 +115,6 @@ const generator = new TypeScriptGenerator({ defaultPreset: DEFAULT_PRESET });
 For each model type, you can implement two basic methods:
 
 - `self` - the method for extending the model shape.
-- `dependencies` - the method for adding dependencies for the model.
 - `additionalContent` - the method which adds additional content to the model.
 
 Each customization method receives the following arguments:

--- a/docs/presets.md
+++ b/docs/presets.md
@@ -115,6 +115,7 @@ const generator = new TypeScriptGenerator({ defaultPreset: DEFAULT_PRESET });
 For each model type, you can implement two basic methods:
 
 - `self` - the method for extending the model shape.
+- `dependencies` - the method for adding dependencies for the model.
 - `additionalContent` - the method which adds additional content to the model.
 
 Each customization method receives the following arguments:

--- a/docs/presets.md
+++ b/docs/presets.md
@@ -97,7 +97,8 @@ const generator = new TypeScriptGenerator({ presets: [
 ```
 
 ## Adding new dependencies
-Each preset hook has the possibility of adding its own dependencies that needs to be rendered. It can be done through the `renderer` argument.
+
+Each preset hook has the possibility of adding its own dependencies that needs to be rendered for the given model. It can be done through the `addDependency` function from `renderer` property.
 
 ```ts
 ...

--- a/src/generators/AbstractGenerator.ts
+++ b/src/generators/AbstractGenerator.ts
@@ -2,6 +2,7 @@ import { CommonInputModel, CommonModel, OutputModel, Preset, Presets } from '../
 import { InputProcessor } from '../processors';
 import { IndentationTypes } from '../helpers';
 import { isPresetWithOptions } from '../utils';
+import { RenderOutput } from 'models/RenderOutput';
 
 export interface CommonGeneratorOptions<P extends Preset = Preset> {
   indentation?: {
@@ -33,7 +34,7 @@ export abstract class AbstractGenerator<Options extends CommonGeneratorOptions =
     this.options = this.mergeOptions(defaultOptions, passedOptions);
   }
 
-  public abstract render(model: CommonModel, inputModel: CommonInputModel): Promise<string>;
+  public abstract render(model: CommonModel, inputModel: CommonInputModel): Promise<RenderOutput>;
 
   public async process(input: Record<string, unknown>): Promise<CommonInputModel> {
     return await InputProcessor.processor.process(input);
@@ -50,8 +51,8 @@ export abstract class AbstractGenerator<Options extends CommonGeneratorOptions =
   protected generateModels(inputModel: CommonInputModel): Promise<OutputModel[]> {
     const models = inputModel.models;
     const renders = Object.entries(models).map(async ([modelName, model]) => {
-      const result = await this.render(model, inputModel);
-      return OutputModel.toOutputModel({ result, model, modelName, inputModel });
+      const renderedOutput = await this.render(model, inputModel);
+      return OutputModel.toOutputModel({ result: renderedOutput.result, model, modelName, inputModel, dependencies: renderedOutput.dependencies});
     });
     return Promise.all(renders);
   }

--- a/src/generators/AbstractRenderer.ts
+++ b/src/generators/AbstractRenderer.ts
@@ -20,7 +20,6 @@ export abstract class AbstractRenderer<O extends CommonGeneratorOptions = Common
    * @param dependency complete dependency string so it can be rendered as is.
    */
   addDependency(dependency: string): void {
-    this.dependencies = this.dependencies || [];
     if (!this.dependencies.includes(dependency)) {
       this.dependencies.push(dependency);
     }

--- a/src/generators/AbstractRenderer.ts
+++ b/src/generators/AbstractRenderer.ts
@@ -19,7 +19,7 @@ export abstract class AbstractRenderer<O extends CommonGeneratorOptions = Common
    * 
    * @param dependency complete dependency string so it can be rendered as is.
    */
-  addUniqueDependency(dependency: string): void {
+  addDependency(dependency: string): void {
     this.dependencies = this.dependencies || [];
     if (!this.dependencies.includes(dependency)) {
       this.dependencies.push(dependency);

--- a/src/generators/AbstractRenderer.ts
+++ b/src/generators/AbstractRenderer.ts
@@ -11,6 +11,7 @@ export abstract class AbstractRenderer<O extends CommonGeneratorOptions = Common
     protected readonly presets: Array<[Preset, unknown]>,
     protected readonly model: CommonModel, 
     protected readonly inputModel: CommonInputModel,
+    public dependencies: string[] = []
   ) {}
 
   renderLine(line: string): string {
@@ -36,15 +37,18 @@ export abstract class AbstractRenderer<O extends CommonGeneratorOptions = Common
     return this.runPreset('self');
   }
 
+  runDependenciesPreset(): Promise<string[]> {
+    return this.runPreset<string[]>('dependencies');
+  }
+
   runAdditionalContentPreset(): Promise<string> {
     return this.runPreset('additionalContent');
   }
-
-  async runPreset(
+  async runPreset<RT = string>(
     functionName: string,
     params: Record<string, unknown> = {},
-  ): Promise<string> {
-    let content = '';
+  ): Promise<RT> {
+    let content;
     for (const [preset, options] of this.presets) {
       if (typeof preset[String(functionName)] === 'function') {
         content = await preset[String(functionName)]({ 

--- a/src/generators/AbstractRenderer.ts
+++ b/src/generators/AbstractRenderer.ts
@@ -14,6 +14,18 @@ export abstract class AbstractRenderer<O extends CommonGeneratorOptions = Common
     public dependencies: string[] = []
   ) {}
 
+  /**
+   * Adds a dependency while ensuring that only one dependency is preset at a time.
+   * 
+   * @param dependency complete dependency string so it can be rendered as is.
+   */
+  addUniqueDependency(dependency: string): void {
+    this.dependencies = this.dependencies || [];
+    if (!this.dependencies.includes(dependency)) {
+      this.dependencies.push(dependency);
+    }
+  }
+
   renderLine(line: string): string {
     return `${line}\n`;
   }
@@ -36,11 +48,7 @@ export abstract class AbstractRenderer<O extends CommonGeneratorOptions = Common
   runSelfPreset(): Promise<string> {
     return this.runPreset('self');
   }
-
-  runDependenciesPreset(): Promise<string[]> {
-    return this.runPreset<string[]>('dependencies');
-  }
-
+  
   runAdditionalContentPreset(): Promise<string> {
     return this.runPreset('additionalContent');
   }

--- a/src/generators/java/JavaGenerator.ts
+++ b/src/generators/java/JavaGenerator.ts
@@ -3,11 +3,9 @@ import {
   CommonGeneratorOptions,
   defaultGeneratorOptions,
 } from '../AbstractGenerator';
-import { CommonModel, CommonInputModel } from '../../models';
+import { CommonModel, CommonInputModel, RenderOutput } from '../../models';
 import { ModelKind, TypeHelpers } from '../../helpers';
-
 import { JavaPreset, JAVA_DEFAULT_PRESET } from './JavaPreset';
-
 import { ClassRenderer } from './renderers/ClassRenderer';
 import { EnumRenderer } from './renderers/EnumRenderer';
 
@@ -25,7 +23,7 @@ export class JavaGenerator extends AbstractGenerator<JavaOptions> {
     super('Java', JavaGenerator.defaultOptions, options);
   }
 
-  render(model: CommonModel, inputModel: CommonInputModel): Promise<string> {
+  render(model: CommonModel, inputModel: CommonInputModel): Promise<RenderOutput> {
     const kind = TypeHelpers.extractKind(model);
     switch (kind) {
     case ModelKind.ENUM: {
@@ -35,15 +33,17 @@ export class JavaGenerator extends AbstractGenerator<JavaOptions> {
     }
   }
 
-  renderClass(model: CommonModel, inputModel: CommonInputModel): Promise<string> {
+  async renderClass(model: CommonModel, inputModel: CommonInputModel): Promise<RenderOutput> {
     const presets = this.getPresets('class');
     const renderer = new ClassRenderer(this.options, presets, model, inputModel);
-    return renderer.runSelfPreset();
+    const result = await renderer.runSelfPreset();
+    return RenderOutput.toRenderOutput({result, dependencies: renderer.dependencies});
   }
 
-  renderEnum(model: CommonModel, inputModel: CommonInputModel): Promise<string> {
+  async renderEnum(model: CommonModel, inputModel: CommonInputModel): Promise<RenderOutput> {
     const presets = this.getPresets('enum'); 
     const renderer = new EnumRenderer(this.options, presets, model, inputModel);
-    return renderer.runSelfPreset();
+    const result = await renderer.runSelfPreset();
+    return RenderOutput.toRenderOutput({result, dependencies: renderer.dependencies});
   }
 }

--- a/src/generators/java/presets/CommonPreset.ts
+++ b/src/generators/java/presets/CommonPreset.ts
@@ -88,7 +88,6 @@ private String toIndentedString(Object o) {
  * 
  * @implements {JavaPreset}
  */
-/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 export const JAVA_COMMON_PRESET: JavaPreset = {
   class: {
     additionalContent({ renderer, model, content, options }) {

--- a/src/generators/java/presets/ConstraintsPreset.ts
+++ b/src/generators/java/presets/ConstraintsPreset.ts
@@ -9,9 +9,8 @@ import { CommonModel } from '../../../models';
  */
 export const JAVA_CONSTRAINTS_PRESET: JavaPreset = {
   class: {
-    self({renderer, content}) {
-      renderer.addUniqueDependency('import javax.validation.constraints.*;');
-      return content;
+    self({renderer}) {
+      renderer.addDependency('import javax.validation.constraints.*;');
     },
     getter({ renderer, model, propertyName, property, content }) {
       if (!(property instanceof CommonModel)) {

--- a/src/generators/java/presets/ConstraintsPreset.ts
+++ b/src/generators/java/presets/ConstraintsPreset.ts
@@ -9,8 +9,9 @@ import { CommonModel } from '../../../models';
  */
 export const JAVA_CONSTRAINTS_PRESET: JavaPreset = {
   class: {
-    dependencies() {
-      return ['javax.validation.constraints.*'];
+    self({renderer, content}) {
+      renderer.addUniqueDependency('import javax.validation.constraints.*;');
+      return content;
     },
     getter({ renderer, model, propertyName, property, content }) {
       if (!(property instanceof CommonModel)) {

--- a/src/generators/java/presets/ConstraintsPreset.ts
+++ b/src/generators/java/presets/ConstraintsPreset.ts
@@ -7,9 +7,11 @@ import { CommonModel } from '../../../models';
  * 
  * @implements {JavaPreset}
  */
-/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 export const JAVA_CONSTRAINTS_PRESET: JavaPreset = {
   class: {
+    dependencies() {
+      return ['javax.validation.constraints.*'];
+    },
     getter({ renderer, model, propertyName, property, content }) {
       if (!(property instanceof CommonModel)) {
         return content;

--- a/src/generators/java/presets/ConstraintsPreset.ts
+++ b/src/generators/java/presets/ConstraintsPreset.ts
@@ -9,8 +9,9 @@ import { CommonModel } from '../../../models';
  */
 export const JAVA_CONSTRAINTS_PRESET: JavaPreset = {
   class: {
-    self({renderer}) {
+    self({renderer, content}) {
       renderer.addDependency('import javax.validation.constraints.*;');
+      return content;
     },
     getter({ renderer, model, propertyName, property, content }) {
       if (!(property instanceof CommonModel)) {

--- a/src/generators/java/presets/DescriptioPreset.ts
+++ b/src/generators/java/presets/DescriptioPreset.ts
@@ -34,7 +34,6 @@ function renderDescription({ renderer, content, item }: {
  * 
  * @implements {JavaPreset}
  */
-/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 export const JAVA_DESCRIPTION_PRESET: JavaPreset = {
   class: {
     self({ renderer, model, content }) {

--- a/src/generators/java/presets/JacksonPreset.ts
+++ b/src/generators/java/presets/JacksonPreset.ts
@@ -8,7 +8,7 @@ import { JavaPreset } from '../JavaPreset';
 export const JAVA_JACKSON_PRESET: JavaPreset = {
   class: {
     self({renderer, content}) {
-      renderer.addUniqueDependency('import com.fasterxml.jackson.annotations.*;');
+      renderer.addDependency('import com.fasterxml.jackson.annotations.*;');
       return content;
     },
     getter({ renderer, propertyName, content }) {

--- a/src/generators/java/presets/JacksonPreset.ts
+++ b/src/generators/java/presets/JacksonPreset.ts
@@ -5,9 +5,11 @@ import { JavaPreset } from '../JavaPreset';
  * 
  * @implements {JavaPreset}
  */
-/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 export const JAVA_JACKSON_PRESET: JavaPreset = {
   class: {
+    dependencies() {
+      return ['com.fasterxml.jackson.annotations.*'];
+    },
     getter({ renderer, propertyName, content }) {
       const annotation = renderer.renderAnnotation('JsonProperty', `"${propertyName}"`);
       return renderer.renderBlock([annotation, content]);

--- a/src/generators/java/presets/JacksonPreset.ts
+++ b/src/generators/java/presets/JacksonPreset.ts
@@ -7,8 +7,9 @@ import { JavaPreset } from '../JavaPreset';
  */
 export const JAVA_JACKSON_PRESET: JavaPreset = {
   class: {
-    dependencies() {
-      return ['com.fasterxml.jackson.annotations.*'];
+    self({renderer, content}) {
+      renderer.addUniqueDependency('import com.fasterxml.jackson.annotations.*;');
+      return content;
     },
     getter({ renderer, propertyName, content }) {
       const annotation = renderer.renderAnnotation('JsonProperty', `"${propertyName}"`);

--- a/src/generators/java/renderers/ClassRenderer.ts
+++ b/src/generators/java/renderers/ClassRenderer.ts
@@ -16,8 +16,6 @@ export class ClassRenderer extends JavaRenderer {
       await this.renderAccessors(),
       await this.runAdditionalContentPreset(),
     ];
-
-    this.dependencies = await this.runDependenciesPreset();
     
     const formattedName = this.model.$id && FormatHelpers.toPascalCase(this.model.$id);
     return `public class ${formattedName} {

--- a/src/generators/java/renderers/ClassRenderer.ts
+++ b/src/generators/java/renderers/ClassRenderer.ts
@@ -17,6 +17,8 @@ export class ClassRenderer extends JavaRenderer {
       await this.runAdditionalContentPreset(),
     ];
 
+    this.dependencies = await this.runDependenciesPreset();
+    
     const formattedName = this.model.$id && FormatHelpers.toPascalCase(this.model.$id);
     return `public class ${formattedName} {
 ${this.indent(this.renderBlock(content, 2))}

--- a/src/generators/java/renderers/EnumRenderer.ts
+++ b/src/generators/java/renderers/EnumRenderer.ts
@@ -14,8 +14,6 @@ export class EnumRenderer extends JavaRenderer {
       await this.runAdditionalContentPreset()
     ];
 
-    this.dependencies = await this.runDependenciesPreset();
-
     const formattedName = this.model.$id && FormatHelpers.toPascalCase(this.model.$id);
     return `public enum ${formattedName} {
 ${this.indent(this.renderBlock(content, 2))}
@@ -64,10 +62,8 @@ ${this.indent(this.renderBlock(content, 2))}
 
 export const JAVA_DEFAULT_ENUM_PRESET: EnumPreset<EnumRenderer> = {
   self({ renderer }) {
+    renderer.addUniqueDependency('import com.fasterxml.jackson.annotations.*;');
     return renderer.defaultSelf();
-  },
-  dependencies() {
-    return ['com.fasterxml.jackson.annotations.*'];
   },
   item({ renderer, item }) {
     const key = renderer.normalizeKey(item);

--- a/src/generators/java/renderers/EnumRenderer.ts
+++ b/src/generators/java/renderers/EnumRenderer.ts
@@ -60,7 +60,7 @@ ${this.indent(this.renderBlock(content, 2))}
 
 export const JAVA_DEFAULT_ENUM_PRESET: EnumPreset<EnumRenderer> = {
   self({ renderer }) {
-    renderer.addUniqueDependency('import com.fasterxml.jackson.annotations.*;');
+    renderer.addDependency('import com.fasterxml.jackson.annotations.*;');
     return renderer.defaultSelf();
   },
   item({ renderer, item }) {

--- a/src/generators/java/renderers/EnumRenderer.ts
+++ b/src/generators/java/renderers/EnumRenderer.ts
@@ -1,6 +1,5 @@
 import { JavaRenderer } from '../JavaRenderer';
-
-import { EnumPreset } from '../../../models';
+import { EnumPreset} from '../../../models';
 import { FormatHelpers } from '../../../helpers';
 
 /**
@@ -12,8 +11,10 @@ export class EnumRenderer extends JavaRenderer {
   async defaultSelf(): Promise<string> {
     const content = [
       await this.renderItems(),
-      await this.runAdditionalContentPreset(),
+      await this.runAdditionalContentPreset()
     ];
+
+    this.dependencies = await this.runDependenciesPreset();
 
     const formattedName = this.model.$id && FormatHelpers.toPascalCase(this.model.$id);
     return `public enum ${formattedName} {
@@ -64,6 +65,9 @@ ${this.indent(this.renderBlock(content, 2))}
 export const JAVA_DEFAULT_ENUM_PRESET: EnumPreset<EnumRenderer> = {
   self({ renderer }) {
     return renderer.defaultSelf();
+  },
+  dependencies() {
+    return ['com.fasterxml.jackson.annotations.*'];
   },
   item({ renderer, item }) {
     const key = renderer.normalizeKey(item);

--- a/src/generators/javascript/JavaScriptGenerator.ts
+++ b/src/generators/javascript/JavaScriptGenerator.ts
@@ -3,7 +3,7 @@ import {
   CommonGeneratorOptions,
   defaultGeneratorOptions,
 } from '../AbstractGenerator';
-import { CommonModel, CommonInputModel } from '../../models';
+import { CommonModel, CommonInputModel, RenderOutput } from '../../models';
 import { TypeHelpers, ModelKind } from '../../helpers';
 
 import { JavaScriptPreset, JS_DEFAULT_PRESET } from './JavaScriptPreset';
@@ -27,19 +27,20 @@ export class JavaScriptGenerator extends AbstractGenerator<JavaScriptOptions> {
     super('JavaScript', JavaScriptGenerator.defaultOptions, options);
   }
 
-  render(model: CommonModel, inputModel: CommonInputModel): Promise<string> {
+  render(model: CommonModel, inputModel: CommonInputModel): Promise<RenderOutput> {
     const kind = TypeHelpers.extractKind(model);
     switch (kind) {
     case ModelKind.OBJECT: {
       return this.renderClass(model, inputModel);
     }
-    default: return Promise.resolve('');
+    default: return Promise.resolve(RenderOutput.toRenderOutput({result: '', dependencies: []}));
     }
   }
 
-  renderClass(model: CommonModel, inputModel: CommonInputModel): Promise<string> {
+  async renderClass(model: CommonModel, inputModel: CommonInputModel): Promise<RenderOutput> {
     const presets = this.getPresets('class'); 
     const renderer = new ClassRenderer(this.options, presets, model, inputModel);
-    return renderer.runSelfPreset();
+    const result = await renderer.runSelfPreset();
+    return RenderOutput.toRenderOutput({result, dependencies: renderer.dependencies});
   }
 }

--- a/src/generators/javascript/renderers/ClassRenderer.ts
+++ b/src/generators/javascript/renderers/ClassRenderer.ts
@@ -14,9 +14,11 @@ export class ClassRenderer extends JavaScriptRenderer {
       await this.renderProperties(),
       await this.runCtorPreset(),
       await this.renderAccessors(),
-      await this.runAdditionalContentPreset(),
+      await this.runAdditionalContentPreset()
     ];
 
+    this.dependencies = await this.runDependenciesPreset();
+    
     const formattedName = this.model.$id && FormatHelpers.toPascalCase(this.model.$id);
     return `class ${formattedName} {
 ${this.indent(this.renderBlock(content, 2))}

--- a/src/generators/javascript/renderers/ClassRenderer.ts
+++ b/src/generators/javascript/renderers/ClassRenderer.ts
@@ -16,8 +16,6 @@ export class ClassRenderer extends JavaScriptRenderer {
       await this.renderAccessors(),
       await this.runAdditionalContentPreset()
     ];
-
-    this.dependencies = await this.runDependenciesPreset();
     
     const formattedName = this.model.$id && FormatHelpers.toPascalCase(this.model.$id);
     return `class ${formattedName} {

--- a/src/generators/typescript/TypeScriptGenerator.ts
+++ b/src/generators/typescript/TypeScriptGenerator.ts
@@ -3,11 +3,9 @@ import {
   CommonGeneratorOptions,
   defaultGeneratorOptions,
 } from '../AbstractGenerator';
-import { CommonModel, CommonInputModel } from '../../models';
+import { CommonModel, CommonInputModel, RenderOutput } from '../../models';
 import { TypeHelpers, ModelKind } from '../../helpers';
-
 import { TypeScriptPreset, TS_DEFAULT_PRESET } from './TypeScriptPreset';
-
 import { ClassRenderer } from './renderers/ClassRenderer';
 import { InterfaceRenderer } from './renderers/InterfaceRenderer';
 import { EnumRenderer } from './renderers/EnumRenderer';
@@ -35,7 +33,7 @@ export class TypeScriptGenerator extends AbstractGenerator<TypeScriptOptions> {
     super('TypeScript', TypeScriptGenerator.defaultOptions, options);
   }
 
-  render(model: CommonModel, inputModel: CommonInputModel): Promise<string> {
+  render(model: CommonModel, inputModel: CommonInputModel): Promise<RenderOutput> {
     const kind = TypeHelpers.extractKind(model);
     switch (kind) {
     case ModelKind.OBJECT: {
@@ -48,31 +46,35 @@ export class TypeScriptGenerator extends AbstractGenerator<TypeScriptOptions> {
     }
   }
 
-  renderClass(model: CommonModel, inputModel: CommonInputModel): Promise<string> {
+  async renderClass(model: CommonModel, inputModel: CommonInputModel): Promise<RenderOutput> {
     const presets = this.getPresets('class'); 
     const renderer = new ClassRenderer(this.options, presets, model, inputModel);
-    return renderer.runSelfPreset();
+    const result = await renderer.runSelfPreset();
+    return RenderOutput.toRenderOutput({result, dependencies: renderer.dependencies});
   }
 
-  renderInterface(model: CommonModel, inputModel: CommonInputModel): Promise<string> {
+  async renderInterface(model: CommonModel, inputModel: CommonInputModel): Promise<RenderOutput> {
     const presets = this.getPresets('interface'); 
     const renderer = new InterfaceRenderer(this.options, presets, model, inputModel);
-    return renderer.runSelfPreset();
+    const result = await renderer.runSelfPreset();
+    return RenderOutput.toRenderOutput({result, dependencies: renderer.dependencies});
   }
 
-  renderEnum(model: CommonModel, inputModel: CommonInputModel): Promise<string> {
+  async renderEnum(model: CommonModel, inputModel: CommonInputModel): Promise<RenderOutput> {
     const presets = this.getPresets('enum'); 
     const renderer = new EnumRenderer(this.options, presets, model, inputModel);
-    return renderer.runSelfPreset();
+    const result = await renderer.runSelfPreset();
+    return RenderOutput.toRenderOutput({result, dependencies: renderer.dependencies});
   }
 
-  renderType(model: CommonModel, inputModel: CommonInputModel): Promise<string> {
+  async renderType(model: CommonModel, inputModel: CommonInputModel): Promise<RenderOutput> {
     const presets = this.getPresets('type'); 
     const renderer = new TypeRenderer(this.options, presets, model, inputModel);
-    return renderer.runSelfPreset();
+    const result = await renderer.runSelfPreset();
+    return RenderOutput.toRenderOutput({result, dependencies: renderer.dependencies});
   }
 
-  private renderModelType(model: CommonModel, inputModel: CommonInputModel): Promise<string> {
+  private renderModelType(model: CommonModel, inputModel: CommonInputModel): Promise<RenderOutput> {
     const modelType = this.options.modelType;
     switch (modelType) {
     case 'interface': {

--- a/src/generators/typescript/renderers/ClassRenderer.ts
+++ b/src/generators/typescript/renderers/ClassRenderer.ts
@@ -17,8 +17,6 @@ export class ClassRenderer extends TypeScriptRenderer {
       await this.runAdditionalContentPreset()
     ];
 
-    this.dependencies = await this.runDependenciesPreset();
-
     const formattedName = this.model.$id && FormatHelpers.toPascalCase(this.model.$id);
     return `class ${formattedName} {
 ${this.indent(this.renderBlock(content, 2))}

--- a/src/generators/typescript/renderers/ClassRenderer.ts
+++ b/src/generators/typescript/renderers/ClassRenderer.ts
@@ -14,8 +14,10 @@ export class ClassRenderer extends TypeScriptRenderer {
       await this.renderProperties(),
       await this.runCtorPreset(),
       await this.renderAccessors(),
-      await this.runAdditionalContentPreset(),
+      await this.runAdditionalContentPreset()
     ];
+
+    this.dependencies = await this.runDependenciesPreset();
 
     const formattedName = this.model.$id && FormatHelpers.toPascalCase(this.model.$id);
     return `class ${formattedName} {

--- a/src/generators/typescript/renderers/EnumRenderer.ts
+++ b/src/generators/typescript/renderers/EnumRenderer.ts
@@ -15,8 +15,6 @@ export class EnumRenderer extends TypeScriptRenderer {
       await this.runAdditionalContentPreset()
     ];
 
-    this.dependencies = await this.runDependenciesPreset();
-
     const formattedName = this.model.$id && FormatHelpers.toPascalCase(this.model.$id);
     return `enum ${formattedName} {
 ${this.indent(this.renderBlock(content, 2))}

--- a/src/generators/typescript/renderers/EnumRenderer.ts
+++ b/src/generators/typescript/renderers/EnumRenderer.ts
@@ -12,8 +12,10 @@ export class EnumRenderer extends TypeScriptRenderer {
   async defaultSelf(): Promise<string> {
     const content = [
       await this.renderItems(),
-      await this.runAdditionalContentPreset(),
+      await this.runAdditionalContentPreset()
     ];
+
+    this.dependencies = await this.runDependenciesPreset();
 
     const formattedName = this.model.$id && FormatHelpers.toPascalCase(this.model.$id);
     return `enum ${formattedName} {

--- a/src/generators/typescript/renderers/InterfaceRenderer.ts
+++ b/src/generators/typescript/renderers/InterfaceRenderer.ts
@@ -15,8 +15,6 @@ export class InterfaceRenderer extends TypeScriptRenderer {
       await this.runAdditionalContentPreset()
     ];
 
-    this.dependencies = await this.runDependenciesPreset();
-
     const formattedName = this.model.$id && FormatHelpers.toPascalCase(this.model.$id);
     return `interface ${formattedName} {
 ${this.indent(this.renderBlock(content, 2))}

--- a/src/generators/typescript/renderers/InterfaceRenderer.ts
+++ b/src/generators/typescript/renderers/InterfaceRenderer.ts
@@ -12,8 +12,10 @@ export class InterfaceRenderer extends TypeScriptRenderer {
   async defaultSelf(): Promise<string> {
     const content = [
       await this.renderProperties(),
-      await this.runAdditionalContentPreset(),
+      await this.runAdditionalContentPreset()
     ];
+
+    this.dependencies = await this.runDependenciesPreset();
 
     const formattedName = this.model.$id && FormatHelpers.toPascalCase(this.model.$id);
     return `interface ${formattedName} {

--- a/src/models/OutputModel.ts
+++ b/src/models/OutputModel.ts
@@ -6,6 +6,7 @@ export interface ToOutputModelArg {
   model: CommonModel;
   modelName: string;
   inputModel: CommonInputModel;
+  dependencies: string[];
 }
 
 /**
@@ -17,14 +18,15 @@ export class OutputModel {
     public readonly model: CommonModel,
     public readonly modelName: string,
     public readonly inputModel: CommonInputModel,
+    public readonly dependencies: string[]
   ) {}
 
   static toOutputModel(args: ToOutputModelArg): OutputModel;
   static toOutputModel(args: Array<ToOutputModelArg>): Array<OutputModel>;
   static toOutputModel(args: ToOutputModelArg | Array<ToOutputModelArg>): OutputModel | Array<OutputModel> {
     if (Array.isArray(args)) {
-      return args.map(arg => new this(arg.result, arg.model, arg.modelName, arg.inputModel));
+      return args.map(arg => new this(arg.result, arg.model, arg.modelName, arg.inputModel, arg.dependencies));
     }
-    return new this(args.result, args.model, args.modelName, args.inputModel);
+    return new this(args.result, args.model, args.modelName, args.inputModel, args.dependencies);
   }
 }

--- a/src/models/Preset.ts
+++ b/src/models/Preset.ts
@@ -13,7 +13,6 @@ export interface PresetArgs<R extends AbstractRenderer, O extends object = any> 
 
 export interface CommonPreset<R extends AbstractRenderer, O extends object = any> {
   self?: (args: PresetArgs<R, O>) => Promise<string> | string;
-  dependencies?: (args: PresetArgs<R, O>) => Promise<string[]> | string[];
   additionalContent?: (args: PresetArgs<R, O>) => Promise<string> | string;
 }
 

--- a/src/models/Preset.ts
+++ b/src/models/Preset.ts
@@ -13,6 +13,7 @@ export interface PresetArgs<R extends AbstractRenderer, O extends object = any> 
 
 export interface CommonPreset<R extends AbstractRenderer, O extends object = any> {
   self?: (args: PresetArgs<R, O>) => Promise<string> | string;
+  dependencies?: (args: PresetArgs<R, O>) => Promise<string[]> | string[];
   additionalContent?: (args: PresetArgs<R, O>) => Promise<string> | string;
 }
 

--- a/src/models/RenderOutput.ts
+++ b/src/models/RenderOutput.ts
@@ -1,0 +1,23 @@
+export interface ToRenderOutputArg {
+  result: string;
+  dependencies: string[];
+}
+
+/**
+ * Common representation for the rendered output.
+ */
+export class RenderOutput {
+  constructor(
+    public readonly result: string,
+    public readonly dependencies: string[] = []
+  ) {}
+
+  static toRenderOutput(args: ToRenderOutputArg): RenderOutput;
+  static toRenderOutput(args: Array<ToRenderOutputArg>): Array<RenderOutput>;
+  static toRenderOutput(args: ToRenderOutputArg | Array<ToRenderOutputArg>): RenderOutput | Array<RenderOutput> {
+    if (Array.isArray(args)) {
+      return args.map(arg => new this(arg.result, arg.dependencies));
+    }
+    return new this(args.result, args.dependencies);
+  }
+}

--- a/src/models/RenderOutput.ts
+++ b/src/models/RenderOutput.ts
@@ -1,6 +1,6 @@
 export interface ToRenderOutputArg {
   result: string;
-  dependencies: string[];
+  dependencies?: string[];
 }
 
 /**
@@ -12,12 +12,7 @@ export class RenderOutput {
     public readonly dependencies: string[] = []
   ) {}
 
-  static toRenderOutput(args: ToRenderOutputArg): RenderOutput;
-  static toRenderOutput(args: Array<ToRenderOutputArg>): Array<RenderOutput>;
-  static toRenderOutput(args: ToRenderOutputArg | Array<ToRenderOutputArg>): RenderOutput | Array<RenderOutput> {
-    if (Array.isArray(args)) {
-      return args.map(arg => new this(arg.result, arg.dependencies));
-    }
+  static toRenderOutput(args: ToRenderOutputArg): RenderOutput {
     return new this(args.result, args.dependencies);
   }
 }

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,5 +1,6 @@
 export * from './CommonInputModel';
 export * from './CommonModel';
+export * from './RenderOutput';
 export * from './CommonSchema';
 export * from './OutputModel';
 export * from './Preset';

--- a/test/blackbox/Dummy.spec.ts
+++ b/test/blackbox/Dummy.spec.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import { TypeScriptGenerator, JavaGenerator, JavaScriptGenerator } from '../../src';
 import { execCommand, generateModels, renderModels } from './utils/Utils';
-import { renderModelsToSeparateFiles } from './utils/Utils';
+import { renderJavaModelsToSeparateFiles } from './utils/Utils';
 const fileToGenerate = path.resolve(__dirname, './docs/dummy.json');
 describe('Dummy JSON Schema file', () => {
   jest.setTimeout(100000);
@@ -11,7 +11,7 @@ describe('Dummy JSON Schema file', () => {
       const generatedModels = await generateModels(fileToGenerate, generator);
       expect(generatedModels).not.toHaveLength(0);
       const renderOutputPath = path.resolve(__dirname, './output/java');
-      await renderModelsToSeparateFiles(generatedModels, renderOutputPath);
+      await renderJavaModelsToSeparateFiles(generatedModels, renderOutputPath);
       const compileCommand = `javac ${path.resolve(renderOutputPath, '*.java')}`;
       await execCommand(compileCommand);
     });

--- a/test/blackbox/utils/Utils.ts
+++ b/test/blackbox/utils/Utils.ts
@@ -40,12 +40,16 @@ export async function execCommand(command: string) : Promise<void> {
  * @param generatedModels to write to file
  * @param outputPath absolute path to output directory
  */
-export async function renderModelsToSeparateFiles(generatedModels: OutputModel[], outputPath: string): Promise<void> {
+export async function renderJavaModelsToSeparateFiles(generatedModels: OutputModel[], outputPath: string): Promise<void> {
   await fs.rm(outputPath, { recursive: true, force: true });
   await fs.mkdir(outputPath, { recursive: true });
   for (const outputModel of generatedModels) {
     const outputFilePath = path.resolve(outputPath, `${FormatHelpers.toPascalCase(outputModel.model.$id || 'undefined')}.java`);
-    await fs.writeFile(outputFilePath, outputModel.result);
+    const outputContent = `
+${outputModel.dependencies.map((dependency) => { return `import ${dependency}`; }).join('\n')}
+${outputModel.result}
+`;
+    await fs.writeFile(outputFilePath, outputContent);
   }
 }
 

--- a/test/blackbox/utils/Utils.ts
+++ b/test/blackbox/utils/Utils.ts
@@ -46,7 +46,7 @@ export async function renderJavaModelsToSeparateFiles(generatedModels: OutputMod
   for (const outputModel of generatedModels) {
     const outputFilePath = path.resolve(outputPath, `${FormatHelpers.toPascalCase(outputModel.model.$id || 'undefined')}.java`);
     const outputContent = `
-${outputModel.dependencies.map((dependency) => { return `import ${dependency}`; }).join('\n')}
+${outputModel.dependencies.join('\n')}
 ${outputModel.result}
 `;
     await fs.writeFile(outputFilePath, outputContent);

--- a/test/generators/AbstractGenerator.spec.ts
+++ b/test/generators/AbstractGenerator.spec.ts
@@ -1,5 +1,5 @@
 import { AbstractGenerator } from '../../src/generators'; 
-import { CommonInputModel, CommonModel } from '../../src/models';
+import { CommonInputModel, CommonModel, RenderOutput } from '../../src/models';
 
 describe('AbstractGenerator', () => {
   class TestGenerator extends AbstractGenerator {
@@ -8,7 +8,7 @@ describe('AbstractGenerator', () => {
     }
 
     render(model: CommonModel, inputModel: CommonInputModel): any {
-      return model.$id || 'rendered content';
+      return RenderOutput.toRenderOutput({result: model.$id || 'rendered content', dependencies: []});
     }
   }
 
@@ -53,7 +53,8 @@ describe('AbstractGenerator', () => {
     const keys = Object.keys(commonInputModel.models);
     const renderedContent = await generator.render(commonInputModel.models[keys[0]], commonInputModel);
 
-    expect(renderedContent).toEqual('SomeModel');
+    expect(renderedContent.result).toEqual('SomeModel');
+    expect(renderedContent.dependencies).toEqual([]);
   });
 
   describe('getPresets()', () => {
@@ -62,9 +63,8 @@ describe('AbstractGenerator', () => {
         constructor() {
           super('TestGenerator', {presets: [{preset: {test: 'test2'}, options: {}}]});
         }
-        render(model: CommonModel, inputModel: CommonInputModel): any {
-          return model.$id || 'rendered content';
-        }
+        render(model: CommonModel, inputModel: CommonInputModel): any { return; }
+
         testGetPresets(string: string) {
           return this.getPresets(string);
         }

--- a/test/generators/AbstractRenderer.spec.ts
+++ b/test/generators/AbstractRenderer.spec.ts
@@ -30,6 +30,17 @@ describe('AbstractRenderer', () => {
     expect(content).toEqual('Test1\nTest2');
   });
 
+  describe('addUniqueDependency()', () => {
+    test('should add dependency', () => {
+      renderer.addUniqueDependency('test');
+      expect(renderer.dependencies).toEqual(['test']);
+    });
+    test('should not add duplicate dependency', () => {
+      renderer.addUniqueDependency('test');
+      renderer.addUniqueDependency('test');
+      expect(renderer.dependencies).toEqual(['test']);
+    });
+  });
   describe('indent()', () => {
     test('should render text with indentation', () => {
       const content = renderer.indent('Test');

--- a/test/generators/AbstractRenderer.spec.ts
+++ b/test/generators/AbstractRenderer.spec.ts
@@ -30,14 +30,14 @@ describe('AbstractRenderer', () => {
     expect(content).toEqual('Test1\nTest2');
   });
 
-  describe('addUniqueDependency()', () => {
+  describe('addDependency()', () => {
     test('should add dependency', () => {
-      renderer.addUniqueDependency('test');
+      renderer.addDependency('test');
       expect(renderer.dependencies).toEqual(['test']);
     });
     test('should not add duplicate dependency', () => {
-      renderer.addUniqueDependency('test');
-      renderer.addUniqueDependency('test');
+      renderer.addDependency('test');
+      renderer.addDependency('test');
       expect(renderer.dependencies).toEqual(['test']);
     });
   });

--- a/test/generators/java/JavaGenerator.spec.ts
+++ b/test/generators/java/JavaGenerator.spec.ts
@@ -153,7 +153,7 @@ describe('JavaGenerator', () => {
     const model = inputModel.models['States'];
 
     let enumModel = await generator.renderEnum(model, inputModel);
-    const expectedDependencies = ['com.fasterxml.jackson.annotations.*'];
+    const expectedDependencies = ['import com.fasterxml.jackson.annotations.*;'];
     expect(enumModel.result).toEqual(expected);
     expect(enumModel.dependencies).toEqual(expectedDependencies);
 
@@ -202,7 +202,7 @@ describe('JavaGenerator', () => {
     const model = inputModel.models['Numbers'];
 
     let enumModel = await generator.renderEnum(model, inputModel);
-    const expectedDependencies = ['com.fasterxml.jackson.annotations.*'];
+    const expectedDependencies = ['import com.fasterxml.jackson.annotations.*;'];
     expect(enumModel.result).toEqual(expected);
     expect(enumModel.dependencies).toEqual(expectedDependencies);
 
@@ -251,7 +251,7 @@ describe('JavaGenerator', () => {
     const model = inputModel.models['Union'];
 
     let enumModel = await generator.renderEnum(model, inputModel);
-    const expectedDependencies = ['com.fasterxml.jackson.annotations.*'];
+    const expectedDependencies = ['import com.fasterxml.jackson.annotations.*;'];
     expect(enumModel.result).toEqual(expected);
     expect(enumModel.dependencies).toEqual(expectedDependencies);
 
@@ -312,7 +312,7 @@ public enum CustomEnum {
     const model = inputModel.models['CustomEnum'];
     
     let enumModel = await generator.render(model, inputModel);
-    const expectedDependencies = ['com.fasterxml.jackson.annotations.*'];
+    const expectedDependencies = ['import com.fasterxml.jackson.annotations.*;'];
     expect(enumModel.result).toEqual(expected);
     expect(enumModel.dependencies).toEqual(expectedDependencies);
     

--- a/test/generators/java/JavaGenerator.spec.ts
+++ b/test/generators/java/JavaGenerator.spec.ts
@@ -56,10 +56,12 @@ describe('JavaGenerator', () => {
     const model = inputModel.models['Address'];
 
     let classModel = await generator.renderClass(model, inputModel);
-    expect(classModel).toEqual(expected);
+    expect(classModel.result).toEqual(expected);
+    expect(classModel.dependencies).toEqual([]);
 
     classModel = await generator.render(model, inputModel);
-    expect(classModel).toEqual(expected);
+    expect(classModel.result).toEqual(expected);
+    expect(classModel.dependencies).toEqual([]);
   });
 
   test('should work custom preset for `class` type', async () => {
@@ -103,10 +105,12 @@ describe('JavaGenerator', () => {
     const model = inputModel.models['CustomClass'];
 
     let classModel = await generator.renderClass(model, inputModel);
-    expect(classModel).toEqual(expected);
+    expect(classModel.result).toEqual(expected);
+    expect(classModel.dependencies).toEqual([]);
 
     classModel = await generator.render(model, inputModel);
-    expect(classModel).toEqual(expected);
+    expect(classModel.result).toEqual(expected);
+    expect(classModel.dependencies).toEqual([]);
   });
 
   test('should render `enum` type (string type)', async () => {
@@ -149,10 +153,13 @@ describe('JavaGenerator', () => {
     const model = inputModel.models['States'];
 
     let enumModel = await generator.renderEnum(model, inputModel);
-    expect(enumModel).toEqual(expected);
+    const expectedDependencies = ['com.fasterxml.jackson.annotations.*'];
+    expect(enumModel.result).toEqual(expected);
+    expect(enumModel.dependencies).toEqual(expectedDependencies);
 
     enumModel = await generator.render(model, inputModel);
-    expect(enumModel).toEqual(expected);
+    expect(enumModel.result).toEqual(expected);
+    expect(enumModel.dependencies).toEqual(expectedDependencies);
   });
 
   test('should render `enum` type (integer type)', async () => {
@@ -195,10 +202,13 @@ describe('JavaGenerator', () => {
     const model = inputModel.models['Numbers'];
 
     let enumModel = await generator.renderEnum(model, inputModel);
-    expect(enumModel).toEqual(expected);
+    const expectedDependencies = ['com.fasterxml.jackson.annotations.*'];
+    expect(enumModel.result).toEqual(expected);
+    expect(enumModel.dependencies).toEqual(expectedDependencies);
 
     enumModel = await generator.render(model, inputModel);
-    expect(enumModel).toEqual(expected);
+    expect(enumModel.result).toEqual(expected);
+    expect(enumModel.dependencies).toEqual(expectedDependencies);
   });
 
   test('should render `enum` type (union type)', async () => {
@@ -241,10 +251,13 @@ describe('JavaGenerator', () => {
     const model = inputModel.models['Union'];
 
     let enumModel = await generator.renderEnum(model, inputModel);
-    expect(enumModel).toEqual(expected);
+    const expectedDependencies = ['com.fasterxml.jackson.annotations.*'];
+    expect(enumModel.result).toEqual(expected);
+    expect(enumModel.dependencies).toEqual(expectedDependencies);
 
     enumModel = await generator.render(model, inputModel);
-    expect(enumModel).toEqual(expected);
+    expect(enumModel.result).toEqual(expected);
+    expect(enumModel.dependencies).toEqual(expectedDependencies);
   });
 
   test('should work custom preset for `enum` type', async () => {
@@ -299,9 +312,12 @@ public enum CustomEnum {
     const model = inputModel.models['CustomEnum'];
     
     let enumModel = await generator.render(model, inputModel);
-    expect(enumModel).toEqual(expected);
+    const expectedDependencies = ['com.fasterxml.jackson.annotations.*'];
+    expect(enumModel.result).toEqual(expected);
+    expect(enumModel.dependencies).toEqual(expectedDependencies);
     
     enumModel = await generator.renderEnum(model, inputModel);
-    expect(enumModel).toEqual(expected);
+    expect(enumModel.result).toEqual(expected);
+    expect(enumModel.dependencies).toEqual(expectedDependencies);
   });
 });

--- a/test/generators/java/presets/CommonPreset.spec.ts
+++ b/test/generators/java/presets/CommonPreset.spec.ts
@@ -64,7 +64,8 @@ describe('JAVA_COMMON_PRESET', () => {
     const model = inputModel.models['Clazz'];
 
     const classModel = await generator.renderClass(model, inputModel);
-    expect(classModel).toEqual(expected);
+    expect(classModel.result).toEqual(expected);
+    expect(classModel.dependencies).toEqual([]);
   });
 
   test('should skip rendering of disabled functions', async () => {
@@ -103,6 +104,7 @@ describe('JAVA_COMMON_PRESET', () => {
     const model = inputModel.models['Clazz'];
 
     const classModel = await generator.renderClass(model, inputModel);
-    expect(classModel).toEqual(expected);
+    expect(classModel.result).toEqual(expected);
+    expect(classModel.dependencies).toEqual([]);
   });
 });

--- a/test/generators/java/presets/ConstraintsPreset.spec.ts
+++ b/test/generators/java/presets/ConstraintsPreset.spec.ts
@@ -1,6 +1,6 @@
 import { JavaGenerator, JAVA_CONSTRAINTS_PRESET } from '../../../../src/generators'; 
 
-describe('JAVA_DESCRIPTION_PRESET', () => {
+describe('JAVA_CONSTRAINTS_PRESET', () => {
   let generator: JavaGenerator;
   beforeEach(() => {
     generator = new JavaGenerator({ presets: [JAVA_CONSTRAINTS_PRESET] });
@@ -49,6 +49,6 @@ describe('JAVA_DESCRIPTION_PRESET', () => {
 
     const classModel = await generator.renderClass(model, inputModel);
     expect(classModel.result).toEqual(expected);
-    expect(classModel.dependencies).toEqual(['javax.validation.constraints.*']);
+    expect(classModel.dependencies).toEqual(['import javax.validation.constraints.*;']);
   });
 });

--- a/test/generators/java/presets/ConstraintsPreset.spec.ts
+++ b/test/generators/java/presets/ConstraintsPreset.spec.ts
@@ -48,6 +48,7 @@ describe('JAVA_DESCRIPTION_PRESET', () => {
     const model = inputModel.models['Clazz'];
 
     const classModel = await generator.renderClass(model, inputModel);
-    expect(classModel).toEqual(expected);
+    expect(classModel.result).toEqual(expected);
+    expect(classModel.dependencies).toEqual(['javax.validation.constraints.*']);
   });
 });

--- a/test/generators/java/presets/DescriptionPreset.spec.ts
+++ b/test/generators/java/presets/DescriptionPreset.spec.ts
@@ -36,6 +36,7 @@ public class Clazz {
 
     const classModel = await generator.renderClass(model, inputModel);
     expect(classModel.result).toEqual(expected);
+    expect(classModel.dependencies).toEqual([]);
   });
 
   test('should render description and examples for enum', async () => {
@@ -88,6 +89,6 @@ public enum Enum {
 
     const enumModel = await generator.renderEnum(model, inputModel);
     expect(enumModel.result).toEqual(expected);
-    expect(enumModel.dependencies).toEqual(['com.fasterxml.jackson.annotations.*']);
+    expect(enumModel.dependencies).toEqual(['import com.fasterxml.jackson.annotations.*;']);
   });
 });

--- a/test/generators/java/presets/DescriptionPreset.spec.ts
+++ b/test/generators/java/presets/DescriptionPreset.spec.ts
@@ -35,7 +35,7 @@ public class Clazz {
     const model = inputModel.models['Clazz'];
 
     const classModel = await generator.renderClass(model, inputModel);
-    expect(classModel).toEqual(expected);
+    expect(classModel.result).toEqual(expected);
   });
 
   test('should render description and examples for enum', async () => {
@@ -87,6 +87,7 @@ public enum Enum {
     const model = inputModel.models['Enum'];
 
     const enumModel = await generator.renderEnum(model, inputModel);
-    expect(enumModel).toEqual(expected);
+    expect(enumModel.result).toEqual(expected);
+    expect(enumModel.dependencies).toEqual(['com.fasterxml.jackson.annotations.*']);
   });
 });

--- a/test/generators/java/presets/JacksonPreset.spec.ts
+++ b/test/generators/java/presets/JacksonPreset.spec.ts
@@ -33,6 +33,6 @@ describe('JAVA_DESCRIPTION_PRESET', () => {
 
     const classModel = await generator.renderClass(model, inputModel);
     expect(classModel.result).toEqual(expected);
-    expect(classModel.dependencies).toEqual(['com.fasterxml.jackson.annotations.*']);
+    expect(classModel.dependencies).toEqual(['import com.fasterxml.jackson.annotations.*;']);
   });
 });

--- a/test/generators/java/presets/JacksonPreset.spec.ts
+++ b/test/generators/java/presets/JacksonPreset.spec.ts
@@ -32,6 +32,7 @@ describe('JAVA_DESCRIPTION_PRESET', () => {
     const model = inputModel.models['Clazz'];
 
     const classModel = await generator.renderClass(model, inputModel);
-    expect(classModel).toEqual(expected);
+    expect(classModel.result).toEqual(expected);
+    expect(classModel.dependencies).toEqual(['com.fasterxml.jackson.annotations.*']);
   });
 });

--- a/test/generators/javascript/JavaScriptGenerator.spec.ts
+++ b/test/generators/javascript/JavaScriptGenerator.spec.ts
@@ -66,10 +66,12 @@ describe('JavaScriptGenerator', () => {
     const model = inputModel.models['Address'];
 
     let classModel = await generator.renderClass(model, inputModel);
-    expect(classModel).toEqual(expected);
+    expect(classModel.result).toEqual(expected);
+    expect(classModel.dependencies).toEqual([]);
 
     classModel = await generator.render(model, inputModel);
-    expect(classModel).toEqual(expected);
+    expect(classModel.result).toEqual(expected);
+    expect(classModel.dependencies).toEqual([]);
   });
 
   test('should not render another type than `object`', async () => {
@@ -83,7 +85,8 @@ describe('JavaScriptGenerator', () => {
     const model = inputModel.models['AnyType'];
 
     const anyModel = await generator.render(model, inputModel);
-    expect(anyModel).toEqual(expected);
+    expect(anyModel.result).toEqual(expected);
+    expect(anyModel.dependencies).toEqual([]);
   });
 
   test('should work custom preset for `class` type', async () => {
@@ -124,7 +127,7 @@ describe('JavaScriptGenerator', () => {
           },
           setter() {
             return 'set property(property) { this.#property = property; }';
-          },
+          }
         }
       }
     ] });
@@ -133,6 +136,7 @@ describe('JavaScriptGenerator', () => {
     const model = inputModel.models['CustomClass'];
     
     const classModel = await generator.render(model, inputModel);
-    expect(classModel).toEqual(expected);
+    expect(classModel.result).toEqual(expected);
+    expect(classModel.dependencies).toEqual([]);
   });
 });

--- a/test/generators/typescript/TypeScriptGenerator.spec.ts
+++ b/test/generators/typescript/TypeScriptGenerator.spec.ts
@@ -30,10 +30,12 @@ describe('TypeScriptGenerator', () => {
     const model = inputModel.models['_address'];
 
     let classModel = await generator.renderClass(model, inputModel);
-    expect(classModel).toEqual(expected);
+    expect(classModel.result).toEqual(expected);
+    expect(classModel.dependencies).toEqual([]);
 
     classModel = await generator.render(model, inputModel);
-    expect(classModel).toEqual(expected);
+    expect(classModel.result).toEqual(expected);
+    expect(classModel.dependencies).toEqual([]);
   });
   test('should render `class` type', async () => {
     const doc = {
@@ -110,10 +112,12 @@ describe('TypeScriptGenerator', () => {
     const model = inputModel.models['_address'];
 
     let classModel = await generator.renderClass(model, inputModel);
-    expect(classModel).toEqual(expected);
+    expect(classModel.result).toEqual(expected);
+    expect(classModel.dependencies).toEqual([]);
 
     classModel = await generator.render(model, inputModel);
-    expect(classModel).toEqual(expected);
+    expect(classModel.result).toEqual(expected);
+    expect(classModel.dependencies).toEqual([]);
   });
 
   test('should work custom preset for `class` type', async () => {
@@ -153,7 +157,8 @@ ${content}`;
     const model = inputModel.models['CustomClass'];
     
     const classModel = await generator.render(model, inputModel);
-    expect(classModel).toEqual(expected);
+    expect(classModel.result).toEqual(expected);
+    expect(classModel.dependencies).toEqual([]);
   });
 
   test('should render `interface` type', async () => {
@@ -188,7 +193,8 @@ ${content}`;
     const model = inputModel.models['Address'];
 
     const interfaceModel = await interfaceGenerator.render(model, inputModel);
-    expect(interfaceModel).toEqual(expected);
+    expect(interfaceModel.result).toEqual(expected);
+    expect(interfaceModel.dependencies).toEqual([]);
   });
 
   test('should work custom preset for `interface` type', async () => {
@@ -217,7 +223,8 @@ ${content}`;
     const model = inputModel.models['CustomInterface'];
 
     const interfaceModel = await generator.renderInterface(model, inputModel);
-    expect(interfaceModel).toEqual(expected);
+    expect(interfaceModel.result).toEqual(expected);
+    expect(interfaceModel.dependencies).toEqual([]);
   });
 
   test('should render `enum` type', async () => {
@@ -236,10 +243,12 @@ ${content}`;
     const model = inputModel.models['States'];
 
     let enumModel = await generator.render(model, inputModel);
-    expect(enumModel).toEqual(expected);
+    expect(enumModel.result).toEqual(expected);
+    expect(enumModel.dependencies).toEqual([]);
     
     enumModel = await generator.renderEnum(model, inputModel);
-    expect(enumModel).toEqual(expected);
+    expect(enumModel.result).toEqual(expected);
+    expect(enumModel.dependencies).toEqual([]);
   });
 
   test('should work custom preset for `enum` type', async () => {
@@ -268,10 +277,12 @@ ${content}`;
     const model = inputModel.models['CustomEnum'];
     
     let enumModel = await generator.render(model, inputModel);
-    expect(enumModel).toEqual(expected);
+    expect(enumModel.result).toEqual(expected);
+    expect(enumModel.dependencies).toEqual([]);
     
     enumModel = await generator.renderEnum(model, inputModel);
-    expect(enumModel).toEqual(expected);
+    expect(enumModel.result).toEqual(expected);
+    expect(enumModel.dependencies).toEqual([]);
   });
 
   test('should render `type` type - primitive', async () => {
@@ -285,10 +296,12 @@ ${content}`;
     const model = inputModel.models['TypePrimitive'];
 
     let primitiveModel = await generator.renderType(model, inputModel);
-    expect(primitiveModel).toEqual(expected);
+    expect(primitiveModel.result).toEqual(expected);
+    expect(primitiveModel.dependencies).toEqual([]);
 
     primitiveModel = await generator.render(model, inputModel);
-    expect(primitiveModel).toEqual(expected);
+    expect(primitiveModel.result).toEqual(expected);
+    expect(primitiveModel.dependencies).toEqual([]);
   });
 
   test('should render `type` type - enum', async () => {
@@ -302,7 +315,8 @@ ${content}`;
     const model = inputModel.models['TypeEnum'];
 
     const enumModel = await generator.renderType(model, inputModel);
-    expect(enumModel).toEqual(expected);
+    expect(enumModel.result).toEqual(expected);
+    expect(enumModel.dependencies).toEqual([]);
   });
 
   test('should render `type` type - union', async () => {
@@ -316,7 +330,8 @@ ${content}`;
     const model = inputModel.models['TypeUnion'];
 
     const unionModel = await generator.renderType(model, inputModel);
-    expect(unionModel).toEqual(expected);
+    expect(unionModel.result).toEqual(expected);
+    expect(unionModel.dependencies).toEqual([]);
   });
 
   test('should render `type` type - array of primitive type', async () => {
@@ -334,7 +349,8 @@ ${content}`;
     const model = inputModel.models['TypeArray'];
 
     const arrayModel = await generator.renderType(model, inputModel);
-    expect(arrayModel).toEqual(expected);
+    expect(arrayModel.result).toEqual(expected);
+    expect(arrayModel.dependencies).toEqual([]);
   });
 
   test('should render `type` type - array of union type', async () => {
@@ -352,6 +368,7 @@ ${content}`;
     const model = inputModel.models['TypeArray'];
 
     const arrayModel = await generator.renderType(model, inputModel);
-    expect(arrayModel).toEqual(expected);
+    expect(arrayModel.result).toEqual(expected);
+    expect(arrayModel.dependencies).toEqual([]);
   });
 });

--- a/test/models/OutputModel.spec.ts
+++ b/test/models/OutputModel.spec.ts
@@ -10,6 +10,7 @@ describe('OutputModel', () => {
       model: commonModel,
       modelName: 'someModel',
       inputModel: new CommonInputModel(),
+      dependencies: ['test']
     };
     const output = OutputModel.toOutputModel(ioutput);
 
@@ -17,6 +18,7 @@ describe('OutputModel', () => {
     expect(output.model).toEqual(ioutput.model);
     expect(output.modelName).toEqual(ioutput.modelName);
     expect(output.inputModel).toEqual(ioutput.inputModel);
+    expect(output.dependencies).toEqual(ioutput.dependencies);
   });
 
   test('should return an array of OutputModel', () => {
@@ -28,6 +30,7 @@ describe('OutputModel', () => {
       model: commonModel,
       modelName: 'someModel',
       inputModel: new CommonInputModel(),
+      dependencies: ['test']
     };
     const output = OutputModel.toOutputModel([ioutput, ioutput]);
 
@@ -35,9 +38,11 @@ describe('OutputModel', () => {
     expect(output[0].model).toEqual(ioutput.model);
     expect(output[0].modelName).toEqual(ioutput.modelName);
     expect(output[0].inputModel).toEqual(ioutput.inputModel);
+    expect(output[0].dependencies).toEqual(ioutput.dependencies);
     expect(output[1].result).toEqual(ioutput.result);
     expect(output[1].model).toEqual(ioutput.model);
     expect(output[1].modelName).toEqual(ioutput.modelName);
     expect(output[1].inputModel).toEqual(ioutput.inputModel);
+    expect(output[1].dependencies).toEqual(ioutput.dependencies);
   });
 });

--- a/test/models/RenderOutput.spec.ts
+++ b/test/models/RenderOutput.spec.ts
@@ -1,0 +1,21 @@
+import { ToRenderOutputArg, RenderOutput } from '../../src/models'; 
+
+describe('RenderOutput', () => {
+  test('should return an RenderOutput', () => {
+    const ioutput: ToRenderOutputArg = {
+      result: 'result',
+      dependencies: ['test']
+    };
+    const output = RenderOutput.toRenderOutput(ioutput);
+    expect(output.result).toEqual(ioutput.result);
+    expect(output.dependencies).toEqual(ioutput.dependencies);
+  });
+  test('should default to values', () => {
+    const ioutput: ToRenderOutputArg = {
+      result: 'result'
+    };
+    const output = RenderOutput.toRenderOutput(ioutput);
+    expect(output.result).toEqual(ioutput.result);
+    expect(output.dependencies).toEqual([]);
+  });
+});


### PR DESCRIPTION
**Description**
This PR adds a `dependencies` preset which can be used to add dependencies to the model rendering.


**Related issue(s)**
fixes #238 