### PR TITLE
fix: run presets should be geared towards string output

### DIFF
--- a/src/generators/AbstractRenderer.ts
+++ b/src/generators/AbstractRenderer.ts
@@ -71,7 +71,7 @@ export abstract class AbstractRenderer<
           model: this.model, 
           inputModel: this.inputModel
         });
-        if (presetRenderedContent === undefined || presetRenderedContent === null) {
+        if (presetRenderedContent === undefined || presetRenderedContent === null || typeof presetRenderedContent !== 'string') {
           content = '';
           continue;
         } 

--- a/src/generators/AbstractRenderer.ts
+++ b/src/generators/AbstractRenderer.ts
@@ -56,10 +56,10 @@ export abstract class AbstractRenderer<
     return this.runPreset('additionalContent');
   }
   
-  async runPreset<RT = string>(
+  async runPreset(
     functionName: string,
     params: Record<string, unknown> = {},
-  ): Promise<RT> {
+  ): Promise<string> {
     let content = '';
     for (const [preset, options] of this.presets) {
       if (typeof preset[String(functionName)] === 'function') {
@@ -71,11 +71,11 @@ export abstract class AbstractRenderer<
           model: this.model, 
           inputModel: this.inputModel
         });
-        if (typeof presetRenderedContent === 'string' && presetRenderedContent !== undefined) {
-          content = presetRenderedContent;
+        if (presetRenderedContent === undefined || presetRenderedContent === null) {
+          content = '';
           continue;
-        }
-        content = '';
+        } 
+        content = presetRenderedContent;
       }
     }
     return content;

--- a/src/generators/AbstractRenderer.ts
+++ b/src/generators/AbstractRenderer.ts
@@ -71,11 +71,11 @@ export abstract class AbstractRenderer<
           model: this.model, 
           inputModel: this.inputModel
         });
-        if (presetRenderedContent === undefined || presetRenderedContent === null || typeof presetRenderedContent !== 'string') {
+        if (typeof presetRenderedContent === 'string') {
+          content = presetRenderedContent;
+        } else {
           content = '';
-          continue;
-        } 
-        content = presetRenderedContent;
+        }
       }
     }
     return content;

--- a/src/generators/AbstractRenderer.ts
+++ b/src/generators/AbstractRenderer.ts
@@ -70,7 +70,7 @@ export abstract class AbstractRenderer<
           options, 
           model: this.model, 
           inputModel: this.inputModel
-        });
+        }) || content;
       }
     }
     return content;

