### PR TITLE
feat: add c# serializer and deserializer functionality

### DIFF
--- a/src/generators/csharp/index.ts
+++ b/src/generators/csharp/index.ts
@@ -1,3 +1,4 @@
 export * from './CSharpGenerator';
 export { CSHARP_DEFAULT_PRESET } from './CSharpPreset';
 export type { CSharpPreset } from './CSharpPreset';
+export * from './presets';

--- a/src/generators/csharp/presets/JsonSerializerPreset.ts
+++ b/src/generators/csharp/presets/JsonSerializerPreset.ts
@@ -218,7 +218,7 @@ ${renderer.indent(unmarshalAdditionalProperties, 4)}
  */
 export const CSHARP_JSON_SERIALIZER_PRESET: CSharpPreset = {
   class: {
-    async self({ renderer, model}) {
+    self({ renderer, model, content }) {
       renderer.addDependency('using System.Text.Json;');
       renderer.addDependency('using System.Text.Json.Serialization;');
       renderer.addDependency('using System.Text.RegularExpressions;');
@@ -228,7 +228,7 @@ export const CSHARP_JSON_SERIALIZER_PRESET: CSharpPreset = {
       const marshal = renderMarshal({renderer, model});
 
       return `[JsonConverter(typeof(${formattedModelName}Converter))]
-${await renderer.defaultSelf()}
+${content}
 
 internal class ${formattedModelName}Converter : JsonConverter<${formattedModelName}>
 {

--- a/src/generators/csharp/presets/JsonSerializerPreset.ts
+++ b/src/generators/csharp/presets/JsonSerializerPreset.ts
@@ -1,0 +1,238 @@
+import { CSharpRenderer } from '../CSharpRenderer';
+import { CSharpPreset } from '../CSharpPreset';
+import { getUniquePropertyName, DefaultPropertyNames } from '../../../helpers';
+import { CommonModel } from '../../../models';
+import { FormatHelpers } from '../../../helpers';
+
+function renderMarshalAdditionalProperties(model: CommonModel, renderer: CSharpRenderer) {
+  const marshalAdditionalProperties = '';
+  if (model.additionalProperties !== undefined) {
+    let additionalPropertyName = getUniquePropertyName(model, DefaultPropertyNames.additionalProperties);
+    additionalPropertyName = FormatHelpers.upperFirst(renderer.nameProperty(additionalPropertyName, model.additionalProperties));
+    return `// Unwrap additional properties in object
+if (value.AdditionalProperties != null) {
+  foreach (var additionalProperty in value.${additionalPropertyName})
+  {
+    //Ignore any additional properties which might already be part of the core properties
+    if (properties.Any(prop => prop.Name == additionalProperty.Key))
+    {
+        continue;
+    }
+    // write property name and let the serializer serialize the value itself
+    writer.WritePropertyName(additionalProperty.Key);
+    JsonSerializer.Serialize(writer, additionalProperty.Value);
+  }
+}`;
+  }
+  return marshalAdditionalProperties;
+}
+
+function renderMarshalProperties(model: CommonModel, renderer: CSharpRenderer) {
+  let marshalProperties = '';
+  if (model.properties !== undefined) {
+    for (const [propertyName, propertyModel] of Object.entries(model.properties)) {
+      const formattedPropertyName = FormatHelpers.upperFirst(renderer.nameProperty(propertyName, propertyModel));
+      marshalProperties += `if(value.${formattedPropertyName} != null) { 
+  // write property name and let the serializer serialize the value itself
+  writer.WritePropertyName("${propertyName}");
+  JsonSerializer.Serialize(writer, value.${formattedPropertyName});
+}\n`;
+    }
+  }
+  return marshalProperties;
+}
+function renderMarshalPatternProperties(model: CommonModel, renderer: CSharpRenderer) {
+  let marshalPatternProperties = '';
+  if (model.patternProperties !== undefined) {
+    for (const [pattern, patternModel] of Object.entries(model.patternProperties)) {
+      let patternPropertyName = getUniquePropertyName(model, `${pattern}${DefaultPropertyNames.patternProperties}`);
+      patternPropertyName = FormatHelpers.upperFirst(renderer.nameProperty(patternPropertyName, patternModel));
+      marshalPatternProperties += `// Unwrap pattern properties in object
+if(value.${patternPropertyName} != null) { 
+  foreach (var patternProp in value.${patternPropertyName})
+  {
+    //Ignore any pattern properties which might already be part of the core properties
+    if (properties.Any(prop => prop.Name == patternProp.Key))
+    {
+        continue;
+    }
+    // write property name and let the serializer serialize the value itself
+    writer.WritePropertyName(patternProp.Key);
+    JsonSerializer.Serialize(writer, patternProp.Value);
+  }
+}`;
+    }
+  }
+  return marshalPatternProperties;
+}
+/**
+ * Render `marshal` function based on model
+ */
+function renderMarshal({ renderer, model }: {
+  renderer: CSharpRenderer,
+  model: CommonModel,
+}): string {
+  const formattedModelName = renderer.nameType(model.$id);
+  const marshalProperties = renderMarshalProperties(model, renderer);
+  const marshalPatternProperties = renderMarshalPatternProperties(model, renderer);
+  const marshalAdditionalProperties = renderMarshalAdditionalProperties(model, renderer);
+  const propertyFilter: string[] = [];
+  if (model.additionalProperties !== undefined) {
+    let additionalPropertyName = getUniquePropertyName(model, DefaultPropertyNames.additionalProperties);
+    additionalPropertyName = FormatHelpers.upperFirst(renderer.nameProperty(additionalPropertyName, model.additionalProperties));
+    propertyFilter.push(`prop.Name != "${additionalPropertyName}"`);
+  }
+  for (const [pattern, patternModel] of Object.entries(model.patternProperties || {})) {
+    let patternPropertyName = getUniquePropertyName(model, `${pattern}${DefaultPropertyNames.patternProperties}`);
+    patternPropertyName = FormatHelpers.upperFirst(renderer.nameProperty(patternPropertyName, patternModel));
+    propertyFilter.push(`prop.Name != "${patternPropertyName}"`);
+  }
+  return `public override void Write(Utf8JsonWriter writer, ${formattedModelName} value, JsonSerializerOptions options)
+{
+  if (value == null)
+  {
+    JsonSerializer.Serialize(writer, null);
+    return;
+  }
+  ${propertyFilter.length === 0 ? 'var properties = value.GetType().GetProperties();': `var properties = value.GetType().GetProperties().Where(prop => ${propertyFilter.join(' && ')});`}
+  
+  writer.WriteStartObject();
+
+${renderer.indent(marshalProperties)}
+
+${renderer.indent(marshalPatternProperties)}
+
+${renderer.indent(marshalAdditionalProperties)}
+
+  writer.WriteEndObject();
+}`;
+} 
+
+function renderUnmarshalProperties(model: CommonModel, renderer: CSharpRenderer) {
+  const propertyEntries = Object.entries(model.properties || {});
+  const unmarshalProperties = propertyEntries.map(([prop, propModel]) => {
+    const formattedPropertyName = FormatHelpers.upperFirst(renderer.nameProperty(prop, propModel));
+    const propertyModelType = renderer.renderType(propModel);
+    return `if (propertyName == "${prop}")
+{
+  var value = JsonSerializer.Deserialize<${propertyModelType}>(ref reader, options);
+  instance.${formattedPropertyName} = value;
+  continue;
+}`;
+  });
+  return unmarshalProperties.join('\n');
+}
+
+function renderUnmarshalPatternProperties(model: CommonModel, renderer: CSharpRenderer) {
+  if (model.patternProperties === undefined) {
+    return '';
+  }
+  const patternProperties = Object.entries(model.patternProperties).map(([pattern, patternModel]) => {
+    let patternPropertyName = getUniquePropertyName(model, `${pattern}${DefaultPropertyNames.patternProperties}`);
+    patternPropertyName = FormatHelpers.upperFirst(renderer.nameProperty(patternPropertyName, patternModel));
+    const patternPropertyType = renderer.renderType(patternModel);
+    return `if(instance.${patternPropertyName} == null) { instance.${patternPropertyName} = new Dictionary<string, ${patternPropertyType}>(); }
+var match = Regex.Match(propertyName, @"${pattern}");
+if (match.Success)
+{
+  var deserializedValue = JsonSerializer.Deserialize<${patternPropertyType}>(ref reader, options);
+  instance.${patternPropertyName}.Add(propertyName, deserializedValue);
+  continue;
+}`;
+  });
+  return patternProperties.join('\n');
+}
+
+function renderUnmarshalAdditionalProperties(model: CommonModel, renderer: CSharpRenderer) {
+  if (model.additionalProperties === undefined) {
+    return ''; 
+  }
+  let additionalPropertyName = getUniquePropertyName(model, DefaultPropertyNames.additionalProperties);
+  additionalPropertyName = FormatHelpers.upperFirst(renderer.nameProperty(additionalPropertyName, model.additionalProperties));
+  const additionalPropertyType = renderer.renderType(model.additionalProperties);
+  return `if(instance.${additionalPropertyName} == null) { instance.${additionalPropertyName} = new Dictionary<string, ${additionalPropertyType}>(); }
+var deserializedValue = JsonSerializer.Deserialize<${additionalPropertyType}>(ref reader, options);
+instance.${additionalPropertyName}.Add(propertyName, deserializedValue);
+continue;`;
+}
+
+/**
+ * Render `unmarshal` function based on model
+ */
+function renderUnmarshal({ renderer, model }: {
+  renderer: CSharpRenderer,
+  model: CommonModel,
+}): string {
+  const formattedModelName = renderer.nameType(model.$id);
+  const unmarshalProperties = renderUnmarshalProperties(model, renderer);
+  const unmarshalPatternProperties = renderUnmarshalPatternProperties(model, renderer);
+  const unmarshalAdditionalProperties = renderUnmarshalAdditionalProperties(model, renderer);
+  return `public override ${formattedModelName} Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+{
+  if (reader.TokenType != JsonTokenType.StartObject)
+  {
+    throw new JsonException();
+  }
+
+  var instance = new ${formattedModelName}();
+  
+  while (reader.Read())
+  {
+    if (reader.TokenType == JsonTokenType.EndObject)
+    {
+      return instance;
+    }
+
+    // Get the key.
+    if (reader.TokenType != JsonTokenType.PropertyName)
+    {
+      throw new JsonException();
+    }
+
+    string propertyName = reader.GetString();
+${renderer.indent(unmarshalProperties, 4)}
+
+${renderer.indent(unmarshalPatternProperties, 4)}
+
+${renderer.indent(unmarshalAdditionalProperties, 4)}
+  }
+  
+  throw new JsonException();
+}`;
+} 
+
+/**
+ * Preset which adds `marshal` and `unmarshal` functions to class. 
+ * 
+ * @implements {CSharpPreset}
+ */
+export const CSHARP_JSON_SERIALIZER_PRESET: CSharpPreset = {
+  class: {
+    async self({ renderer, model}) {
+      renderer.addDependency('using System.Text.Json;');
+      renderer.addDependency('using System.Text.Json.Serialization;');
+      renderer.addDependency('using System.Text.RegularExpressions;');
+      renderer.addDependency('using System.Linq;');
+      
+      const formattedModelName = renderer.nameType(model.$id);
+      const unmarshal = renderUnmarshal({renderer, model});
+      const marshal = renderMarshal({renderer, model});
+
+      return `[JsonConverter(typeof(${formattedModelName}Converter))]
+${await renderer.defaultSelf()}
+
+internal class ${formattedModelName}Converter : JsonConverter<${formattedModelName}>
+{
+  public override bool CanConvert(Type objectType)
+  {
+    // this converter can be applied to any type
+    return true;
+  }
+${renderer.indent(unmarshal)}
+${renderer.indent(marshal)}
+
+}
+`;
+    }
+  }
+};

--- a/src/generators/csharp/presets/index.ts
+++ b/src/generators/csharp/presets/index.ts
@@ -1,0 +1,1 @@
+export * from './JsonSerializerPreset';

--- a/src/helpers/FormatHelpers.ts
+++ b/src/helpers/FormatHelpers.ts
@@ -1,9 +1,8 @@
-/* eslint-disable no-unused-vars */
 import { 
   camelCase,
   pascalCase,
   paramCase,
-  constantCase,
+  constantCase
 } from 'change-case';
 
 export enum IndentationTypes {

--- a/test/generators/csharp/presets/JsonSerializerPreset.spec.ts
+++ b/test/generators/csharp/presets/JsonSerializerPreset.spec.ts
@@ -1,0 +1,35 @@
+import { CSharpGenerator, CSHARP_JSON_SERIALIZER_PRESET } from '../../../../src/generators'; 
+const doc = {
+  $id: 'Test',
+  type: 'object',
+  additionalProperties: true,
+  required: ['string prop'],
+  properties: {
+    'string prop': { type: 'string' },
+    numberProp: { type: 'number' },
+    objectProp: { type: 'object', $id: 'NestedTest', properties: {stringProp: { type: 'string' }}}
+  },
+  patternProperties: {
+    '^S(.?)test': {
+      type: 'string'
+    }
+  },
+};
+describe('JSON serializer preset', () => {
+  test('should render serialize and deserialize converters', async () => {
+    const generator = new CSharpGenerator({ 
+      presets: [
+        CSHARP_JSON_SERIALIZER_PRESET
+      ]
+    });
+    const inputModel = await generator.process(doc);
+    const testModel = inputModel.models['Test'];
+    const nestedTestModel = inputModel.models['NestedTest'];
+
+    const testClass = await generator.renderClass(testModel, inputModel);
+    const nestedTestClass = await generator.renderClass(nestedTestModel, inputModel);
+
+    expect(testClass.result).toMatchSnapshot();
+    expect(nestedTestClass.result).toMatchSnapshot();
+  });
+});

--- a/test/generators/csharp/presets/__snapshots__/JsonSerializerPreset.spec.ts.snap
+++ b/test/generators/csharp/presets/__snapshots__/JsonSerializerPreset.spec.ts.snap
@@ -1,0 +1,280 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`JSON serializer preset should render serialize and deserialize converters 1`] = `
+"[JsonConverter(typeof(TestConverter))]
+public class Test {
+  private string stringProp;
+  private float? numberProp;
+  private NestedTest objectProp;
+  private Dictionary<string, dynamic> additionalProperties;
+  private Dictionary<string, string> sTestPatternProperties;
+
+  public string StringProp 
+  {
+    get { return stringProp; }
+    set { stringProp = value; }
+  }
+
+  public float? NumberProp 
+  {
+    get { return numberProp; }
+    set { numberProp = value; }
+  }
+
+  public NestedTest ObjectProp 
+  {
+    get { return objectProp; }
+    set { objectProp = value; }
+  }
+
+  public Dictionary<string, dynamic> AdditionalProperties 
+  {
+    get { return additionalProperties; }
+    set { additionalProperties = value; }
+  }
+
+  public Dictionary<string, string> STestPatternProperties 
+  {
+    get { return sTestPatternProperties; }
+    set { sTestPatternProperties = value; }
+  }
+}
+
+internal class TestConverter : JsonConverter<Test>
+{
+  public override bool CanConvert(Type objectType)
+  {
+    // this converter can be applied to any type
+    return true;
+  }
+  public override Test Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+  {
+    if (reader.TokenType != JsonTokenType.StartObject)
+    {
+      throw new JsonException();
+    }
+
+    var instance = new Test();
+  
+    while (reader.Read())
+    {
+      if (reader.TokenType == JsonTokenType.EndObject)
+      {
+        return instance;
+      }
+
+      // Get the key.
+      if (reader.TokenType != JsonTokenType.PropertyName)
+      {
+        throw new JsonException();
+      }
+
+      string propertyName = reader.GetString();
+      if (propertyName == \\"string prop\\")
+      {
+        var value = JsonSerializer.Deserialize<string>(ref reader, options);
+        instance.StringProp = value;
+        continue;
+      }
+      if (propertyName == \\"numberProp\\")
+      {
+        var value = JsonSerializer.Deserialize<float?>(ref reader, options);
+        instance.NumberProp = value;
+        continue;
+      }
+      if (propertyName == \\"objectProp\\")
+      {
+        var value = JsonSerializer.Deserialize<NestedTest>(ref reader, options);
+        instance.ObjectProp = value;
+        continue;
+      }
+
+      if(instance.STestPatternProperties == null) { instance.STestPatternProperties = new Dictionary<string, string>(); }
+      var match = Regex.Match(propertyName, @\\"^S(.?)test\\");
+      if (match.Success)
+      {
+        var deserializedValue = JsonSerializer.Deserialize<string>(ref reader, options);
+        instance.STestPatternProperties.Add(propertyName, deserializedValue);
+        continue;
+      }
+
+      if(instance.AdditionalProperties == null) { instance.AdditionalProperties = new Dictionary<string, dynamic>(); }
+      var deserializedValue = JsonSerializer.Deserialize<dynamic>(ref reader, options);
+      instance.AdditionalProperties.Add(propertyName, deserializedValue);
+      continue;
+    }
+  
+    throw new JsonException();
+  }
+  public override void Write(Utf8JsonWriter writer, Test value, JsonSerializerOptions options)
+  {
+    if (value == null)
+    {
+      JsonSerializer.Serialize(writer, null);
+      return;
+    }
+    var properties = value.GetType().GetProperties().Where(prop => prop.Name != \\"AdditionalProperties\\" && prop.Name != \\"STestPatternProperties\\");
+  
+    writer.WriteStartObject();
+
+    if(value.StringProp != null) { 
+      // write property name and let the serializer serialize the value itself
+      writer.WritePropertyName(\\"string prop\\");
+      JsonSerializer.Serialize(writer, value.StringProp);
+    }
+    if(value.NumberProp != null) { 
+      // write property name and let the serializer serialize the value itself
+      writer.WritePropertyName(\\"numberProp\\");
+      JsonSerializer.Serialize(writer, value.NumberProp);
+    }
+    if(value.ObjectProp != null) { 
+      // write property name and let the serializer serialize the value itself
+      writer.WritePropertyName(\\"objectProp\\");
+      JsonSerializer.Serialize(writer, value.ObjectProp);
+    }
+
+
+    // Unwrap pattern properties in object
+    if(value.STestPatternProperties != null) { 
+      foreach (var patternProp in value.STestPatternProperties)
+      {
+        //Ignore any pattern properties which might already be part of the core properties
+        if (properties.Any(prop => prop.Name == patternProp.Key))
+        {
+            continue;
+        }
+        // write property name and let the serializer serialize the value itself
+        writer.WritePropertyName(patternProp.Key);
+        JsonSerializer.Serialize(writer, patternProp.Value);
+      }
+    }
+
+    // Unwrap additional properties in object
+    if (value.AdditionalProperties != null) {
+      foreach (var additionalProperty in value.AdditionalProperties)
+      {
+        //Ignore any additional properties which might already be part of the core properties
+        if (properties.Any(prop => prop.Name == additionalProperty.Key))
+        {
+            continue;
+        }
+        // write property name and let the serializer serialize the value itself
+        writer.WritePropertyName(additionalProperty.Key);
+        JsonSerializer.Serialize(writer, additionalProperty.Value);
+      }
+    }
+
+    writer.WriteEndObject();
+  }
+
+}
+"
+`;
+
+exports[`JSON serializer preset should render serialize and deserialize converters 2`] = `
+"[JsonConverter(typeof(NestedTestConverter))]
+public class NestedTest {
+  private string stringProp;
+  private Dictionary<string, dynamic> additionalProperties;
+
+  public string StringProp 
+  {
+    get { return stringProp; }
+    set { stringProp = value; }
+  }
+
+  public Dictionary<string, dynamic> AdditionalProperties 
+  {
+    get { return additionalProperties; }
+    set { additionalProperties = value; }
+  }
+}
+
+internal class NestedTestConverter : JsonConverter<NestedTest>
+{
+  public override bool CanConvert(Type objectType)
+  {
+    // this converter can be applied to any type
+    return true;
+  }
+  public override NestedTest Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+  {
+    if (reader.TokenType != JsonTokenType.StartObject)
+    {
+      throw new JsonException();
+    }
+
+    var instance = new NestedTest();
+  
+    while (reader.Read())
+    {
+      if (reader.TokenType == JsonTokenType.EndObject)
+      {
+        return instance;
+      }
+
+      // Get the key.
+      if (reader.TokenType != JsonTokenType.PropertyName)
+      {
+        throw new JsonException();
+      }
+
+      string propertyName = reader.GetString();
+      if (propertyName == \\"stringProp\\")
+      {
+        var value = JsonSerializer.Deserialize<string>(ref reader, options);
+        instance.StringProp = value;
+        continue;
+      }
+
+    
+
+      if(instance.AdditionalProperties == null) { instance.AdditionalProperties = new Dictionary<string, dynamic>(); }
+      var deserializedValue = JsonSerializer.Deserialize<dynamic>(ref reader, options);
+      instance.AdditionalProperties.Add(propertyName, deserializedValue);
+      continue;
+    }
+  
+    throw new JsonException();
+  }
+  public override void Write(Utf8JsonWriter writer, NestedTest value, JsonSerializerOptions options)
+  {
+    if (value == null)
+    {
+      JsonSerializer.Serialize(writer, null);
+      return;
+    }
+    var properties = value.GetType().GetProperties().Where(prop => prop.Name != \\"AdditionalProperties\\");
+  
+    writer.WriteStartObject();
+
+    if(value.StringProp != null) { 
+      // write property name and let the serializer serialize the value itself
+      writer.WritePropertyName(\\"stringProp\\");
+      JsonSerializer.Serialize(writer, value.StringProp);
+    }
+
+
+  
+
+    // Unwrap additional properties in object
+    if (value.AdditionalProperties != null) {
+      foreach (var additionalProperty in value.AdditionalProperties)
+      {
+        //Ignore any additional properties which might already be part of the core properties
+        if (properties.Any(prop => prop.Name == additionalProperty.Key))
+        {
+            continue;
+        }
+        // write property name and let the serializer serialize the value itself
+        writer.WritePropertyName(additionalProperty.Key);
+        JsonSerializer.Serialize(writer, additionalProperty.Value);
+      }
+    }
+
+    writer.WriteEndObject();
+  }
+
+}
+"
+`;


### PR DESCRIPTION
**Description**
This PR adds functionality to render serializer and deserializer functionality to C# class output. This will enable correct behavior from `System.Text.Json.JsonSerializer.Serialize` and `System.Text.Json.JsonSerializer.Deserialize`, so you can do the following in your code:
```c#
TestModel temp = new TestModel
{
    ...
};
string json = JsonSerializer.Serialize(temp);
TestModel output = JsonSerializer.Deserialize<TestModel>(json);
```

**Related issue(s)**
Partly solves https://github.com/asyncapi/modelina/issues/262