### PR TITLE
fix: enum keys cannot have a number as first character

### DIFF
--- a/src/generators/csharp/renderers/EnumRenderer.ts
+++ b/src/generators/csharp/renderers/EnumRenderer.ts
@@ -112,7 +112,9 @@ export const CSHARP_DEFAULT_ENUM_PRESET: EnumPreset<EnumRenderer> = {
       itemName = `Number_${itemName}`;
     } else if (typeof item === 'object') {
       itemName = `${JSON.stringify(item)}`;
-    }
+    } else if (!(/^[a-zA-Z]+$/).test(itemName.charAt(0))) {
+      itemName = `String_${itemName}`;
+    } 
 
     return pascalCase(itemName);
   },

--- a/src/generators/java/renderers/EnumRenderer.ts
+++ b/src/generators/java/renderers/EnumRenderer.ts
@@ -33,19 +33,30 @@ ${this.indent(this.renderBlock(content, 2))}
   }
 
   normalizeKey(value: any): string {
+    let key;
     switch (typeof value) {
     case 'bigint':
     case 'number': {
-      return FormatHelpers.toConstantCase(`number ${value}`);
+      key = `number_${value}`;
+      break;
     }
     case 'boolean': {
-      return FormatHelpers.toConstantCase(`boolean ${value}`);
+      key = `boolean_${value}`;
+      break;
     }
     case 'object': {
-      return FormatHelpers.toConstantCase(JSON.stringify(value));
+      key = JSON.stringify(value);
+      break;
     }
-    default: return FormatHelpers.toConstantCase(String(value));
+    default: {
+      key = String(value);
+      //Ensure no special char can be the beginning letter 
+      if (!(/^[a-zA-Z]+$/).test(key.charAt(0))) {
+        key = `string_${key}`;
+      }
     }
+    }
+    return FormatHelpers.toConstantCase(key);
   }
 
   normalizeValue(value: any): string {

--- a/src/generators/typescript/renderers/EnumRenderer.ts
+++ b/src/generators/typescript/renderers/EnumRenderer.ts
@@ -87,6 +87,6 @@ export const TS_DEFAULT_ENUM_PRESET: EnumPreset<EnumRenderer> = {
   item({ item, renderer }): string {
     const key = renderer.normalizeKey(item);
     const value = renderer.normalizeValue(item);
-    return `${key} = ${value},`;
+    return `"${key}" = ${value},`;
   }
 };

--- a/src/generators/typescript/renderers/EnumRenderer.ts
+++ b/src/generators/typescript/renderers/EnumRenderer.ts
@@ -42,7 +42,7 @@ ${this.indent(this.renderBlock(content, 2))}
     switch (typeof value) {
     case 'bigint':
     case 'number': {
-      key = `number ${value}`;
+      key = `number_${value}`;
       break;
     }
     case 'object': {
@@ -51,6 +51,10 @@ ${this.indent(this.renderBlock(content, 2))}
     }
     default: {
       key = String(value);
+      //Ensure no special char can be the beginning letter 
+      if (!(/^[a-zA-Z]+$/).test(key.charAt(0))) {
+        key = `String_${key}`;
+      }
     }
     }
     return FormatHelpers.toConstantCase(key);
@@ -87,6 +91,6 @@ export const TS_DEFAULT_ENUM_PRESET: EnumPreset<EnumRenderer> = {
   item({ item, renderer }): string {
     const key = renderer.normalizeKey(item);
     const value = renderer.normalizeValue(item);
-    return `"${key}" = ${value},`;
+    return `${key} = ${value},`;
   }
 };

--- a/test/generators/csharp/CSharpGenerator.spec.ts
+++ b/test/generators/csharp/CSharpGenerator.spec.ts
@@ -106,7 +106,7 @@ describe('CSharpGenerator', () => {
       name: 'with enums of mixed types',
       doc: {
         $id: 'Things',
-        enum: ['Texas', 1, false, {test: 'test'}],
+        enum: ['Texas', '1', 1, false, {test: 'test'}],
       }
     },
   ])('should render `enum` type $name', ({doc}) => {

--- a/test/generators/csharp/__snapshots__/CSharpGenerator.spec.ts.snap
+++ b/test/generators/csharp/__snapshots__/CSharpGenerator.spec.ts.snap
@@ -252,7 +252,7 @@ public static class StatesExtensions {
 
 exports[`CSharpGenerator should render \`enum\` type $name should not be empty 3`] = `
 "public enum Things {
-  Texas, Number_1, False, TestTest
+  Texas, String_1, Number_1, False, TestTest
 }
 public static class ThingsExtensions {
   public static dynamic GetValue(this Things enumValue)
@@ -260,6 +260,7 @@ public static class ThingsExtensions {
     switch (enumValue)
     {
       case Things.Texas: return \\"Texas\\";
+      case Things.String_1: return \\"1\\";
       case Things.Number_1: return 1;
       case Things.False: return false;
       case Things.TestTest: return \\"{\\\\\\"test\\\\\\":\\\\\\"test\\\\\\"}\\";
@@ -272,6 +273,7 @@ public static class ThingsExtensions {
     switch (value)
     {
       case \\"Texas\\": return Things.Texas;
+      case \\"1\\": return Things.String_1;
       case 1: return Things.Number_1;
       case false: return Things.False;
       case \\"{\\\\\\"test\\\\\\":\\\\\\"test\\\\\\"}\\": return Things.TestTest;
@@ -285,7 +287,7 @@ public static class ThingsExtensions {
 
 exports[`CSharpGenerator should render \`enum\` type $name should not be empty 4`] = `
 "public enum Things {
-  Texas, Number_1, False, TestTest
+  Texas, String_1, Number_1, False, TestTest
 }
 public static class ThingsExtensions {
   public static dynamic GetValue(this Things enumValue)
@@ -293,6 +295,7 @@ public static class ThingsExtensions {
     switch (enumValue)
     {
       case Things.Texas: return \\"Texas\\";
+      case Things.String_1: return \\"1\\";
       case Things.Number_1: return 1;
       case Things.False: return false;
       case Things.TestTest: return \\"{\\\\\\"test\\\\\\":\\\\\\"test\\\\\\"}\\";
@@ -305,6 +308,7 @@ public static class ThingsExtensions {
     switch (value)
     {
       case \\"Texas\\": return Things.Texas;
+      case \\"1\\": return Things.String_1;
       case 1: return Things.Number_1;
       case false: return Things.False;
       case \\"{\\\\\\"test\\\\\\":\\\\\\"test\\\\\\"}\\": return Things.TestTest;

--- a/test/generators/go/GoGenerator.spec.ts
+++ b/test/generators/go/GoGenerator.spec.ts
@@ -105,7 +105,7 @@ type States string`,
       name: 'with enums of mixed types',
       doc: {
         $id: 'Things',
-        enum: ['Texas', 1, false, {test: 'test'}],
+        enum: ['Texas', 1, '1', false, {test: 'test'}],
       },
       expected: `// Things represents an enum of mixed types.
 type Things interface{}`,

--- a/test/generators/java/JavaGenerator.spec.ts
+++ b/test/generators/java/JavaGenerator.spec.ts
@@ -267,10 +267,10 @@ describe('JavaGenerator', () => {
     const doc = {
       $id: 'Union',
       type: ['string', 'integer', 'boolean'],
-      enum: ['Texas', 'Alabama', 0, 1, true, {test: 'test'}],
+      enum: ['Texas', 'Alabama', 0, 1, '1', true, {test: 'test'}],
     };
     const expected = `public enum Union {
-  TEXAS("Texas"), ALABAMA("Alabama"), NUMBER_0(0), NUMBER_1(1), BOOLEAN_TRUE(true), TEST_TEST("{\\"test\\":\\"test\\"}");
+  TEXAS("Texas"), ALABAMA("Alabama"), NUMBER_0(0), NUMBER_1(1), STRING_1("1"), BOOLEAN_TRUE(true), TEST_TEST("{\\"test\\":\\"test\\"}");
 
   private Object value;
 

--- a/test/generators/typescript/TypeScriptGenerator.spec.ts
+++ b/test/generators/typescript/TypeScriptGenerator.spec.ts
@@ -297,10 +297,11 @@ ${content}`;
   test('should render union `enum` values', async () => {
     const doc = {
       $id: 'States',
-      enum: [2, 'test', true, {test: 'test'}]
+      enum: [2, '2', 'test', true, {test: 'test'}]
     };
     const expected = `export enum States {
   NUMBER_2 = 2,
+  STRING_2 = "2",
   TEST = "test",
   TRUE = "true",
   TEST_TEST = '{"test":"test"}',


### PR DESCRIPTION
**Description**
As the title states, enum keys cannot have a number as the first character. This happens for enums that have the value `"1"` as it is seen as a string (so `Number_1` is not prepended).

If the enum generations encounter such a case it prepends `string_${number}` to the key.