--- a/src/generators/AbstractRenderer.ts
+++ b/src/generators/AbstractRenderer.ts
@@ -60,17 +60,22 @@ export abstract class AbstractRenderer<
     functionName: string,
     params: Record<string, unknown> = {},
   ): Promise<RT> {
-    let content;
+    let content = '';
     for (const [preset, options] of this.presets) {
       if (typeof preset[String(functionName)] === 'function') {
-        content = await preset[String(functionName)]({ 
+        const presetRenderedContent: any = await preset[String(functionName)]({ 
           ...params, 
           renderer: this, 
           content, 
           options, 
           model: this.model, 
           inputModel: this.inputModel
-        }) || content;
+        });
+        if (typeof presetRenderedContent === 'string' && presetRenderedContent !== undefined) {
+          content = presetRenderedContent;
+          continue;
+        }
+        content = '';
       }
     }
     return content;

--- a/test/generators/AbstractRenderer.spec.ts
+++ b/test/generators/AbstractRenderer.spec.ts
@@ -60,11 +60,73 @@ describe('AbstractRenderer', () => {
   });
 
   describe('runSelfPreset()', () => {
+    test('should call correct preset', async () => {
+      const presetCallback = jest.fn();
+      const tempRenderer = new TestRenderer([
+        [{
+          self: presetCallback as never
+        } as never, {} as never] as never
+      ]);
+      await tempRenderer.runSelfPreset();
+      expect(presetCallback).toHaveBeenCalled();
+    });
     test('should not call incorrect preset', async () => {
       const presetCallback = jest.fn();
-      const tempRenderer = new TestRenderer({{self: presetCallback as never} , {}} as never]);
+      
+      const tempRenderer = new TestRenderer([
+        [{
+          none_self: presetCallback as never
+        } as never, {} as never] as never
+      ]);
       await tempRenderer.runSelfPreset();
       expect(presetCallback).not.toHaveBeenCalled();
+    });
+  });
+  describe('runAdditionalContentPreset()', () => {
+    test('should call correct preset', async () => {
+      const presetCallback = jest.fn();
+      const tempRenderer = new TestRenderer([
+        [{
+          additionalContent: presetCallback as never
+        } as never, {} as never] as never
+      ]);
+      await tempRenderer.runAdditionalContentPreset();
+      expect(presetCallback).toHaveBeenCalled();
+    });
+    test('should not call incorrect preset', async () => {
+      const presetCallback = jest.fn();
+      
+      const tempRenderer = new TestRenderer([
+        [{
+          none_additionalContent: presetCallback as never
+        } as never, {} as never] as never
+      ]);
+      await tempRenderer.runAdditionalContentPreset();
+      expect(presetCallback).not.toHaveBeenCalled();
+    });
+  });
+  describe('runPreset()', () => {
+    test('should call correct preset', async () => {
+      const preset1Callback = jest.fn();
+      const preset2Callback = jest.fn();
+      const tempRenderer = new TestRenderer([
+        [{
+          test: preset1Callback.mockReturnValue('value') as never
+        } as never, {} as never] as never,
+        [{
+          test: preset2Callback.mockReturnValue(undefined) as never
+        } as never, {} as never] as never,
+        [{
+          test: preset2Callback.mockReturnValue('') as never
+        } as never, {} as never] as never,
+        [{
+          test: preset2Callback.mockReturnValue(null) as never
+        } as never, {} as never] as never
+      ]);
+      const content = await tempRenderer.runPreset('test');
+      expect(content).toEqual('value');
+      expect(preset1Callback).toHaveBeenCalled();
+      expect(preset2Callback).toHaveBeenCalled();
     });
   });
 });

--- a/test/generators/AbstractRenderer.spec.ts
+++ b/test/generators/AbstractRenderer.spec.ts
@@ -117,6 +117,17 @@ describe('AbstractRenderer', () => {
       expect(content).toEqual('value');
       expect(preset1Callback).toHaveBeenCalled();
     });
