### PR TITLE
fix: typescript should never render duplicate types

### DIFF
--- a/src/generators/typescript/TypeScriptRenderer.ts
+++ b/src/generators/typescript/TypeScriptRenderer.ts
@@ -59,7 +59,7 @@ export abstract class TypeScriptRenderer extends AbstractRenderer<TypeScriptOpti
       return this.nameType(model.$ref);
     }
     if (Array.isArray(model.type)) {
-      return model.type.map(t => this.toTsType(t, model)).join(' | ');
+      return [... new Set(model.type.map(t => this.toTsType(t, model)))].join(' | ');
     }
     return this.toTsType(model.type, model);
   }

--- a/test/generators/typescript/TypeScriptGenerator.spec.ts
+++ b/test/generators/typescript/TypeScriptGenerator.spec.ts
@@ -75,9 +75,9 @@ describe('TypeScriptGenerator', () => {
   private _marriage?: boolean;
   private _members?: string | number | boolean;
   private _tupleType?: [string, number];
-  private _tupleTypeWithAdditionalItems?: [string, number, ...(object | string | number | Array<unknown> | boolean | null | number)[]];
+  private _tupleTypeWithAdditionalItems?: [string, number, ...(object | string | number | Array<unknown> | boolean | null)[]];
   private _arrayType: Array<string>;
-  private _additionalProperties?: Map<String, object | string | number | Array<unknown> | boolean | null | number>;
+  private _additionalProperties?: Map<String, object | string | number | Array<unknown> | boolean | null>;
   private _sTestPatternProperties?: Map<String, string>;
 
   constructor(input: {
@@ -88,7 +88,7 @@ describe('TypeScriptGenerator', () => {
     marriage?: boolean,
     members?: string | number | boolean,
     tupleType?: [string, number],
-    tupleTypeWithAdditionalItems?: [string, number, ...(object | string | number | Array<unknown> | boolean | null | number)[]],
+    tupleTypeWithAdditionalItems?: [string, number, ...(object | string | number | Array<unknown> | boolean | null)[]],
     arrayType: Array<string>,
   }) {
     this._streetName = input.streetName;
@@ -123,14 +123,14 @@ describe('TypeScriptGenerator', () => {
   get tupleType(): [string, number] | undefined { return this._tupleType; }
   set tupleType(tupleType: [string, number] | undefined) { this._tupleType = tupleType; }
 
-  get tupleTypeWithAdditionalItems(): [string, number, ...(object | string | number | Array<unknown> | boolean | null | number)[]] | undefined { return this._tupleTypeWithAdditionalItems; }
-  set tupleTypeWithAdditionalItems(tupleTypeWithAdditionalItems: [string, number, ...(object | string | number | Array<unknown> | boolean | null | number)[]] | undefined) { this._tupleTypeWithAdditionalItems = tupleTypeWithAdditionalItems; }
+  get tupleTypeWithAdditionalItems(): [string, number, ...(object | string | number | Array<unknown> | boolean | null)[]] | undefined { return this._tupleTypeWithAdditionalItems; }
+  set tupleTypeWithAdditionalItems(tupleTypeWithAdditionalItems: [string, number, ...(object | string | number | Array<unknown> | boolean | null)[]] | undefined) { this._tupleTypeWithAdditionalItems = tupleTypeWithAdditionalItems; }
 
   get arrayType(): Array<string> { return this._arrayType; }
   set arrayType(arrayType: Array<string>) { this._arrayType = arrayType; }
 
-  get additionalProperties(): Map<String, object | string | number | Array<unknown> | boolean | null | number> | undefined { return this._additionalProperties; }
-  set additionalProperties(additionalProperties: Map<String, object | string | number | Array<unknown> | boolean | null | number> | undefined) { this._additionalProperties = additionalProperties; }
+  get additionalProperties(): Map<String, object | string | number | Array<unknown> | boolean | null> | undefined { return this._additionalProperties; }
+  set additionalProperties(additionalProperties: Map<String, object | string | number | Array<unknown> | boolean | null> | undefined) { this._additionalProperties = additionalProperties; }
 
   get sTestPatternProperties(): Map<String, string> | undefined { return this._sTestPatternProperties; }
   set sTestPatternProperties(sTestPatternProperties: Map<String, string> | undefined) { this._sTestPatternProperties = sTestPatternProperties; }
@@ -160,7 +160,7 @@ describe('TypeScriptGenerator', () => {
   @JsonProperty("property")
   private _property?: string;
   @JsonProperty("additionalProperties")
-  private _additionalProperties?: Map<String, object | string | number | Array<unknown> | boolean | null | number>;
+  private _additionalProperties?: Map<String, object | string | number | Array<unknown> | boolean | null>;
 
   constructor(input: {
     property?: string,
@@ -171,8 +171,8 @@ describe('TypeScriptGenerator', () => {
   get property(): string | undefined { return this._property; }
   set property(property: string | undefined) { this._property = property; }
 
-  get additionalProperties(): Map<String, object | string | number | Array<unknown> | boolean | null | number> | undefined { return this._additionalProperties; }
-  set additionalProperties(additionalProperties: Map<String, object | string | number | Array<unknown> | boolean | null | number> | undefined) { this._additionalProperties = additionalProperties; }
+  get additionalProperties(): Map<String, object | string | number | Array<unknown> | boolean | null> | undefined { return this._additionalProperties; }
+  set additionalProperties(additionalProperties: Map<String, object | string | number | Array<unknown> | boolean | null> | undefined) { this._additionalProperties = additionalProperties; }
 }`;
 
     generator = new TypeScriptGenerator({ presets: [
@@ -224,9 +224,9 @@ ${content}`;
   marriage?: boolean;
   members?: string | number | boolean;
   tupleType?: [string, number];
-  tupleTypeWithAdditionalItems?: [string, number, ...(object | string | number | Array<unknown> | boolean | null | number)[]];
+  tupleTypeWithAdditionalItems?: [string, number, ...(object | string | number | Array<unknown> | boolean | null)[]];
   arrayType: Array<string>;
-  additionalProperties?: Map<String, object | string | number | Array<unknown> | boolean | null | number>;
+  additionalProperties?: Map<String, object | string | number | Array<unknown> | boolean | null>;
   sTestPatternProperties?: Map<String, string>;
 }`;
 
@@ -249,7 +249,7 @@ ${content}`;
     };
     const expected = `export interface CustomInterface {
   property?: string;
-  additionalProperties?: Map<String, object | string | number | Array<unknown> | boolean | null | number>;
+  additionalProperties?: Map<String, object | string | number | Array<unknown> | boolean | null>;
 }`;
 
     generator = new TypeScriptGenerator({ presets: [

--- a/test/generators/typescript/TypeScriptRenderer.spec.ts
+++ b/test/generators/typescript/TypeScriptRenderer.spec.ts
@@ -41,11 +41,13 @@ describe('TypeScriptRenderer', () => {
   });
 
   describe('toTsType()', () => {
+    test('should not render duplicate types', () => {
+      expect(renderer.toTsType(undefined, new CommonModel())).toEqual('any');
+    });
     test('Should render unknown type', () => {
       expect(renderer.toTsType(undefined, new CommonModel())).toEqual('any');
     });
     test('Should render number type', () => {
-      expect(renderer.toTsType('integer', new CommonModel())).toEqual('number');
       expect(renderer.toTsType('number', new CommonModel())).toEqual('number');
     });
     test('Should render array type', () => {
@@ -87,6 +89,11 @@ describe('TypeScriptRenderer', () => {
       const model = new CommonModel();
       model.enum = ['enum1', 'enum2', 9];
       expect(renderer.renderType(model)).toEqual('"enum1" | "enum2" | 9');
+    });
+    test('should not render duplicate types', () => {
+      const model = new CommonModel();
+      model.type = ['integer', 'number'];
+      expect(renderer.renderType(model)).toEqual('number');
     });
   });
 });

--- a/test/generators/typescript/preset/MarshallingPreset.spec.ts
+++ b/test/generators/typescript/preset/MarshallingPreset.spec.ts
@@ -56,7 +56,7 @@ describe('Marshalling preset', () => {
     }
     class NestedTest {
       private _stringProp?: string;
-      private _additionalProperties?: Map<String, object | string | number | Array<unknown> | boolean | null | number>;
+      private _additionalProperties?: Map<String, object | string | number | Array<unknown> | boolean | null>;
     
       constructor(input: {
         stringProp?: string,
@@ -67,8 +67,8 @@ describe('Marshalling preset', () => {
       get stringProp(): string | undefined { return this._stringProp; }
       set stringProp(stringProp: string | undefined) { this._stringProp = stringProp; }
     
-      get additionalProperties(): Map<String, object | string | number | Array<unknown> | boolean | null | number> | undefined { return this._additionalProperties; }
-      set additionalProperties(additionalProperties: Map<String, object | string | number | Array<unknown> | boolean | null | number> | undefined) { this._additionalProperties = additionalProperties; }
+      get additionalProperties(): Map<String, object | string | number | Array<unknown> | boolean | null> | undefined { return this._additionalProperties; }
+      set additionalProperties(additionalProperties: Map<String, object | string | number | Array<unknown> | boolean | null> | undefined) { this._additionalProperties = additionalProperties; }
     
       public marshal() : string {
         let json = '{'

--- a/test/generators/typescript/preset/__snapshots__/ExamplePreset.spec.ts.snap
+++ b/test/generators/typescript/preset/__snapshots__/ExamplePreset.spec.ts.snap
@@ -5,7 +5,7 @@ exports[`Example function generation should render example function for model 1`
   private _stringProp: string;
   private _numberProp?: number;
   private _objectProp?: NestedTest;
-  private _additionalProperties?: Map<String, object | string | number | Array<unknown> | boolean | null | number>;
+  private _additionalProperties?: Map<String, object | string | number | Array<unknown> | boolean | null>;
   private _sTestPatternProperties?: Map<String, string>;
 
   constructor(input: {
@@ -27,8 +27,8 @@ exports[`Example function generation should render example function for model 1`
   get objectProp(): NestedTest | undefined { return this._objectProp; }
   set objectProp(objectProp: NestedTest | undefined) { this._objectProp = objectProp; }
 
-  get additionalProperties(): Map<String, object | string | number | Array<unknown> | boolean | null | number> | undefined { return this._additionalProperties; }
-  set additionalProperties(additionalProperties: Map<String, object | string | number | Array<unknown> | boolean | null | number> | undefined) { this._additionalProperties = additionalProperties; }
+  get additionalProperties(): Map<String, object | string | number | Array<unknown> | boolean | null> | undefined { return this._additionalProperties; }
+  set additionalProperties(additionalProperties: Map<String, object | string | number | Array<unknown> | boolean | null> | undefined) { this._additionalProperties = additionalProperties; }
 
   get sTestPatternProperties(): Map<String, string> | undefined { return this._sTestPatternProperties; }
   set sTestPatternProperties(sTestPatternProperties: Map<String, string> | undefined) { this._sTestPatternProperties = sTestPatternProperties; }
@@ -46,7 +46,7 @@ exports[`Example function generation should render example function for model 1`
 exports[`Example function generation should render example function for model 2`] = `
 "export class NestedTest {
   private _stringProp?: string;
-  private _additionalProperties?: Map<String, object | string | number | Array<unknown> | boolean | null | number>;
+  private _additionalProperties?: Map<String, object | string | number | Array<unknown> | boolean | null>;
 
   constructor(input: {
     stringProp?: string,
@@ -57,8 +57,8 @@ exports[`Example function generation should render example function for model 2`
   get stringProp(): string | undefined { return this._stringProp; }
   set stringProp(stringProp: string | undefined) { this._stringProp = stringProp; }
 
-  get additionalProperties(): Map<String, object | string | number | Array<unknown> | boolean | null | number> | undefined { return this._additionalProperties; }
-  set additionalProperties(additionalProperties: Map<String, object | string | number | Array<unknown> | boolean | null | number> | undefined) { this._additionalProperties = additionalProperties; }
+  get additionalProperties(): Map<String, object | string | number | Array<unknown> | boolean | null> | undefined { return this._additionalProperties; }
+  set additionalProperties(additionalProperties: Map<String, object | string | number | Array<unknown> | boolean | null> | undefined) { this._additionalProperties = additionalProperties; }
 
   public static example(): NestedTest {
     const instance = new NestedTest({} as any);

--- a/test/generators/typescript/preset/__snapshots__/MarshallingPreset.spec.ts.snap
+++ b/test/generators/typescript/preset/__snapshots__/MarshallingPreset.spec.ts.snap
@@ -124,7 +124,7 @@ exports[`Marshalling preset should render un/marshal code 1`] = `
 exports[`Marshalling preset should render un/marshal code 2`] = `
 "export class NestedTest {
   private _stringProp?: string;
-  private _additionalProperties?: Map<String, object | string | number | Array<unknown> | boolean | null | number>;
+  private _additionalProperties?: Map<String, object | string | number | Array<unknown> | boolean | null>;
 
   constructor(input: {
     stringProp?: string,
@@ -135,8 +135,8 @@ exports[`Marshalling preset should render un/marshal code 2`] = `
   get stringProp(): string | undefined { return this._stringProp; }
   set stringProp(stringProp: string | undefined) { this._stringProp = stringProp; }
 
-  get additionalProperties(): Map<String, object | string | number | Array<unknown> | boolean | null | number> | undefined { return this._additionalProperties; }
-  set additionalProperties(additionalProperties: Map<String, object | string | number | Array<unknown> | boolean | null | number> | undefined) { this._additionalProperties = additionalProperties; }
+  get additionalProperties(): Map<String, object | string | number | Array<unknown> | boolean | null> | undefined { return this._additionalProperties; }
+  set additionalProperties(additionalProperties: Map<String, object | string | number | Array<unknown> | boolean | null> | undefined) { this._additionalProperties = additionalProperties; }
 
   public marshal() : string {
     let json = '{'


### PR DESCRIPTION
**Description**
This PR fixes a problem where duplicate types was rendered for union types.

**Related issue(s)**
fixes https://github.com/asyncapi/modelina/issues/329