### PR TITLE
fix: publish esm modules and TS types

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "generate:readme:toc": "markdown-toc -i README.md",
     "generate:assets": "npm run build:prod && npm run docs && npm run generate:readme:toc",
     "bump:version": "npm --no-git-tag-version --allow-same-version version $VERSION",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build:prod && npm run generate:readme:toc"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

As in title: publish `esm` modules and TS types - update `prepublishOnly` script.