### PR TITLE
feat: pass options to processors

### DIFF
--- a/src/generators/AbstractGenerator.ts
+++ b/src/generators/AbstractGenerator.ts
@@ -9,7 +9,7 @@ export interface CommonGeneratorOptions<P extends Preset = Preset> {
   };
   defaultPreset?: P;
   presets?: Presets<P>;
-  processorOption?: ProcessorOptions
+  processorOptions?: ProcessorOptions
 }
 
 export const defaultGeneratorOptions: CommonGeneratorOptions = {
@@ -36,7 +36,7 @@ export abstract class AbstractGenerator<Options extends CommonGeneratorOptions =
   public abstract render(model: CommonModel, inputModel: CommonInputModel): Promise<RenderOutput>;
 
   public process(input: Record<string, unknown>): Promise<CommonInputModel> {
-    return InputProcessor.processor.process(input, this.options.processorOption);
+    return InputProcessor.processor.process(input, this.options.processorOptions);
   }
 
   public async generate(input: Record<string, unknown> | CommonInputModel): Promise<OutputModel[]> {

--- a/src/generators/AbstractGenerator.ts
+++ b/src/generators/AbstractGenerator.ts
@@ -10,7 +10,7 @@ export interface CommonGeneratorOptions<P extends Preset = Preset> {
   };
   defaultPreset?: P;
   presets?: Presets<P>;
-  parserOptions?: ProcessOptions
+  processOptions?: ProcessOptions
 }
 
 export const defaultGeneratorOptions: CommonGeneratorOptions = {
@@ -37,7 +37,7 @@ export abstract class AbstractGenerator<Options extends CommonGeneratorOptions =
   public abstract render(model: CommonModel, inputModel: CommonInputModel): Promise<RenderOutput>;
 
   public async process(input: Record<string, unknown>): Promise<CommonInputModel> {
-    return await InputProcessor.processor.process(input, this.options.parserOptions);
+    return await InputProcessor.processor.process(input, this.options.processOptions);
   }
 
   public async generate(input: Record<string, unknown> | CommonInputModel): Promise<OutputModel[]> {

--- a/src/generators/AbstractGenerator.ts
+++ b/src/generators/AbstractGenerator.ts
@@ -2,7 +2,7 @@ import { CommonInputModel, CommonModel, OutputModel, Preset, Presets } from '../
 import { InputProcessor } from '../processors';
 import { IndentationTypes } from '../helpers';
 import { isPresetWithOptions } from '../utils';
-import { RenderOutput, ProcessOptions } from '../models';
+import { RenderOutput, ProcessorOption } from '../models';
 export interface CommonGeneratorOptions<P extends Preset = Preset> {
   indentation?: {
     type: IndentationTypes;
@@ -10,7 +10,7 @@ export interface CommonGeneratorOptions<P extends Preset = Preset> {
   };
   defaultPreset?: P;
   presets?: Presets<P>;
-  processorOption?: ProcessOptions
+  processorOption?: ProcessorOption
 }
 
 export const defaultGeneratorOptions: CommonGeneratorOptions = {

--- a/src/generators/AbstractGenerator.ts
+++ b/src/generators/AbstractGenerator.ts
@@ -36,7 +36,7 @@ export abstract class AbstractGenerator<Options extends CommonGeneratorOptions =
   public abstract render(model: CommonModel, inputModel: CommonInputModel): Promise<RenderOutput>;
 
   public async process(input: Record<string, unknown>): Promise<CommonInputModel> {
-    return await InputProcessor.processor.process(input, this.options.processorOption);
+    return InputProcessor.processor.process(input, this.options.processorOption);
   }
 
   public async generate(input: Record<string, unknown> | CommonInputModel): Promise<OutputModel[]> {

--- a/src/generators/AbstractGenerator.ts
+++ b/src/generators/AbstractGenerator.ts
@@ -2,8 +2,7 @@ import { CommonInputModel, CommonModel, OutputModel, Preset, Presets } from '../
 import { InputProcessor } from '../processors';
 import { IndentationTypes } from '../helpers';
 import { isPresetWithOptions } from '../utils';
-import { RenderOutput } from '../models/RenderOutput';
-
+import { RenderOutput, ProcessOptions } from '../models';
 export interface CommonGeneratorOptions<P extends Preset = Preset> {
   indentation?: {
     type: IndentationTypes;
@@ -11,6 +10,7 @@ export interface CommonGeneratorOptions<P extends Preset = Preset> {
   };
   defaultPreset?: P;
   presets?: Presets<P>;
+  parserOptions?: ProcessOptions
 }
 
 export const defaultGeneratorOptions: CommonGeneratorOptions = {
@@ -37,7 +37,7 @@ export abstract class AbstractGenerator<Options extends CommonGeneratorOptions =
   public abstract render(model: CommonModel, inputModel: CommonInputModel): Promise<RenderOutput>;
 
   public async process(input: Record<string, unknown>): Promise<CommonInputModel> {
-    return await InputProcessor.processor.process(input);
+    return await InputProcessor.processor.process(input, this.options.parserOptions);
   }
 
   public async generate(input: Record<string, unknown> | CommonInputModel): Promise<OutputModel[]> {

--- a/src/generators/AbstractGenerator.ts
+++ b/src/generators/AbstractGenerator.ts
@@ -1,8 +1,7 @@
-import { CommonInputModel, CommonModel, OutputModel, Preset, Presets } from '../models';
+import { CommonInputModel, CommonModel, OutputModel, Preset, Presets, RenderOutput, ProcessorOptions } from '../models';
 import { InputProcessor } from '../processors';
 import { IndentationTypes } from '../helpers';
 import { isPresetWithOptions } from '../utils';
-import { RenderOutput, ProcessorOptions } from '../models';
 export interface CommonGeneratorOptions<P extends Preset = Preset> {
   indentation?: {
     type: IndentationTypes;

--- a/src/generators/AbstractGenerator.ts
+++ b/src/generators/AbstractGenerator.ts
@@ -2,7 +2,7 @@ import { CommonInputModel, CommonModel, OutputModel, Preset, Presets } from '../
 import { InputProcessor } from '../processors';
 import { IndentationTypes } from '../helpers';
 import { isPresetWithOptions } from '../utils';
-import { RenderOutput, ProcessorOption } from '../models';
+import { RenderOutput, ProcessorOptions } from '../models';
 export interface CommonGeneratorOptions<P extends Preset = Preset> {
   indentation?: {
     type: IndentationTypes;
@@ -10,7 +10,7 @@ export interface CommonGeneratorOptions<P extends Preset = Preset> {
   };
   defaultPreset?: P;
   presets?: Presets<P>;
-  processorOption?: ProcessorOption
+  processorOption?: ProcessorOptions
 }
 
 export const defaultGeneratorOptions: CommonGeneratorOptions = {

--- a/src/generators/AbstractGenerator.ts
+++ b/src/generators/AbstractGenerator.ts
@@ -10,7 +10,7 @@ export interface CommonGeneratorOptions<P extends Preset = Preset> {
   };
   defaultPreset?: P;
   presets?: Presets<P>;
-  processOptions?: ProcessOptions
+  processorOption?: ProcessOptions
 }
 
 export const defaultGeneratorOptions: CommonGeneratorOptions = {
@@ -37,7 +37,7 @@ export abstract class AbstractGenerator<Options extends CommonGeneratorOptions =
   public abstract render(model: CommonModel, inputModel: CommonInputModel): Promise<RenderOutput>;
 
   public async process(input: Record<string, unknown>): Promise<CommonInputModel> {
-    return await InputProcessor.processor.process(input, this.options.processOptions);
+    return await InputProcessor.processor.process(input, this.options.processorOption);
   }
 
   public async generate(input: Record<string, unknown> | CommonInputModel): Promise<OutputModel[]> {

--- a/src/generators/AbstractGenerator.ts
+++ b/src/generators/AbstractGenerator.ts
@@ -35,7 +35,7 @@ export abstract class AbstractGenerator<Options extends CommonGeneratorOptions =
 
   public abstract render(model: CommonModel, inputModel: CommonInputModel): Promise<RenderOutput>;
 
-  public async process(input: Record<string, unknown>): Promise<CommonInputModel> {
+  public process(input: Record<string, unknown>): Promise<CommonInputModel> {
     return InputProcessor.processor.process(input, this.options.processorOption);
   }
 

--- a/src/models/ProcessOptions.ts
+++ b/src/models/ProcessOptions.ts
@@ -1,0 +1,6 @@
+export interface AsyncapiProcessOptions {
+  path?: string
+}
+export interface ProcessOptions {
+  asyncapi?: AsyncapiProcessOptions
+}

--- a/src/models/ProcessOptions.ts
+++ b/src/models/ProcessOptions.ts
@@ -1,6 +1,6 @@
-export interface AsyncapiProcessOptions {
+export interface AsyncapiProcessorOption {
   path?: string
 }
-export interface ProcessOptions {
-  asyncapi?: AsyncapiProcessOptions
+export interface ProcessorOption {
+  asyncapi?: AsyncapiProcessorOption
 }

--- a/src/models/ProcessOptions.ts
+++ b/src/models/ProcessOptions.ts
@@ -1,6 +1,0 @@
-export interface AsyncapiProcessorOption {
-  path?: string
-}
-export interface ProcessorOption {
-  asyncapi?: AsyncapiProcessorOption
-}

--- a/src/models/ProcessorOptions.ts
+++ b/src/models/ProcessorOptions.ts
@@ -1,5 +1,8 @@
 export interface AsyncapiProcessorOptions {
   path?: string
+  parse?: any;
+  resolve?: any;
+  applyTraits?: any;
 }
 export interface ProcessorOptions {
   asyncapi?: AsyncapiProcessorOptions

--- a/src/models/ProcessorOptions.ts
+++ b/src/models/ProcessorOptions.ts
@@ -1,0 +1,6 @@
+export interface AsyncapiProcessorOptions {
+  path?: string
+}
+export interface ProcessorOptions {
+  asyncapi?: AsyncapiProcessorOptions
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -5,3 +5,4 @@ export * from './CommonSchema';
 export * from './OutputModel';
 export * from './Preset';
 export * from './Schema';
+export * from './ProcessOptions';

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -5,4 +5,4 @@ export * from './CommonSchema';
 export * from './OutputModel';
 export * from './Preset';
 export * from './Schema';
-export * from './ProcessOptions';
+export * from './ProcessorOption';

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -5,4 +5,4 @@ export * from './CommonSchema';
 export * from './OutputModel';
 export * from './Preset';
 export * from './Schema';
-export * from './ProcessorOption';
+export * from './ProcessorOptions';

--- a/src/processors/AbstractInputProcessor.ts
+++ b/src/processors/AbstractInputProcessor.ts
@@ -1,6 +1,6 @@
-import { ProcessorOption, CommonInputModel } from '../models';
+import { ProcessorOptions, CommonInputModel } from '../models';
 export abstract class AbstractInputProcessor {
   public static MODELGEN_INFFERED_NAME = 'x-modelgen-inferred-name';
-  abstract process(input: Record<string, any>, options?: ProcessorOption): Promise<CommonInputModel>;
+  abstract process(input: Record<string, any>, options?: ProcessorOptions): Promise<CommonInputModel>;
   abstract shouldProcess(input: Record<string, any>): boolean;
 }

--- a/src/processors/AbstractInputProcessor.ts
+++ b/src/processors/AbstractInputProcessor.ts
@@ -1,7 +1,6 @@
-import { CommonInputModel } from '../models/CommonInputModel';
-
+import { ProcessOptions, CommonInputModel } from '../models';
 export abstract class AbstractInputProcessor {
   public static MODELGEN_INFFERED_NAME = 'x-modelgen-inferred-name';
-  abstract process(input: Record<string, any>): Promise<CommonInputModel>;
+  abstract process(input: Record<string, any>, options?: ProcessOptions): Promise<CommonInputModel>;
   abstract shouldProcess(input: Record<string, any>): boolean;
 }

--- a/src/processors/AbstractInputProcessor.ts
+++ b/src/processors/AbstractInputProcessor.ts
@@ -1,6 +1,6 @@
-import { ProcessOptions, CommonInputModel } from '../models';
+import { ProcessorOption, CommonInputModel } from '../models';
 export abstract class AbstractInputProcessor {
   public static MODELGEN_INFFERED_NAME = 'x-modelgen-inferred-name';
-  abstract process(input: Record<string, any>, options?: ProcessOptions): Promise<CommonInputModel>;
+  abstract process(input: Record<string, any>, options?: ProcessorOption): Promise<CommonInputModel>;
   abstract shouldProcess(input: Record<string, any>): boolean;
 }

--- a/src/processors/AsyncAPIInputProcessor.ts
+++ b/src/processors/AsyncAPIInputProcessor.ts
@@ -2,7 +2,7 @@ import {parse, AsyncAPIDocument, Schema as AsyncAPISchema} from '@asyncapi/parse
 
 import { AbstractInputProcessor } from './AbstractInputProcessor';
 import { JsonSchemaInputProcessor } from './JsonSchemaInputProcessor';
-import { CommonInputModel, ProcessOptions, Schema } from '../models';
+import { CommonInputModel, ProcessorOption, Schema } from '../models';
 import { Logger } from '../utils';
 
 /**
@@ -15,7 +15,7 @@ export class AsyncAPIInputProcessor extends AbstractInputProcessor {
    * 
    * @param input 
    */
-  async process(input: Record<string, any>, options?: ProcessOptions): Promise<CommonInputModel> {
+  async process(input: Record<string, any>, options?: ProcessorOption): Promise<CommonInputModel> {
     if (!this.shouldProcess(input)) {throw new Error('Input is not an AsyncAPI document so it cannot be processed.');}
 
     Logger.debug('Processing input as an AsyncAPI document');

--- a/src/processors/AsyncAPIInputProcessor.ts
+++ b/src/processors/AsyncAPIInputProcessor.ts
@@ -2,7 +2,7 @@ import {parse, AsyncAPIDocument, Schema as AsyncAPISchema} from '@asyncapi/parse
 
 import { AbstractInputProcessor } from './AbstractInputProcessor';
 import { JsonSchemaInputProcessor } from './JsonSchemaInputProcessor';
-import { CommonInputModel, Schema } from '../models';
+import { CommonInputModel, ProcessOptions, Schema } from '../models';
 import { Logger } from '../utils';
 
 /**
@@ -15,14 +15,14 @@ export class AsyncAPIInputProcessor extends AbstractInputProcessor {
    * 
    * @param input 
    */
-  async process(input: Record<string, any>): Promise<CommonInputModel> {
+  async process(input: Record<string, any>, options?: ProcessOptions): Promise<CommonInputModel> {
     if (!this.shouldProcess(input)) {throw new Error('Input is not an AsyncAPI document so it cannot be processed.');}
 
     Logger.debug('Processing input as an AsyncAPI document');
     let doc: AsyncAPIDocument;
     const common = new CommonInputModel();
     if (!AsyncAPIInputProcessor.isFromParser(input)) {
-      doc = await parse(input as any);
+      doc = await parse(input as any, options?.asyncapi);
     } else {
       doc = input as AsyncAPIDocument;
     }

--- a/src/processors/AsyncAPIInputProcessor.ts
+++ b/src/processors/AsyncAPIInputProcessor.ts
@@ -1,5 +1,4 @@
 import {parse, AsyncAPIDocument, Schema as AsyncAPISchema} from '@asyncapi/parser';
-
 import { AbstractInputProcessor } from './AbstractInputProcessor';
 import { JsonSchemaInputProcessor } from './JsonSchemaInputProcessor';
 import { CommonInputModel, ProcessorOptions, Schema } from '../models';
@@ -10,6 +9,7 @@ import { Logger } from '../utils';
  */
 export class AsyncAPIInputProcessor extends AbstractInputProcessor {
   static supportedVersions = ['2.0.0', '2.1.0'];
+
   /**
    * Process the input as an AsyncAPI document
    * 

--- a/src/processors/AsyncAPIInputProcessor.ts
+++ b/src/processors/AsyncAPIInputProcessor.ts
@@ -2,7 +2,7 @@ import {parse, AsyncAPIDocument, Schema as AsyncAPISchema} from '@asyncapi/parse
 
 import { AbstractInputProcessor } from './AbstractInputProcessor';
 import { JsonSchemaInputProcessor } from './JsonSchemaInputProcessor';
-import { CommonInputModel, ProcessorOption, Schema } from '../models';
+import { CommonInputModel, ProcessorOptions, Schema } from '../models';
 import { Logger } from '../utils';
 
 /**
@@ -15,7 +15,7 @@ export class AsyncAPIInputProcessor extends AbstractInputProcessor {
    * 
    * @param input 
    */
-  async process(input: Record<string, any>, options?: ProcessorOption): Promise<CommonInputModel> {
+  async process(input: Record<string, any>, options?: ProcessorOptions): Promise<CommonInputModel> {
     if (!this.shouldProcess(input)) {throw new Error('Input is not an AsyncAPI document so it cannot be processed.');}
 
     Logger.debug('Processing input as an AsyncAPI document');

--- a/src/processors/InputProcessor.ts
+++ b/src/processors/InputProcessor.ts
@@ -1,7 +1,7 @@
 import { AbstractInputProcessor } from './AbstractInputProcessor';
 import { AsyncAPIInputProcessor } from './AsyncAPIInputProcessor';
 import { JsonSchemaInputProcessor } from './JsonSchemaInputProcessor';
-import { ProcessOptions, CommonInputModel } from '../models';
+import { ProcessorOption, CommonInputModel } from '../models';
 
 /**
  * Main input processor which figures out the type of input it receives and delegates the processing into separate individual processors.
@@ -39,7 +39,7 @@ export class InputProcessor {
    * @param input to process
    * @param options passed to the parsers
    */
-  process(input: Record<string, any>, options?: ProcessOptions): Promise<CommonInputModel> {
+  process(input: Record<string, any>, options?: ProcessorOption): Promise<CommonInputModel> {
     for (const [type, processor] of this.processors) {
       if (type === 'default') {continue;}
       if (processor.shouldProcess(input)) {

--- a/src/processors/InputProcessor.ts
+++ b/src/processors/InputProcessor.ts
@@ -1,7 +1,7 @@
 import { AbstractInputProcessor } from './AbstractInputProcessor';
 import { AsyncAPIInputProcessor } from './AsyncAPIInputProcessor';
 import { JsonSchemaInputProcessor } from './JsonSchemaInputProcessor';
-import { ProcessorOption, CommonInputModel } from '../models';
+import { ProcessorOptions, CommonInputModel } from '../models';
 
 /**
  * Main input processor which figures out the type of input it receives and delegates the processing into separate individual processors.
@@ -39,7 +39,7 @@ export class InputProcessor {
    * @param input to process
    * @param options passed to the parsers
    */
-  process(input: Record<string, any>, options?: ProcessorOption): Promise<CommonInputModel> {
+  process(input: Record<string, any>, options?: ProcessorOptions): Promise<CommonInputModel> {
     for (const [type, processor] of this.processors) {
       if (type === 'default') {continue;}
       if (processor.shouldProcess(input)) {

--- a/src/processors/InputProcessor.ts
+++ b/src/processors/InputProcessor.ts
@@ -37,7 +37,7 @@ export class InputProcessor {
    * The processor code which delegates the processing to the correct implementation.
    * 
    * @param input to process
-   * @param options passed to the parsers
+   * @param options passed to the processors
    */
   process(input: Record<string, any>, options?: ProcessorOptions): Promise<CommonInputModel> {
     for (const [type, processor] of this.processors) {

--- a/src/processors/InputProcessor.ts
+++ b/src/processors/InputProcessor.ts
@@ -1,7 +1,7 @@
 import { AbstractInputProcessor } from './AbstractInputProcessor';
 import { AsyncAPIInputProcessor } from './AsyncAPIInputProcessor';
 import { JsonSchemaInputProcessor } from './JsonSchemaInputProcessor';
-import { CommonInputModel } from '../models/CommonInputModel';
+import { ProcessOptions, CommonInputModel } from '../models';
 
 /**
  * Main input processor which figures out the type of input it receives and delegates the processing into separate individual processors.
@@ -37,18 +37,18 @@ export class InputProcessor {
    * The processor code which delegates the processing to the correct implementation.
    * 
    * @param input to process
-   * @param type of processor to use
+   * @param options passed to the parsers
    */
-  process(input: Record<string, any>): Promise<CommonInputModel> {
+  process(input: Record<string, any>, options?: ProcessOptions): Promise<CommonInputModel> {
     for (const [type, processor] of this.processors) {
       if (type === 'default') {continue;}
       if (processor.shouldProcess(input)) {
-        return processor.process(input);
+        return processor.process(input, options);
       }
     }
     const defaultProcessor = this.processors.get('default');
     if (defaultProcessor !== undefined) {
-      return defaultProcessor.process(input);
+      return defaultProcessor.process(input, options);
     }
     return Promise.reject(new Error('No default processor found'));
   }

--- a/test/processors/InputProcessor.spec.ts
+++ b/test/processors/InputProcessor.spec.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { CommonInputModel, ProcessorOption } from '../../src/models';
+import { CommonInputModel, ProcessorOptions } from '../../src/models';
 import { InputProcessor } from '../../src/processors/InputProcessor';
 import { JsonSchemaInputProcessor } from '../../src/processors/JsonSchemaInputProcessor';
 import { AsyncAPIInputProcessor } from '../../src/processors/AsyncAPIInputProcessor';
@@ -80,7 +80,7 @@ describe('InputProcessor', () => {
     });
     test('should be able to process AsyncAPI schema input with options', async () => {
       const {processor, asyncInputProcessor, defaultInputProcessor} = getProcessors(); 
-      const options: ProcessorOption = {
+      const options: ProcessorOptions = {
         asyncapi: {
           path: 'test'
         }

--- a/test/processors/InputProcessor.spec.ts
+++ b/test/processors/InputProcessor.spec.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { CommonInputModel, ProcessOptions } from '../../src/models';
+import { CommonInputModel, ProcessorOption } from '../../src/models';
 import { InputProcessor } from '../../src/processors/InputProcessor';
 import { JsonSchemaInputProcessor } from '../../src/processors/JsonSchemaInputProcessor';
 import { AsyncAPIInputProcessor } from '../../src/processors/AsyncAPIInputProcessor';
@@ -80,7 +80,7 @@ describe('InputProcessor', () => {
     });
     test('should be able to process AsyncAPI schema input with options', async () => {
       const {processor, asyncInputProcessor, defaultInputProcessor} = getProcessors(); 
-      const options: ProcessOptions = {
+      const options: ProcessorOption = {
         asyncapi: {
           path: 'test'
         }

--- a/test/processors/InputProcessor.spec.ts
+++ b/test/processors/InputProcessor.spec.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { CommonInputModel } from '../../src/models';
+import { CommonInputModel, ProcessOptions } from '../../src/models';
 import { InputProcessor } from '../../src/processors/InputProcessor';
 import { JsonSchemaInputProcessor } from '../../src/processors/JsonSchemaInputProcessor';
 import { AsyncAPIInputProcessor } from '../../src/processors/AsyncAPIInputProcessor';
@@ -64,7 +64,7 @@ describe('InputProcessor', () => {
       await processor.process(inputSchema);
       expect(asyncInputProcessor.process).not.toHaveBeenCalled();
       expect(asyncInputProcessor.shouldProcess).toHaveBeenNthCalledWith(1, inputSchema);
-      expect(defaultInputProcessor.process).toHaveBeenNthCalledWith(1, inputSchema);
+      expect(defaultInputProcessor.process).toHaveBeenNthCalledWith(1, inputSchema, undefined);
       expect(defaultInputProcessor.shouldProcess).toHaveBeenNthCalledWith(1, inputSchema);
     });
 
@@ -73,7 +73,22 @@ describe('InputProcessor', () => {
       const inputSchemaString = fs.readFileSync(path.resolve(__dirname, './AsyncAPIInputProcessor/basic.json'), 'utf8');
       const inputSchema = JSON.parse(inputSchemaString);
       await processor.process(inputSchema);
-      expect(asyncInputProcessor.process).toHaveBeenNthCalledWith(1, inputSchema);
+      expect(asyncInputProcessor.process).toHaveBeenNthCalledWith(1, inputSchema, undefined);
+      expect(asyncInputProcessor.shouldProcess).toHaveBeenNthCalledWith(1, inputSchema);
+      expect(defaultInputProcessor.process).not.toHaveBeenCalled();
+      expect(defaultInputProcessor.shouldProcess).not.toHaveBeenCalled();
+    });
+    test('should be able to process AsyncAPI schema input with options', async () => {
+      const {processor, asyncInputProcessor, defaultInputProcessor} = getProcessors(); 
+      const options: ProcessOptions = {
+        asyncapi: {
+          path: 'test'
+        }
+      };
+      const inputSchemaString = fs.readFileSync(path.resolve(__dirname, './AsyncAPIInputProcessor/basic.json'), 'utf8');
+      const inputSchema = JSON.parse(inputSchemaString);
+      await processor.process(inputSchema, options);
+      expect(asyncInputProcessor.process).toHaveBeenNthCalledWith(1, inputSchema, options);
       expect(asyncInputProcessor.shouldProcess).toHaveBeenNthCalledWith(1, inputSchema);
       expect(defaultInputProcessor.process).not.toHaveBeenCalled();
       expect(defaultInputProcessor.shouldProcess).not.toHaveBeenCalled();

--- a/test/processors/InputProcessor.spec.ts
+++ b/test/processors/InputProcessor.spec.ts
@@ -5,7 +5,7 @@ import { InputProcessor } from '../../src/processors/InputProcessor';
 import { JsonSchemaInputProcessor } from '../../src/processors/JsonSchemaInputProcessor';
 import { AsyncAPIInputProcessor } from '../../src/processors/AsyncAPIInputProcessor';
 import { AbstractInputProcessor } from '../../src/processors';
-
+import AsyncAPIParser from '@asyncapi/parser';
 describe('InputProcessor', () => {
   beforeEach(() => {
     jest.resetAllMocks();
@@ -80,6 +80,7 @@ describe('InputProcessor', () => {
     });
     test('should be able to process AsyncAPI schema input with options', async () => {
       const {processor, asyncInputProcessor, defaultInputProcessor} = getProcessors(); 
+      const spy = jest.spyOn(AsyncAPIParser, 'parse');
       const options: ProcessorOptions = {
         asyncapi: {
           path: 'test'
@@ -90,6 +91,7 @@ describe('InputProcessor', () => {
       await processor.process(inputSchema, options);
       expect(asyncInputProcessor.process).toHaveBeenNthCalledWith(1, inputSchema, options);
       expect(asyncInputProcessor.shouldProcess).toHaveBeenNthCalledWith(1, inputSchema);
+      expect(spy).toHaveBeenNthCalledWith(1, inputSchema, expect.objectContaining(options.asyncapi));
       expect(defaultInputProcessor.process).not.toHaveBeenCalled();
       expect(defaultInputProcessor.shouldProcess).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
**Description**
This PR introduces ProcessorOptions, which can be used by the processors to change certain behavior of the internals. This is especially useful for example when the library is used in browsers the AsyncAPI processor needs to alter the `path` for derefences.