### PR TITLE
fix: some reserved keywords are overlooked

### DIFF
--- a/src/generators/csharp/CSharpRenderer.ts
+++ b/src/generators/csharp/CSharpRenderer.ts
@@ -30,7 +30,7 @@ export abstract class CSharpRenderer extends AbstractRenderer<CSharpOptions> {
    */
   nameType(name: string | undefined, model?: CommonModel): string {
     return this.options?.namingConvention?.type 
-      ? this.options.namingConvention.type(name, { model: model || this.model, inputModel: this.inputModel, isReservedKeywordCallback: isReservedCSharpKeyword })
+      ? this.options.namingConvention.type(name, { model: model || this.model, inputModel: this.inputModel, reservedKeywordCallback: isReservedCSharpKeyword })
       : name || '';
   }
 
@@ -42,7 +42,7 @@ export abstract class CSharpRenderer extends AbstractRenderer<CSharpOptions> {
    */
   nameProperty(propertyName: string | undefined, property?: CommonModel): string {
     return this.options?.namingConvention?.property 
-      ? this.options.namingConvention.property(propertyName, { model: this.model, inputModel: this.inputModel, property, isReservedKeywordCallback: isReservedCSharpKeyword })
+      ? this.options.namingConvention.property(propertyName, { model: this.model, inputModel: this.inputModel, property, reservedKeywordCallback: isReservedCSharpKeyword })
       : propertyName || '';
   }
 

--- a/src/generators/csharp/CSharpRenderer.ts
+++ b/src/generators/csharp/CSharpRenderer.ts
@@ -30,7 +30,7 @@ export abstract class CSharpRenderer extends AbstractRenderer<CSharpOptions> {
    */
   nameType(name: string | undefined, model?: CommonModel): string {
     return this.options?.namingConvention?.type 
-      ? this.options.namingConvention.type(name, { model: model || this.model, inputModel: this.inputModel, isReservedKeyword: isReservedCSharpKeyword(`${name}`) })
+      ? this.options.namingConvention.type(name, { model: model || this.model, inputModel: this.inputModel, isReservedKeywordCallback: isReservedCSharpKeyword })
       : name || '';
   }
 
@@ -42,7 +42,7 @@ export abstract class CSharpRenderer extends AbstractRenderer<CSharpOptions> {
    */
   nameProperty(propertyName: string | undefined, property?: CommonModel): string {
     return this.options?.namingConvention?.property 
-      ? this.options.namingConvention.property(propertyName, { model: this.model, inputModel: this.inputModel, property, isReservedKeyword: isReservedCSharpKeyword(`${propertyName}`) })
+      ? this.options.namingConvention.property(propertyName, { model: this.model, inputModel: this.inputModel, property, isReservedKeywordCallback: isReservedCSharpKeyword })
       : propertyName || '';
   }
 

--- a/src/generators/java/JavaRenderer.ts
+++ b/src/generators/java/JavaRenderer.ts
@@ -30,7 +30,7 @@ export abstract class JavaRenderer extends AbstractRenderer<JavaOptions, JavaGen
    */
   nameType(name: string | undefined, model?: CommonModel): string {
     return this.options?.namingConvention?.type 
-      ? this.options.namingConvention.type(name, { model: model || this.model, inputModel: this.inputModel, isReservedKeywordCallback: isReservedJavaKeyword })
+      ? this.options.namingConvention.type(name, { model: model || this.model, inputModel: this.inputModel, reservedKeywordCallback: isReservedJavaKeyword })
       : name || '';
   }
 
@@ -42,7 +42,7 @@ export abstract class JavaRenderer extends AbstractRenderer<JavaOptions, JavaGen
    */
   nameProperty(propertyName: string | undefined, property?: CommonModel): string {
     return this.options?.namingConvention?.property 
-      ? this.options.namingConvention.property(propertyName, { model: this.model, inputModel: this.inputModel, property, isReservedKeywordCallback: isReservedJavaKeyword })
+      ? this.options.namingConvention.property(propertyName, { model: this.model, inputModel: this.inputModel, property, reservedKeywordCallback: isReservedJavaKeyword })
       : propertyName || '';
   }
   

--- a/src/generators/java/JavaRenderer.ts
+++ b/src/generators/java/JavaRenderer.ts
@@ -30,7 +30,7 @@ export abstract class JavaRenderer extends AbstractRenderer<JavaOptions, JavaGen
    */
   nameType(name: string | undefined, model?: CommonModel): string {
     return this.options?.namingConvention?.type 
-      ? this.options.namingConvention.type(name, { model: model || this.model, inputModel: this.inputModel, isReservedKeyword: isReservedJavaKeyword(`${name}`) })
+      ? this.options.namingConvention.type(name, { model: model || this.model, inputModel: this.inputModel, isReservedKeywordCallback: isReservedJavaKeyword })
       : name || '';
   }
 
@@ -42,7 +42,7 @@ export abstract class JavaRenderer extends AbstractRenderer<JavaOptions, JavaGen
    */
   nameProperty(propertyName: string | undefined, property?: CommonModel): string {
     return this.options?.namingConvention?.property 
-      ? this.options.namingConvention.property(propertyName, { model: this.model, inputModel: this.inputModel, property, isReservedKeyword: isReservedJavaKeyword(`${propertyName}`) })
+      ? this.options.namingConvention.property(propertyName, { model: this.model, inputModel: this.inputModel, property, isReservedKeywordCallback: isReservedJavaKeyword })
       : propertyName || '';
   }
   

--- a/src/generators/javascript/JavaScriptRenderer.ts
+++ b/src/generators/javascript/JavaScriptRenderer.ts
@@ -30,7 +30,7 @@ export abstract class JavaScriptRenderer extends AbstractRenderer<JavaScriptOpti
    */
   nameType(name: string | undefined, model?: CommonModel): string {
     return this.options?.namingConvention?.type 
-      ? this.options.namingConvention.type(name, { model: model || this.model, inputModel: this.inputModel, isReservedKeyword: isReservedJavaScriptKeyword(`${name}`) })
+      ? this.options.namingConvention.type(name, { model: model || this.model, inputModel: this.inputModel, isReservedKeywordCallback: isReservedJavaScriptKeyword })
       : name || '';
   }
 
@@ -42,7 +42,7 @@ export abstract class JavaScriptRenderer extends AbstractRenderer<JavaScriptOpti
    */
   nameProperty(propertyName: string | undefined, property?: CommonModel): string {
     return this.options?.namingConvention?.property 
-      ? this.options.namingConvention.property(propertyName, { model: this.model, inputModel: this.inputModel, property, isReservedKeyword: isReservedJavaScriptKeyword(`${propertyName}`) })
+      ? this.options.namingConvention.property(propertyName, { model: this.model, inputModel: this.inputModel, property, isReservedKeywordCallback: isReservedJavaScriptKeyword })
       : propertyName || '';
   }
 

--- a/src/generators/javascript/JavaScriptRenderer.ts
+++ b/src/generators/javascript/JavaScriptRenderer.ts
@@ -30,7 +30,7 @@ export abstract class JavaScriptRenderer extends AbstractRenderer<JavaScriptOpti
    */
   nameType(name: string | undefined, model?: CommonModel): string {
     return this.options?.namingConvention?.type 
-      ? this.options.namingConvention.type(name, { model: model || this.model, inputModel: this.inputModel, isReservedKeywordCallback: isReservedJavaScriptKeyword })
+      ? this.options.namingConvention.type(name, { model: model || this.model, inputModel: this.inputModel, reservedKeywordCallback: isReservedJavaScriptKeyword })
       : name || '';
   }
 
@@ -42,7 +42,7 @@ export abstract class JavaScriptRenderer extends AbstractRenderer<JavaScriptOpti
    */
   nameProperty(propertyName: string | undefined, property?: CommonModel): string {
     return this.options?.namingConvention?.property 
-      ? this.options.namingConvention.property(propertyName, { model: this.model, inputModel: this.inputModel, property, isReservedKeywordCallback: isReservedJavaScriptKeyword })
+      ? this.options.namingConvention.property(propertyName, { model: this.model, inputModel: this.inputModel, property, reservedKeywordCallback: isReservedJavaScriptKeyword })
       : propertyName || '';
   }
 

--- a/src/generators/typescript/TypeScriptRenderer.ts
+++ b/src/generators/typescript/TypeScriptRenderer.ts
@@ -32,7 +32,7 @@ export abstract class TypeScriptRenderer extends AbstractRenderer<TypeScriptOpti
    */
   nameType(name: string | undefined, model?: CommonModel): string {
     return this.options?.namingConvention?.type 
-      ? this.options.namingConvention.type(name, { model: model || this.model, inputModel: this.inputModel, isReservedKeyword: isReservedTypeScriptKeyword(`${name}`)})
+      ? this.options.namingConvention.type(name, { model: model || this.model, inputModel: this.inputModel, isReservedKeywordCallback: isReservedTypeScriptKeyword })
       : name || '';
   }
 
@@ -44,7 +44,7 @@ export abstract class TypeScriptRenderer extends AbstractRenderer<TypeScriptOpti
    */
   nameProperty(propertyName: string | undefined, property?: CommonModel): string {
     return this.options?.namingConvention?.property 
-      ? this.options.namingConvention.property(propertyName, { model: this.model, inputModel: this.inputModel, property, isReservedKeyword: isReservedTypeScriptKeyword(`${propertyName}`) })
+      ? this.options.namingConvention.property(propertyName, { model: this.model, inputModel: this.inputModel, property, isReservedKeywordCallback: isReservedTypeScriptKeyword })
       : propertyName || '';
   }
 

--- a/src/generators/typescript/TypeScriptRenderer.ts
+++ b/src/generators/typescript/TypeScriptRenderer.ts
@@ -32,7 +32,7 @@ export abstract class TypeScriptRenderer extends AbstractRenderer<TypeScriptOpti
    */
   nameType(name: string | undefined, model?: CommonModel): string {
     return this.options?.namingConvention?.type 
-      ? this.options.namingConvention.type(name, { model: model || this.model, inputModel: this.inputModel, isReservedKeywordCallback: isReservedTypeScriptKeyword })
+      ? this.options.namingConvention.type(name, { model: model || this.model, inputModel: this.inputModel, reservedKeywordCallback: isReservedTypeScriptKeyword })
       : name || '';
   }
 
@@ -44,7 +44,7 @@ export abstract class TypeScriptRenderer extends AbstractRenderer<TypeScriptOpti
    */
   nameProperty(propertyName: string | undefined, property?: CommonModel): string {
     return this.options?.namingConvention?.property 
-      ? this.options.namingConvention.property(propertyName, { model: this.model, inputModel: this.inputModel, property, isReservedKeywordCallback: isReservedTypeScriptKeyword })
+      ? this.options.namingConvention.property(propertyName, { model: this.model, inputModel: this.inputModel, property, reservedKeywordCallback: isReservedTypeScriptKeyword })
       : propertyName || '';
   }
 

--- a/src/helpers/NameHelpers.ts
+++ b/src/helpers/NameHelpers.ts
@@ -27,8 +27,8 @@ export function getUniquePropertyName(rootModel: CommonModel, propertyName: stri
 /**
  * The common naming convention context type.
  */
-export type CommonTypeNamingConventionCtx = { model: CommonModel, inputModel: CommonInputModel, isReservedKeywordCallback?: (name: string) => boolean};
-export type CommonPropertyNamingConventionCtx = { model: CommonModel, inputModel: CommonInputModel, property?: CommonModel, isReservedKeywordCallback?: (name: string) => boolean};
+export type CommonTypeNamingConventionCtx = { model: CommonModel, inputModel: CommonInputModel, reservedKeywordCallback?: (name: string) => boolean};
+export type CommonPropertyNamingConventionCtx = { model: CommonModel, inputModel: CommonInputModel, property?: CommonModel, reservedKeywordCallback?: (name: string) => boolean};
 
 /**
  * The common naming convention type shared between generators for different languages.
@@ -45,7 +45,7 @@ export const CommonNamingConventionImplementation: CommonNamingConvention = {
   type: (name, ctx) => {
     if (!name) {return '';}
     let formattedName = FormatHelpers.toPascalCase(name);
-    if (ctx.isReservedKeywordCallback !== undefined && ctx.isReservedKeywordCallback(formattedName)) { 
+    if (ctx.reservedKeywordCallback !== undefined && ctx.reservedKeywordCallback(formattedName)) { 
       formattedName = FormatHelpers.toPascalCase(`reserved_${formattedName}`);
     }
     return formattedName;
@@ -53,7 +53,7 @@ export const CommonNamingConventionImplementation: CommonNamingConvention = {
   property: (name, ctx) => {
     if (!name) {return '';}
     let formattedName = FormatHelpers.toCamelCase(name);
-    if (ctx.isReservedKeywordCallback !== undefined && ctx.isReservedKeywordCallback(formattedName)) { 
+    if (ctx.reservedKeywordCallback !== undefined && ctx.reservedKeywordCallback(formattedName)) { 
       // If name is considered reserved, make sure we rename it appropriately
       // and make sure no clashes occur.
       formattedName = FormatHelpers.toCamelCase(`reserved_${formattedName}`);

--- a/src/helpers/NameHelpers.ts
+++ b/src/helpers/NameHelpers.ts
@@ -27,8 +27,8 @@ export function getUniquePropertyName(rootModel: CommonModel, propertyName: stri
 /**
  * The common naming convention context type.
  */
-export type CommonTypeNamingConventionCtx = { model: CommonModel, inputModel: CommonInputModel, isReservedKeyword?: boolean};
-export type CommonPropertyNamingConventionCtx = { model: CommonModel, inputModel: CommonInputModel, property?: CommonModel, isReservedKeyword?: boolean};
+export type CommonTypeNamingConventionCtx = { model: CommonModel, inputModel: CommonInputModel, isReservedKeywordCallback?: (name: string) => boolean};
+export type CommonPropertyNamingConventionCtx = { model: CommonModel, inputModel: CommonInputModel, property?: CommonModel, isReservedKeywordCallback?: (name: string) => boolean};
 
 /**
  * The common naming convention type shared between generators for different languages.
@@ -44,22 +44,24 @@ export type CommonNamingConvention = {
 export const CommonNamingConventionImplementation: CommonNamingConvention = {
   type: (name, ctx) => {
     if (!name) {return '';}
-    if (ctx.isReservedKeyword) { 
-      name = `reserved_${name}`;
+    let formattedName = FormatHelpers.toPascalCase(name);
+    if (ctx.isReservedKeywordCallback && ctx.isReservedKeywordCallback(formattedName)) { 
+      formattedName = FormatHelpers.toPascalCase(`reserved_${formattedName}`);
     }
-    return FormatHelpers.toPascalCase(name);
+    return formattedName;
   },
   property: (name, ctx) => {
     if (!name) {return '';}
-    if (ctx.isReservedKeyword) { 
+    let formattedName = FormatHelpers.toCamelCase(name);
+    if (ctx.isReservedKeywordCallback && ctx.isReservedKeywordCallback(formattedName)) { 
       // If name is considered reserved, make sure we rename it appropriately
       // and make sure no clashes occur.
-      name = FormatHelpers.toCamelCase(`reserved_${name}`);
-      if (Object.keys(ctx.model.properties || {}).includes(name)) {
+      formattedName = FormatHelpers.toCamelCase(`reserved_${formattedName}`);
+      if (Object.keys(ctx.model.properties || {}).includes(formattedName)) {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        return CommonNamingConventionImplementation.property!(name, ctx);
+        return CommonNamingConventionImplementation.property!(`reserved_${formattedName}`, ctx);
       }
     }
-    return FormatHelpers.toCamelCase(name);
+    return formattedName;
   }
 };

--- a/src/helpers/NameHelpers.ts
+++ b/src/helpers/NameHelpers.ts
@@ -45,7 +45,7 @@ export const CommonNamingConventionImplementation: CommonNamingConvention = {
   type: (name, ctx) => {
     if (!name) {return '';}
     let formattedName = FormatHelpers.toPascalCase(name);
-    if (ctx.isReservedKeywordCallback && ctx.isReservedKeywordCallback(formattedName)) { 
+    if (ctx.isReservedKeywordCallback !== undefined && ctx.isReservedKeywordCallback(formattedName)) { 
       formattedName = FormatHelpers.toPascalCase(`reserved_${formattedName}`);
     }
     return formattedName;
@@ -53,7 +53,7 @@ export const CommonNamingConventionImplementation: CommonNamingConvention = {
   property: (name, ctx) => {
     if (!name) {return '';}
     let formattedName = FormatHelpers.toCamelCase(name);
-    if (ctx.isReservedKeywordCallback && ctx.isReservedKeywordCallback(formattedName)) { 
+    if (ctx.isReservedKeywordCallback !== undefined && ctx.isReservedKeywordCallback(formattedName)) { 
       // If name is considered reserved, make sure we rename it appropriately
       // and make sure no clashes occur.
       formattedName = FormatHelpers.toCamelCase(`reserved_${formattedName}`);

--- a/test/generators/java/JavaRenderer.spec.ts
+++ b/test/generators/java/JavaRenderer.spec.ts
@@ -17,7 +17,7 @@ describe('JavaRenderer', () => {
     });
     test('should render reserved type keyword correctly', () => {
       const name = renderer.nameType('enum');
-      expect(name).toEqual('ReservedEnum');
+      expect(name).toEqual('Enum');
     });
   });
   

--- a/test/generators/javascript/JavaScriptRenderer.spec.ts
+++ b/test/generators/javascript/JavaScriptRenderer.spec.ts
@@ -17,7 +17,7 @@ describe('JavaScriptRenderer', () => {
     });
     test('should render reserved type keyword correctly', () => {
       const name = renderer.nameType('enum');
-      expect(name).toEqual('ReservedEnum');
+      expect(name).toEqual('Enum');
     });
   });
   

--- a/test/generators/typescript/TypeScriptRenderer.spec.ts
+++ b/test/generators/typescript/TypeScriptRenderer.spec.ts
@@ -17,7 +17,7 @@ describe('TypeScriptRenderer', () => {
     });
     test('should render reserved type keyword correctly', () => {
       const name = renderer.nameType('enum');
-      expect(name).toEqual('ReservedEnum');
+      expect(name).toEqual('Enum');
     });
   });
   

--- a/test/helpers/NameHelpers.spec.ts
+++ b/test/helpers/NameHelpers.spec.ts
@@ -21,7 +21,7 @@ describe('NameHelpers', () => {
 
   describe('CommonNamingConventionImplementation', () => {
     const isReservedKeyword = jest.fn().mockReturnValue(false);
-    const defaultCtx = {model: CommonModel.toCommonModel({}), inputModel: new CommonInputModel(), isReservedKeywordCallback: isReservedKeyword};
+    const defaultCtx = {model: CommonModel.toCommonModel({}), inputModel: new CommonInputModel(), reservedKeywordCallback: isReservedKeyword};
     describe('type', () => {
       test('should handle undefined', () => {
         const name = undefined;

--- a/test/helpers/NameHelpers.spec.ts
+++ b/test/helpers/NameHelpers.spec.ts
@@ -20,7 +20,8 @@ describe('NameHelpers', () => {
   });
 
   describe('CommonNamingConventionImplementation', () => {
-    const defaultCtx = {model: CommonModel.toCommonModel({}), inputModel: new CommonInputModel()};
+    const isReservedKeyword = jest.fn().mockReturnValue(false);
+    const defaultCtx = {model: CommonModel.toCommonModel({}), inputModel: new CommonInputModel(), isReservedKeywordCallback: isReservedKeyword};
     describe('type', () => {
       test('should handle undefined', () => {
         const name = undefined;
@@ -43,6 +44,12 @@ describe('NameHelpers', () => {
         const name = 'some_not Pascal string';
         const formattedName = CommonNamingConventionImplementation!.property!(name, defaultCtx);
         expect(formattedName).toEqual('someNotPascalString');
+      });
+      test('Should return accurate reserved property name', () => {
+        const name = '$ref';
+        isReservedKeyword.mockReturnValueOnce(true);
+        const formattedName = CommonNamingConventionImplementation!.property!(name, defaultCtx);
+        expect(formattedName).toEqual('reservedRef');
       });
     });
   });


### PR DESCRIPTION
**Description**
If you have a property name something like `$ref` and `ref` is reserved for that language, the current property naming function would still output `ref` as `$ref` is not transformed until after it is checked.
