### PR TITLE
fix: c# generator should render types as nullable by default

### DIFF
--- a/src/generators/csharp/CSharpRenderer.ts
+++ b/src/generators/csharp/CSharpRenderer.ts
@@ -76,11 +76,11 @@ export abstract class CSharpRenderer extends AbstractRenderer<CSharpOptions> {
     case 'string':
       return 'string';
     case 'integer':
-      return 'int';
+      return 'int?';
     case 'number':
-      return 'float';
+      return 'float?';
     case 'boolean':
-      return 'bool';
+      return 'bool?';
     case 'object':
       return 'object';
     case 'array': {

--- a/test/generators/csharp/CSharpRenderer.spec.ts
+++ b/test/generators/csharp/CSharpRenderer.spec.ts
@@ -14,16 +14,16 @@ describe('CSharpRenderer', () => {
     test('Should render undefined as dynamic type', () => {
       expect(renderer.toCSharpType(undefined, new CommonModel())).toEqual('dynamic');
     });
-    test('Should render integer as int type', () => {
-      expect(renderer.toCSharpType('integer', new CommonModel())).toEqual('int');
+    test('Should render integer as nullable int type', () => {
+      expect(renderer.toCSharpType('integer', new CommonModel())).toEqual('int?');
     });
-    test('Should render number as float type', () => {
-      expect(renderer.toCSharpType('number', new CommonModel())).toEqual('float');
+    test('Should render number as nullable float type', () => {
+      expect(renderer.toCSharpType('number', new CommonModel())).toEqual('float?');
     });
     test('Should render array as slice of the type', () => {
       const model = new CommonModel();
       model.items = CommonModel.toCommonModel({ type: 'number' });
-      expect(renderer.toCSharpType('array', model)).toEqual('float[]');
+      expect(renderer.toCSharpType('array', model)).toEqual('float?[]');
     });
     test('Should render tuple with multiple types as dynamic', () => {
       const model = new CommonModel();
@@ -56,7 +56,7 @@ describe('CSharpRenderer', () => {
     test('Should render single union type', () => {
       const model = CommonModel.toCommonModel({ type: ['number'] });
       const renderedType = renderer.renderType(model);
-      expect(renderedType).toEqual('float');
+      expect(renderedType).toEqual('float?');
     });
     test('Should render union types with multiple types as slice of interface', () => {
       const model = CommonModel.toCommonModel({ type: ['number', 'string'] });

--- a/test/generators/csharp/__snapshots__/CSharpGenerator.spec.ts.snap
+++ b/test/generators/csharp/__snapshots__/CSharpGenerator.spec.ts.snap
@@ -43,8 +43,8 @@ exports[`CSharpGenerator should render \`class\` type 1`] = `
   private string streetName;
   private string city;
   private string state;
-  private float houseNumber;
-  private bool marriage;
+  private float? houseNumber;
+  private bool? marriage;
   private dynamic members;
   private dynamic[] tupleType;
   private string[] arrayType;
@@ -69,13 +69,13 @@ exports[`CSharpGenerator should render \`class\` type 1`] = `
     set { state = value; }
   }
 
-  public float HouseNumber 
+  public float? HouseNumber 
   {
     get { return houseNumber; }
     set { houseNumber = value; }
   }
 
-  public bool Marriage 
+  public bool? Marriage 
   {
     get { return marriage; }
     set { marriage = value; }
@@ -118,8 +118,8 @@ exports[`CSharpGenerator should render \`class\` type 2`] = `
   private string streetName;
   private string city;
   private string state;
-  private float houseNumber;
-  private bool marriage;
+  private float? houseNumber;
+  private bool? marriage;
   private dynamic members;
   private dynamic[] tupleType;
   private string[] arrayType;
@@ -144,13 +144,13 @@ exports[`CSharpGenerator should render \`class\` type 2`] = `
     set { state = value; }
   }
 
-  public float HouseNumber 
+  public float? HouseNumber 
   {
     get { return houseNumber; }
     set { houseNumber = value; }
   }
 
-  public bool Marriage 
+  public bool? Marriage 
   {
     get { return marriage; }
     set { marriage = value; }


### PR DESCRIPTION
**Description**
This PR introduces a change to the underlying C# type rendering. It changes the rendering for `float`, `int` and `bool` to being optional primitives, instead of primitives. As we don't render required properties (yet, gonna do a follow-up issue) we should make them optional.