+    test('should not render non-string values', async () => {
+      const preset1Callback = jest.fn();
+      const tempRenderer = new TestRenderer([
+        [{
+          test: preset1Callback.mockReturnValue(213) as never
+        } as never, {} as never] as never,
+      ]);
+      const content = await tempRenderer.runPreset('test');
+      expect(content).toEqual('');
+      expect(preset1Callback).toHaveBeenCalled();
+    });
     test('should overwrite previous preset', async () => {
       const preset1Callback = jest.fn();
       const preset2Callback = jest.fn();

--- a/test/generators/AbstractRenderer.spec.ts
+++ b/test/generators/AbstractRenderer.spec.ts
@@ -106,7 +106,34 @@ describe('AbstractRenderer', () => {
     });
   });
   describe('runPreset()', () => {
-    test('should call correct preset', async () => {
+    test('should use string', async () => {
+      const preset1Callback = jest.fn();
+      const tempRenderer = new TestRenderer([
+        [{
+          test: preset1Callback.mockReturnValue('value') as never
+        } as never, {} as never] as never,
+      ]);
+      const content = await tempRenderer.runPreset('test');
+      expect(content).toEqual('value');
+      expect(preset1Callback).toHaveBeenCalled();
+    });
+    test('should overwrite previous preset', async () => {
+      const preset1Callback = jest.fn();
+      const preset2Callback = jest.fn();
+      const tempRenderer = new TestRenderer([
+        [{
+          test: preset1Callback.mockReturnValue('value') as never
+        } as never, {} as never] as never,
+        [{
+          test: preset1Callback.mockReturnValue('value2') as never
+        } as never, {} as never] as never,
+      ]);
+      const content = await tempRenderer.runPreset('test');
+      expect(content).toEqual('value2');
+      expect(preset1Callback).toHaveBeenCalled();
+      expect(preset2Callback).toHaveBeenCalled();
+    });
+    test('should not use previous preset if undefined returned', async () => {
       const preset1Callback = jest.fn();
       const preset2Callback = jest.fn();
       const tempRenderer = new TestRenderer([
@@ -115,16 +142,42 @@ describe('AbstractRenderer', () => {
         } as never, {} as never] as never,
         [{
           test: preset2Callback.mockReturnValue(undefined) as never
-        } as never, {} as never] as never,
+        } as never, {} as never] as never
+      ]);
+      const content = await tempRenderer.runPreset('test');
+      expect(content).toEqual('');
+      expect(preset1Callback).toHaveBeenCalled();
+      expect(preset2Callback).toHaveBeenCalled();
+    });
+    test('should not use previous preset if null returned', async () => {
+      const preset1Callback = jest.fn();
+      const preset2Callback = jest.fn();
+      const tempRenderer = new TestRenderer([
         [{
-          test: preset2Callback.mockReturnValue('') as never
+          test: preset1Callback.mockReturnValue('value') as never
         } as never, {} as never] as never,
         [{
           test: preset2Callback.mockReturnValue(null) as never
         } as never, {} as never] as never
       ]);
       const content = await tempRenderer.runPreset('test');
-      expect(content).toEqual('value');
+      expect(content).toEqual('');
+      expect(preset1Callback).toHaveBeenCalled();
+      expect(preset2Callback).toHaveBeenCalled();
+    });
+    test('should not use previous preset if empty string returned', async () => {
+      const preset1Callback = jest.fn();
+      const preset2Callback = jest.fn();
+      const tempRenderer = new TestRenderer([
+        [{
+          test: preset1Callback.mockReturnValue('value') as never
+        } as never, {} as never] as never,
+        [{
+          test: preset2Callback.mockReturnValue('') as never
+        } as never, {} as never] as never
+      ]);
+      const content = await tempRenderer.runPreset('test');
+      expect(content).toEqual('');
       expect(preset1Callback).toHaveBeenCalled();
       expect(preset2Callback).toHaveBeenCalled();
     });

--- a/test/generators/AbstractRenderer.spec.ts
+++ b/test/generators/AbstractRenderer.spec.ts
@@ -5,8 +5,8 @@ import { testOptions, TestGenerator } from './AbstractGenerator.spec';
 
 describe('AbstractRenderer', () => {
   class TestRenderer extends AbstractRenderer {
-    constructor() {
-      super(testOptions, new TestGenerator(), [], new CommonModel(), new CommonInputModel());
+    constructor(presets = []) {
+      super(testOptions, new TestGenerator(), presets, new CommonModel(), new CommonInputModel());
     }
     render(): Promise<RenderOutput> {
       return Promise.resolve(RenderOutput.toRenderOutput({result: ''}));
@@ -56,6 +56,15 @@ describe('AbstractRenderer', () => {
     test('should render indentation  with options', () => {
       const content = renderer.indent('Test', 4, IndentationTypes.SPACES);
       expect(content).toEqual('    Test');
+    });
+  });
+
+  describe('runSelfPreset()', () => {
+    test('should not call incorrect preset', async () => {
+      const presetCallback = jest.fn();
+      const tempRenderer = new TestRenderer({{self: presetCallback as never} , {}} as never]);
+      await tempRenderer.runSelfPreset();
+      expect(presetCallback).not.toHaveBeenCalled();
     });
   });
 });

--- a/test/generators/AbstractRenderer.spec.ts
+++ b/test/generators/AbstractRenderer.spec.ts
@@ -125,7 +125,7 @@ describe('AbstractRenderer', () => {
           test: preset1Callback.mockReturnValue('value') as never
         } as never, {} as never] as never,
         [{
-          test: preset1Callback.mockReturnValue('value2') as never
+          test: preset2Callback.mockReturnValue('value2') as never
         } as never, {} as never] as never,
       ]);
       const content = await tempRenderer.runPreset('test');
@@ -180,6 +180,11 @@ describe('AbstractRenderer', () => {
       expect(content).toEqual('');
       expect(preset1Callback).toHaveBeenCalled();
       expect(preset2Callback).toHaveBeenCalled();
+    });
+    test('should default to empty string with no presets', async () => {
+      const tempRenderer = new TestRenderer([]);
+      const content = await tempRenderer.runPreset('test');
+      expect(content).toEqual('');
     });
   });
 });


### PR DESCRIPTION
**Description**
This PR changes the default of the preset rendering, to use the latest non-falsey preset content.

**Related issue(s)**
fixes https://github.com/asyncapi/modelina/issues/247