### PR TITLE
fix: un/marshal TS class functions did not render references correctly

### DIFF
--- a/src/generators/typescript/presets/CommonPreset.ts
+++ b/src/generators/typescript/presets/CommonPreset.ts
@@ -136,7 +136,7 @@ function renderUnmarshalAdditionalProperties(model: CommonModel, renderer: TypeS
 /**
  * Render `unmarshal` function based on model
  */
-function renderUnmarshal({ renderer, model, inputModel }: {
+function renderUnmarshal({ renderer, model }: {
   renderer: TypeScriptRenderer,
   model: CommonModel,
 }): string {
@@ -169,13 +169,13 @@ ${renderer.indent(unmarshalAdditionalProperties, 4)}
  */
 export const TS_COMMON_PRESET: TypeScriptPreset = {
   class: {
-    additionalContent({ renderer, model, content, options, inputModel }) {
+    additionalContent({ renderer, model, content, options }) {
       options = options || {};
       const blocks: string[] = [];
       
       if (options.marshalling === true) {
-        blocks.push(renderMarshal({ renderer, model, inputModel }));
-        blocks.push(renderUnmarshal({ renderer, model, inputModel }));
+        blocks.push(renderMarshal({ renderer, model }));
+        blocks.push(renderUnmarshal({ renderer, model }));
       }
 
       if (options.example === true) {

--- a/test/blackbox/Dummy.spec.ts
+++ b/test/blackbox/Dummy.spec.ts
@@ -30,22 +30,13 @@ describe('Dummy JSON Schema file', () => {
 
   describe('should be able to generate and transpile TS', () => {
     test('class', async () => {
-      const generator = new TypeScriptGenerator({ 
-        presets: [
-          {
-            preset: TS_COMMON_PRESET,
-            options: {
-              marshalling: true
-            }
-          }
-        ]
-      });
+      const generator = new TypeScriptGenerator();
       const generatedModels = await generateModels(fileToGenerate, generator);
       expect(generatedModels).not.toHaveLength(0);
       const renderOutputPath = path.resolve(__dirname, './output/ts/class/output.ts');
       await renderModels(generatedModels, renderOutputPath);
       const transpiledOutputPath = path.resolve(__dirname, './output/ts/class/output.js');
-      const transpileAndRunCommand = `tsc -t es5 ${renderOutputPath} && node ${transpiledOutputPath}`;
+      const transpileAndRunCommand = `tsc --downlevelIteration -t es5 ${renderOutputPath} && node ${transpiledOutputPath}`;
       await execCommand(transpileAndRunCommand);
     });
 

--- a/test/blackbox/Dummy.spec.ts
+++ b/test/blackbox/Dummy.spec.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import { TypeScriptGenerator, JavaGenerator, JavaScriptGenerator, GoGenerator, CSharpGenerator } from '../../src';
+import { TypeScriptGenerator, JavaGenerator, JavaScriptGenerator, GoGenerator, CSharpGenerator, TS_COMMON_PRESET } from '../../src';
 import { execCommand, generateModels, renderModels, renderModelsToSeparateFiles } from './utils/Utils';
 const fileToGenerate = path.resolve(__dirname, './docs/dummy.json');
 describe('Dummy JSON Schema file', () => {
@@ -30,7 +30,16 @@ describe('Dummy JSON Schema file', () => {
 
   describe('should be able to generate and transpile TS', () => {
     test('class', async () => {
-      const generator = new TypeScriptGenerator();
+      const generator = new TypeScriptGenerator({ 
+        presets: [
+          {
+            preset: TS_COMMON_PRESET,
+            options: {
+              marshalling: true
+            }
+          }
+        ]
+      });
       const generatedModels = await generateModels(fileToGenerate, generator);
       expect(generatedModels).not.toHaveLength(0);
       const renderOutputPath = path.resolve(__dirname, './output/ts/class/output.ts');

--- a/test/generators/typescript/preset/MarshallingPreset.spec.ts
+++ b/test/generators/typescript/preset/MarshallingPreset.spec.ts
@@ -14,7 +14,7 @@ const doc = {
   required: ['string prop'],
   properties: {
     'string prop': { type: 'string' },
-    enumProp: { $id: 'EnumTest', enum: ['Some enum String']},
+    enumProp: { $id: 'EnumTest', enum: ['Some enum String', "some other enum string"]},
     numberProp: { type: 'number' },
     objectProp: { $ref: '#/definitions/NestedTest' }
   },
@@ -50,6 +50,7 @@ describe('Marshalling preset', () => {
   test('should provide a two way conversion', async () => {
     enum EnumTest {
       SOME_ENUM_STRING = "Some enum String",
+      SOME_OTHER_ENUM_STRING = "some other enum string"
     }
     class NestedTest {
       private _stringProp?: string;

--- a/test/generators/typescript/preset/MarshallingPreset.spec.ts
+++ b/test/generators/typescript/preset/MarshallingPreset.spec.ts
@@ -9,6 +9,7 @@ const doc = {
   required: ['string prop'],
   properties: {
     'string prop': { type: 'string' },
+    enumProp: { $id: 'EnumTest', enum: ['Some enum String']},
     numberProp: { type: 'number' },
     objectProp: { type: 'object', $id: 'NestedTest', properties: {stringProp: { type: 'string' }}}
   },
@@ -31,6 +32,7 @@ describe('Marshalling preset', () => {
       ]
     });
     const inputModel = await generator.process(doc);
+
     const testModel = inputModel.models['Test'];
     const nestedTestModel = inputModel.models['NestedTest'];
 
@@ -42,50 +44,51 @@ describe('Marshalling preset', () => {
   });
 
   test('should provide a two way conversion', async () => {
+    enum EnumTest {
+      SOME_ENUM_STRING = "Some enum String",
+    }
     class NestedTest {
       private _stringProp?: string;
       private _additionalProperties?: Map<String, object | string | number | Array<unknown> | boolean | null | number>;
-
+    
       constructor(input: {
         stringProp?: string,
       }) {
         this._stringProp = input.stringProp;
       }
-
+    
       get stringProp(): string | undefined { return this._stringProp; }
       set stringProp(stringProp: string | undefined) { this._stringProp = stringProp; }
-
+    
       get additionalProperties(): Map<String, object | string | number | Array<unknown> | boolean | null | number> | undefined { return this._additionalProperties; }
       set additionalProperties(additionalProperties: Map<String, object | string | number | Array<unknown> | boolean | null | number> | undefined) { this._additionalProperties = additionalProperties; }
-
+    
       public marshal() : string {
         let json = '{'
         if(this.stringProp !== undefined) {
-          json += `\"stringProp\": ${typeof this.stringProp === 'number' || typeof this.stringProp === 'boolean' ? this.stringProp : JSON.stringify(this.stringProp)},`; 
+          json += `"stringProp": ${typeof this.stringProp === 'number' || typeof this.stringProp === 'boolean' ? this.stringProp : JSON.stringify(this.stringProp)},`; 
         }
-
       
-
         if(this.additionalProperties !== undefined) { 
           for (const [key, value] of this.additionalProperties.entries()) {
             //Only render additionalProperties which are not already a property
             if(Object.keys(this).includes(String(key))) continue;
-            json += `\"${key}\": ${typeof value === 'number' || typeof value === 'boolean' ? value : JSON.stringify(value)},`;    
+            json += `"${key}": ${typeof value === 'number' || typeof value === 'boolean' ? value : JSON.stringify(value)},`;    
           }
         }
-
+    
         //Remove potential last comma 
         return `${json.charAt(json.length-1) === ',' ? json.slice(0, json.length-1) : json}}`;
       }
-
+    
       public static unmarshal(json: string | object): NestedTest {
         const obj = typeof json === "object" ? json : JSON.parse(json);
         const instance = new NestedTest({} as any);
-
-        if (obj.stringProp !== undefined) {
+    
+        if (obj["stringProp"] !== undefined) {
           instance.stringProp = obj["stringProp"];
         }
-
+    
         //Not part of core properties
       
         if (instance.additionalProperties === undefined) {instance.additionalProperties = new Map();}
@@ -98,86 +101,96 @@ describe('Marshalling preset', () => {
     }
     class Test {
       private _stringProp: string;
+      private _enumProp?: EnumTest;
       private _numberProp?: number;
       private _objectProp?: NestedTest;
       private _additionalProperties?: Map<String, object | string | number | Array<unknown> | boolean | null | number>;
       private _sTestPatternProperties?: Map<String, string>;
-
+    
       constructor(input: {
         stringProp: string,
+        enumProp?: EnumTest,
         numberProp?: number,
         objectProp?: NestedTest,
       }) {
         this._stringProp = input.stringProp;
+        this._enumProp = input.enumProp;
         this._numberProp = input.numberProp;
         this._objectProp = input.objectProp;
       }
-
+    
       get stringProp(): string { return this._stringProp; }
       set stringProp(stringProp: string) { this._stringProp = stringProp; }
-
+    
+      get enumProp(): EnumTest | undefined { return this._enumProp; }
+      set enumProp(enumProp: EnumTest | undefined) { this._enumProp = enumProp; }
+    
       get numberProp(): number | undefined { return this._numberProp; }
       set numberProp(numberProp: number | undefined) { this._numberProp = numberProp; }
-
+    
       get objectProp(): NestedTest | undefined { return this._objectProp; }
       set objectProp(objectProp: NestedTest | undefined) { this._objectProp = objectProp; }
-
+    
       get additionalProperties(): Map<String, object | string | number | Array<unknown> | boolean | null | number> | undefined { return this._additionalProperties; }
       set additionalProperties(additionalProperties: Map<String, object | string | number | Array<unknown> | boolean | null | number> | undefined) { this._additionalProperties = additionalProperties; }
-
+    
       get sTestPatternProperties(): Map<String, string> | undefined { return this._sTestPatternProperties; }
       set sTestPatternProperties(sTestPatternProperties: Map<String, string> | undefined) { this._sTestPatternProperties = sTestPatternProperties; }
-
+    
       public marshal() : string {
         let json = '{'
         if(this.stringProp !== undefined) {
-          json += `\"string prop\": ${typeof this.stringProp === 'number' || typeof this.stringProp === 'boolean' ? this.stringProp : JSON.stringify(this.stringProp)},`; 
+          json += `"string prop": ${typeof this.stringProp === 'number' || typeof this.stringProp === 'boolean' ? this.stringProp : JSON.stringify(this.stringProp)},`; 
+        }
+        if(this.enumProp !== undefined) {
+          json += `"enumProp": ${typeof this.enumProp === 'number' || typeof this.enumProp === 'boolean' ? this.enumProp : JSON.stringify(this.enumProp)},`; 
         }
         if(this.numberProp !== undefined) {
-          json += `\"numberProp\": ${typeof this.numberProp === 'number' || typeof this.numberProp === 'boolean' ? this.numberProp : JSON.stringify(this.numberProp)},`; 
+          json += `"numberProp": ${typeof this.numberProp === 'number' || typeof this.numberProp === 'boolean' ? this.numberProp : JSON.stringify(this.numberProp)},`; 
         }
         if(this.objectProp !== undefined) {
-          json += `\"objectProp\": ${this.objectProp.marshal()},`; 
+          json += `"objectProp": ${this.objectProp.marshal()},`; 
         }
-
         if(this.sTestPatternProperties !== undefined) { 
           for (const [key, value] of this.sTestPatternProperties.entries()) {
             //Only render pattern properties which are not already a property
             if(Object.keys(this).includes(String(key))) continue;
-            json += `\"${key}\": ${typeof value === 'number' || typeof value === 'boolean' ? value : JSON.stringify(value)},`;
+            json += `"${key}": ${typeof value === 'number' || typeof value === 'boolean' ? value : JSON.stringify(value)},`;
           }
         }
-
         if(this.additionalProperties !== undefined) { 
           for (const [key, value] of this.additionalProperties.entries()) {
             //Only render additionalProperties which are not already a property
             if(Object.keys(this).includes(String(key))) continue;
-            json += `\"${key}\": ${typeof value === 'number' || typeof value === 'boolean' ? value : JSON.stringify(value)},`;    
+            json += `"${key}": ${typeof value === 'number' || typeof value === 'boolean' ? value : JSON.stringify(value)},`;    
           }
         }
-
+    
         //Remove potential last comma 
         return `${json.charAt(json.length-1) === ',' ? json.slice(0, json.length-1) : json}}`;
       }
-
+    
       public static unmarshal(json: string | object): Test {
         const obj = typeof json === "object" ? json : JSON.parse(json);
         const instance = new Test({} as any);
-
+    
         if (obj["string prop"] !== undefined) {
           instance.stringProp = obj["string prop"];
         }
-        if (obj.numberProp !== undefined) {
+        if (obj["enumProp"] !== undefined) {
+          instance.enumProp = obj["enumProp"];
+        }
+        if (obj["numberProp"] !== undefined) {
           instance.numberProp = obj["numberProp"];
         }
-        if (obj.objectProp !== undefined) {
+        if (obj["objectProp"] !== undefined) {
           instance.objectProp = NestedTest.unmarshal(obj["objectProp"]);
         }
-
+    
         //Not part of core properties
         if (instance.sTestPatternProperties === undefined) {instance.sTestPatternProperties = new Map();}
         if (instance.additionalProperties === undefined) {instance.additionalProperties = new Map();}
-        for (const [key, value] of Object.entries(obj).filter((([key,]) => {return !["string prop","numberProp","objectProp"].includes(key);}))) {
+        for (const [key, value] of Object.entries(obj).filter((([key,]) => {return !["string prop","enumProp","numberProp","objectProp"].includes(key);}))) {
           //Check all pattern properties
           if (key.match(new RegExp('^S(.?)test'))) {
             instance.sTestPatternProperties.set(key, value as any);
@@ -191,7 +204,7 @@ describe('Marshalling preset', () => {
     const ajv = new Ajv();
     const nestedTestInstance = new NestedTest({stringProp: "SomeTestString"});
     nestedTestInstance.additionalProperties = new Map();
-    const testInstance = new Test({numberProp: 0, stringProp: "SomeTestString", objectProp: nestedTestInstance});
+    const testInstance = new Test({numberProp: 0, stringProp: "SomeTestString", objectProp: nestedTestInstance, enumProp: EnumTest.SOME_ENUM_STRING});
     testInstance.additionalProperties = new Map();
     testInstance.additionalProperties.set('additionalProp', ['Some test value']);
     testInstance.sTestPatternProperties = new Map();
@@ -202,7 +215,7 @@ describe('Marshalling preset', () => {
     const unmarshalInstance = Test.unmarshal(marshalContent);
     const validationResult = ajv.validate(doc, JSON.parse(marshalContent));
 
-    expect(marshalContent).toEqual("{\"string prop\": \"SomeTestString\",\"numberProp\": 0,\"objectProp\": {\"stringProp\": \"SomeTestString\"},\"Stest\": \"Some pattern value\",\"additionalProp\": [\"Some test value\"]}");
+    expect(marshalContent).toEqual("{\"string prop\": \"SomeTestString\",\"enumProp\": \"Some enum String\",\"numberProp\": 0,\"objectProp\": {\"stringProp\": \"SomeTestString\"},\"Stest\": \"Some pattern value\",\"additionalProp\": [\"Some test value\"]}");
     expect(validationResult).toEqual(true);
     expect(unmarshalInstance).toEqual(testInstance);
   });

--- a/test/generators/typescript/preset/__snapshots__/MarshallingPreset.spec.ts.snap
+++ b/test/generators/typescript/preset/__snapshots__/MarshallingPreset.spec.ts.snap
@@ -3,6 +3,7 @@
 exports[`Marshalling preset should render un/marshal code 1`] = `
 "export class Test {
   private _stringProp: string;
+  private _enumProp?: EnumTest;
   private _numberProp?: number;
   private _objectProp?: NestedTest;
   private _additionalProperties?: Map<String, object | string | number | Array<unknown> | boolean | null | number>;
@@ -10,16 +11,21 @@ exports[`Marshalling preset should render un/marshal code 1`] = `
 
   constructor(input: {
     stringProp: string,
+    enumProp?: EnumTest,
     numberProp?: number,
     objectProp?: NestedTest,
   }) {
     this._stringProp = input.stringProp;
+    this._enumProp = input.enumProp;
     this._numberProp = input.numberProp;
     this._objectProp = input.objectProp;
   }
 
   get stringProp(): string { return this._stringProp; }
   set stringProp(stringProp: string) { this._stringProp = stringProp; }
+
+  get enumProp(): EnumTest | undefined { return this._enumProp; }
+  set enumProp(enumProp: EnumTest | undefined) { this._enumProp = enumProp; }
 
   get numberProp(): number | undefined { return this._numberProp; }
   set numberProp(numberProp: number | undefined) { this._numberProp = numberProp; }
@@ -37,6 +43,9 @@ exports[`Marshalling preset should render un/marshal code 1`] = `
     let json = '{'
     if(this.stringProp !== undefined) {
       json += \`\\"string prop\\": \${typeof this.stringProp === 'number' || typeof this.stringProp === 'boolean' ? this.stringProp : JSON.stringify(this.stringProp)},\`; 
+    }
+    if(this.enumProp !== undefined) {
+      json += \`\\"enumProp\\": \${typeof this.enumProp === 'number' || typeof this.enumProp === 'boolean' ? this.enumProp : JSON.stringify(this.enumProp)},\`; 
     }
     if(this.numberProp !== undefined) {
       json += \`\\"numberProp\\": \${typeof this.numberProp === 'number' || typeof this.numberProp === 'boolean' ? this.numberProp : JSON.stringify(this.numberProp)},\`; 
@@ -70,6 +79,9 @@ exports[`Marshalling preset should render un/marshal code 1`] = `
     if (obj[\\"string prop\\"] !== undefined) {
       instance.stringProp = obj[\\"string prop\\"];
     }
+    if (obj[\\"enumProp\\"] !== undefined) {
+      instance.enumProp = obj[\\"enumProp\\"];
+    }
     if (obj[\\"numberProp\\"] !== undefined) {
       instance.numberProp = obj[\\"numberProp\\"];
     }
@@ -80,7 +92,7 @@ exports[`Marshalling preset should render un/marshal code 1`] = `
     //Not part of core properties
     if (instance.sTestPatternProperties === undefined) {instance.sTestPatternProperties = new Map();}
     if (instance.additionalProperties === undefined) {instance.additionalProperties = new Map();}
-    for (const [key, value] of Object.entries(obj).filter((([key,]) => {return ![\\"string prop\\",\\"numberProp\\",\\"objectProp\\"].includes(key);}))) {
+    for (const [key, value] of Object.entries(obj).filter((([key,]) => {return ![\\"string prop\\",\\"enumProp\\",\\"numberProp\\",\\"objectProp\\"].includes(key);}))) {
       //Check all pattern properties
       if (key.match(new RegExp('^S(.?)test'))) {
         instance.sTestPatternProperties.set(key, value as any);

--- a/test/generators/typescript/preset/__snapshots__/MarshallingPreset.spec.ts.snap
+++ b/test/generators/typescript/preset/__snapshots__/MarshallingPreset.spec.ts.snap
@@ -6,8 +6,9 @@ exports[`Marshalling preset should render un/marshal code 1`] = `
   private _enumProp?: EnumTest;
   private _numberProp?: number;
   private _objectProp?: NestedTest;
-  private _additionalProperties?: Map<String, object | string | number | Array<unknown> | boolean | null | number>;
+  private _additionalProperties?: Map<String, NestedTest>;
   private _sTestPatternProperties?: Map<String, string>;
+  private _sAnotherTestPatternProperties?: Map<String, NestedTest>;
 
   constructor(input: {
     stringProp: string,
@@ -33,11 +34,14 @@ exports[`Marshalling preset should render un/marshal code 1`] = `
   get objectProp(): NestedTest | undefined { return this._objectProp; }
   set objectProp(objectProp: NestedTest | undefined) { this._objectProp = objectProp; }
 
-  get additionalProperties(): Map<String, object | string | number | Array<unknown> | boolean | null | number> | undefined { return this._additionalProperties; }
-  set additionalProperties(additionalProperties: Map<String, object | string | number | Array<unknown> | boolean | null | number> | undefined) { this._additionalProperties = additionalProperties; }
+  get additionalProperties(): Map<String, NestedTest> | undefined { return this._additionalProperties; }
+  set additionalProperties(additionalProperties: Map<String, NestedTest> | undefined) { this._additionalProperties = additionalProperties; }
 
   get sTestPatternProperties(): Map<String, string> | undefined { return this._sTestPatternProperties; }
   set sTestPatternProperties(sTestPatternProperties: Map<String, string> | undefined) { this._sTestPatternProperties = sTestPatternProperties; }
+
+  get sAnotherTestPatternProperties(): Map<String, NestedTest> | undefined { return this._sAnotherTestPatternProperties; }
+  set sAnotherTestPatternProperties(sAnotherTestPatternProperties: Map<String, NestedTest> | undefined) { this._sAnotherTestPatternProperties = sAnotherTestPatternProperties; }
 
   public marshal() : string {
     let json = '{'
@@ -59,12 +63,18 @@ exports[`Marshalling preset should render un/marshal code 1`] = `
         if(Object.keys(this).includes(String(key))) continue;
         json += \`\\"\${key}\\": \${typeof value === 'number' || typeof value === 'boolean' ? value : JSON.stringify(value)},\`;
       }
+    }if(this.sAnotherTestPatternProperties !== undefined) { 
+      for (const [key, value] of this.sAnotherTestPatternProperties.entries()) {
+        //Only render pattern properties which are not already a property
+        if(Object.keys(this).includes(String(key))) continue;
+        json += \`\\"\${key}\\": \${value.marshal()},\`;
+      }
     }
     if(this.additionalProperties !== undefined) { 
       for (const [key, value] of this.additionalProperties.entries()) {
         //Only render additionalProperties which are not already a property
         if(Object.keys(this).includes(String(key))) continue;
-        json += \`\\"\${key}\\": \${typeof value === 'number' || typeof value === 'boolean' ? value : JSON.stringify(value)},\`;    
+        json += \`\\"\${key}\\": \${value.marshal()},\`;
       }
     }
 
@@ -91,14 +101,20 @@ exports[`Marshalling preset should render un/marshal code 1`] = `
 
     //Not part of core properties
     if (instance.sTestPatternProperties === undefined) {instance.sTestPatternProperties = new Map();}
+  if (instance.sAnotherTestPatternProperties === undefined) {instance.sAnotherTestPatternProperties = new Map();}
+
     if (instance.additionalProperties === undefined) {instance.additionalProperties = new Map();}
     for (const [key, value] of Object.entries(obj).filter((([key,]) => {return ![\\"string prop\\",\\"enumProp\\",\\"numberProp\\",\\"objectProp\\"].includes(key);}))) {
       //Check all pattern properties
       if (key.match(new RegExp('^S(.?)test'))) {
         instance.sTestPatternProperties.set(key, value as any);
         continue;
+      }//Check all pattern properties
+      if (key.match(new RegExp('^S(.?)AnotherTest'))) {
+        instance.sAnotherTestPatternProperties.set(key, NestedTest.unmarshal(value as any));
+        continue;
       }
-      instance.additionalProperties.set(key, value as any);
+      instance.additionalProperties.set(key, NestedTest.unmarshal(value as any));
     }
     return instance;
   }
@@ -132,7 +148,7 @@ exports[`Marshalling preset should render un/marshal code 2`] = `
       for (const [key, value] of this.additionalProperties.entries()) {
         //Only render additionalProperties which are not already a property
         if(Object.keys(this).includes(String(key))) continue;
-        json += \`\\"\${key}\\": \${typeof value === 'number' || typeof value === 'boolean' ? value : JSON.stringify(value)},\`;    
+        json += \`\\"\${key}\\": \${typeof value === 'number' || typeof value === 'boolean' ? value : JSON.stringify(value)},\`;
       }
     }
 


### PR DESCRIPTION
**Description**
This PR fixes a couple of things: 
1. When enums are referenced, they should be un/marshaled as is, and not through helper functions
2. Ensured that pattern properties and additional properties render the correct un/marshal functionality based on type.