### PR TITLE
fix: wrong import paths

### DIFF
--- a/src/generators/AbstractGenerator.ts
+++ b/src/generators/AbstractGenerator.ts
@@ -2,7 +2,7 @@ import { CommonInputModel, CommonModel, OutputModel, Preset, Presets } from '../
 import { InputProcessor } from '../processors';
 import { IndentationTypes } from '../helpers';
 import { isPresetWithOptions } from '../utils';
-import { RenderOutput } from 'models/RenderOutput';
+import { RenderOutput } from '../models/RenderOutput';
 
 export interface CommonGeneratorOptions<P extends Preset = Preset> {
   indentation?: {

--- a/src/interpreter/InterpretAdditionalItems.ts
+++ b/src/interpreter/InterpretAdditionalItems.ts
@@ -1,5 +1,5 @@
-import { CommonModel } from 'models';
-import { Schema } from 'models/Schema';
+import { CommonModel } from '../models';
+import { Schema } from '../models/Schema';
 import { Interpreter, InterpreterOptions } from './Interpreter';
 
 /**

--- a/src/interpreter/InterpretAdditionalProperties.ts
+++ b/src/interpreter/InterpretAdditionalProperties.ts
@@ -1,5 +1,5 @@
-import { CommonModel } from 'models';
-import { Schema } from 'models/Schema';
+import { CommonModel } from '../models';
+import { Schema } from '../models/Schema';
 import { Interpreter, InterpreterOptions } from './Interpreter';
 import { isModelObject } from './Utils';
 


### PR DESCRIPTION
*Description**

Running the example I found that compiling TS gave the following error:

```
node_modules/@asyncapi/modelina/lib/types/generators/AbstractGenerator.d.ts:3:30 - error TS2307: Cannot find module 'models/RenderOutput' or its corresponding type declarations.
3 import { RenderOutput } from 'models/RenderOutput';
```

I noticed the import path was wrong in this case. Fixed that one and a couple more.