### PR TITLE
feat: generate Java models to files and full output

### DIFF
--- a/src/generators/java/JavaGenerator.ts
+++ b/src/generators/java/JavaGenerator.ts
@@ -37,34 +37,6 @@ export class JavaGenerator extends AbstractGenerator<JavaOptions> {
     return this.renderClass(model, inputModel);
   }
 
-  /**
-   * Generates all the models to the same output directory. 
-   * 
-   * This function is invasive, as it overwrite any existing files with the same name as the model.
-   * 
-   * @param input
-   * @param outputDirectory where you want the models generated to
-   * @param packageName for the models
-   */
-  public async generateToFile(input: Record<string, unknown> | CommonInputModel, outputDirectory: string, packageName: string): Promise<OutputModel[]> {
-    if (isReservedJavaKeyword(packageName)) {
-      return Promise.reject(`You cannot use reserved java keyword (${packageName}) as package name, please use another.`);
-    }
-
-    const generatedModels = await this.generate(input);
-    for (const outputModel of generatedModels) {
-      const outputFilePath = path.resolve(outputDirectory, `${FormatHelpers.toPascalCase(outputModel.model.$id || 'undefined')}.java`);
-      const modelDependencies = outputModel.model.getNearestDependencies().map((dependencyModel) => { return `import ${packageName}.${FormatHelpers.toPascalCase(dependencyModel || 'undefined')};`;});
-      const outputContent = `package ${packageName};
-${modelDependencies.join('\n')}
-${outputModel.dependencies.join('\n')}
-${outputModel.result}
-`;
-      await FileHelpers.writeToFile(outputContent, outputFilePath);
-    }
-    return Promise.resolve(generatedModels);
-  }
-
   async renderClass(model: CommonModel, inputModel: CommonInputModel): Promise<RenderOutput> {
     const presets = this.getPresets('class');
     const renderer = new ClassRenderer(this.options, this, presets, model, inputModel);
@@ -77,5 +49,51 @@ ${outputModel.result}
     const renderer = new EnumRenderer(this.options, this, presets, model, inputModel);
     const result = await renderer.runSelfPreset();
     return RenderOutput.toRenderOutput({result, dependencies: renderer.dependencies});
+  }
+
+  /**
+   * Generates all the models to an output directory. 
+   * 
+   * This function is invasive, as it overwrite any existing files with the same name as the model.
+   * 
+   * @param input
+   * @param outputDirectory where you want the models generated to
+   * @param packageName for the models
+   */
+  public async generateToFile(input: Record<string, unknown> | CommonInputModel, outputDirectory: string, packageName: string): Promise<OutputModel[]> {
+    const generatedModels = await this.generateFullOutput(input, packageName);
+    for (const outputModel of generatedModels) {
+      const outputFilePath = path.resolve(outputDirectory, `${FormatHelpers.toPascalCase(outputModel.model.$id || 'undefined')}.java`);
+      await FileHelpers.writeToFile(outputModel.result, outputFilePath);
+    }
+    return Promise.resolve(generatedModels);
+  }
+
+  /**
+   * Generates the full output of a model, instead of a scattered model.
+   * 
+   * OutputModels result is no longer the model itself, but including package, package dependencies and model dependencies.
+   * 
+   * @param input 
+   * @param packageName for the models
+   */
+  public async generateFullOutput(input: Record<string, unknown> | CommonInputModel, packageName: string): Promise<OutputModel[]> {
+    if (isReservedJavaKeyword(packageName)) {
+      return Promise.reject(`You cannot use reserved Java keyword (${packageName}) as package name, please use another.`);
+    }
+
+    const fullOutputModels = [];
+    const generatedModels = await this.generate(input);
+    for (const outputModel of generatedModels) {
+      const modelDependencies = outputModel.model.getNearestDependencies().map((dependencyModel) => { return `import ${packageName}.${FormatHelpers.toPascalCase(dependencyModel || 'undefined')};`;});
+      const outputContent = `package ${packageName};
+${modelDependencies.join('\n')}
+${outputModel.dependencies.join('\n')}
+${outputModel.result}
+`; 
+      const newOutputModel = new OutputModel(outputContent, outputModel.model, outputModel.modelName, outputModel.inputModel, outputModel.dependencies);
+      fullOutputModels.push(newOutputModel);
+    }
+    return Promise.resolve(fullOutputModels);
   }
 }

--- a/src/generators/java/JavaGenerator.ts
+++ b/src/generators/java/JavaGenerator.ts
@@ -82,18 +82,14 @@ export class JavaGenerator extends AbstractGenerator<JavaOptions> {
       return Promise.reject(`You cannot use reserved Java keyword (${packageName}) as package name, please use another.`);
     }
 
-    const fullOutputModels = [];
     const generatedModels = await this.generate(input);
-    for (const outputModel of generatedModels) {
+    return Promise.resolve(generatedModels.map((outputModel) => {
       const modelDependencies = outputModel.model.getNearestDependencies().map((dependencyModel) => { return `import ${packageName}.${FormatHelpers.toPascalCase(dependencyModel || 'undefined')};`;});
       const outputContent = `package ${packageName};
 ${modelDependencies.join('\n')}
 ${outputModel.dependencies.join('\n')}
-${outputModel.result}
-`; 
-      const newOutputModel = new OutputModel(outputContent, outputModel.model, outputModel.modelName, outputModel.inputModel, outputModel.dependencies);
-      fullOutputModels.push(newOutputModel);
-    }
-    return Promise.resolve(fullOutputModels);
+${outputModel.result}`; 
+      return new OutputModel(outputContent, outputModel.model, outputModel.modelName, outputModel.inputModel, outputModel.dependencies);
+    }));
   }
 }

--- a/src/generators/java/JavaGenerator.ts
+++ b/src/generators/java/JavaGenerator.ts
@@ -3,11 +3,13 @@ import {
   CommonGeneratorOptions,
   defaultGeneratorOptions,
 } from '../AbstractGenerator';
-import { CommonModel, CommonInputModel, RenderOutput } from '../../models';
-import { CommonNamingConvention, CommonNamingConventionImplementation, ModelKind, TypeHelpers } from '../../helpers';
+import { CommonModel, CommonInputModel, RenderOutput, OutputModel } from '../../models';
+import { CommonNamingConvention, CommonNamingConventionImplementation, ModelKind, TypeHelpers, FileHelpers, FormatHelpers } from '../../helpers';
 import { JavaPreset, JAVA_DEFAULT_PRESET } from './JavaPreset';
 import { ClassRenderer } from './renderers/ClassRenderer';
 import { EnumRenderer } from './renderers/EnumRenderer';
+import * as path from 'path';
+import { isReservedJavaKeyword } from './Constants';
 export interface JavaOptions extends CommonGeneratorOptions<JavaPreset> {
   collectionType?: 'List' | 'Array';
   namingConvention?: CommonNamingConvention;
@@ -33,6 +35,34 @@ export class JavaGenerator extends AbstractGenerator<JavaOptions> {
       return this.renderEnum(model, inputModel);
     }
     return this.renderClass(model, inputModel);
+  }
+
+  /**
+   * Generates all the models to the same output directory. 
+   * 
+   * This function is invasive, as it overwrite any existing files with the same name as the model.
+   * 
+   * @param input
+   * @param outputDirectory where you want the models generated to
+   * @param packageName for the models
+   */
+  public async generateToFile(input: Record<string, unknown> | CommonInputModel, outputDirectory: string, packageName: string): Promise<OutputModel[]> {
+    if (isReservedJavaKeyword(packageName)) {
+      return Promise.reject(`You cannot use reserved java keyword (${packageName}) as package name, please use another.`);
+    }
+
+    const generatedModels = await this.generate(input);
+    for (const outputModel of generatedModels) {
+      const outputFilePath = path.resolve(outputDirectory, `${FormatHelpers.toPascalCase(outputModel.model.$id || 'undefined')}.java`);
+      const modelDependencies = outputModel.model.getNearestDependencies().map((dependencyModel) => { return `import ${packageName}.${FormatHelpers.toPascalCase(dependencyModel || 'undefined')};`;});
+      const outputContent = `package ${packageName};
+${modelDependencies.join('\n')}
+${outputModel.dependencies.join('\n')}
+${outputModel.result}
+`;
+      await FileHelpers.writeToFile(outputContent, outputFilePath);
+    }
+    return Promise.resolve(generatedModels);
   }
 
   async renderClass(model: CommonModel, inputModel: CommonInputModel): Promise<RenderOutput> {

--- a/src/helpers/FileHelpers.ts
+++ b/src/helpers/FileHelpers.ts
@@ -1,0 +1,17 @@
+import {promises as fs} from 'fs';
+import * as path from 'path';
+
+export class FileHelpers {
+  static async writeToFile(content: string, outputFile: string): Promise<void> {
+    const outputFilePath = path.resolve(outputFile);
+    try {
+      // eslint-disable-next-line security/detect-non-literal-fs-filename
+      await fs.mkdir(path.dirname(outputFilePath), { recursive: true });
+      // eslint-disable-next-line security/detect-non-literal-fs-filename
+      await fs.writeFile(outputFilePath, content);
+    } catch (e: any) {
+      return Promise.reject(e);
+    }
+    return Promise.resolve();
+  }
+}

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,3 +1,4 @@
 export * from './FormatHelpers';
 export * from './TypeHelpers';
 export * from './NameHelpers';
+export * from './FileHelpers';

--- a/test/blackbox/Dummy.spec.ts
+++ b/test/blackbox/Dummy.spec.ts
@@ -2,16 +2,18 @@ import * as path from 'path';
 import { TypeScriptGenerator, JavaGenerator, JavaScriptGenerator, GoGenerator, CSharpGenerator, TS_COMMON_PRESET } from '../../src';
 import { execCommand, generateModels, renderModels, renderModelsToSeparateFiles } from './utils/Utils';
 const fileToGenerate = path.resolve(__dirname, './docs/dummy.json');
+import {promises as fs} from 'fs';
 describe('Dummy JSON Schema file', () => {
   jest.setTimeout(100000);
   describe('should be able to generate and compile Java', () => {
     test('class', async () => {
       const generator = new JavaGenerator();
-      const generatedModels = await generateModels(fileToGenerate, generator);
-      expect(generatedModels).not.toHaveLength(0);
+      const inputFileContent = await fs.readFile(fileToGenerate);
+      const input = JSON.parse(String(inputFileContent));
       const renderOutputPath = path.resolve(__dirname, './output/java/class');
+      const generatedModels = await generator.generateToFile(input, renderOutputPath, 'somepackage');
+      expect(generatedModels).not.toHaveLength(0);
       const dependencyPath = path.resolve(__dirname, './dependencies/java/*');
-      await renderModelsToSeparateFiles(generatedModels, renderOutputPath, 'java');
       const compileCommand = `javac  -cp ${dependencyPath} ${path.resolve(renderOutputPath, '*.java')}`;
       await execCommand(compileCommand);
     });

--- a/test/generators/java/JavaGenerator.spec.ts
+++ b/test/generators/java/JavaGenerator.spec.ts
@@ -1,4 +1,4 @@
-import { FileHelpers } from '../../../src';
+import { CommonInputModel, CommonModel, FileHelpers, OutputModel } from '../../../src';
 import { JavaGenerator } from '../../../src/generators'; 
 
 describe('JavaGenerator', () => {
@@ -419,22 +419,52 @@ public enum CustomEnum {
     };
     test('should throw accurate error if file cannot be written', async () => {
       generator = new JavaGenerator();
-      const error = new Error('write error');
-      jest.spyOn(FileHelpers, 'writeToFile').mockRejectedValue(error);
-      await expect(generator.generateToFile(doc, '/test/', 'SomePackage')).rejects.toEqual(error);
+      const expectedError = new Error('write error');
+      jest.spyOn(FileHelpers, 'writeToFile').mockRejectedValue(expectedError);
+      jest.spyOn(generator, 'generateFullOutput').mockResolvedValue([new OutputModel('content', new CommonModel(), '', new CommonInputModel(), [])]);
+      await expect(generator.generateToFile(doc, '/test/', 'SomePackage')).rejects.toEqual(expectedError);
+      expect(generator.generateFullOutput).toHaveBeenCalledTimes(1);
       expect(FileHelpers.writeToFile).toHaveBeenCalledTimes(1);
     });
-    test('should be able to use reserved keywords as package name', async () => {
+    test('should try and generate models to files', async () => {
       generator = new JavaGenerator();
-      await expect(generator.generateToFile(doc, '/test/', 'package')).rejects.toEqual('You cannot use reserved java keyword (package) as package name, please use another.');
+      jest.spyOn(FileHelpers, 'writeToFile').mockResolvedValue(undefined);
+      jest.spyOn(generator, 'generateFullOutput').mockResolvedValue([new OutputModel('content', new CommonModel(), '', new CommonInputModel(), [])]);
+      await generator.generateToFile(doc, '/test/', 'SomePackage');
+      expect(generator.generateFullOutput).toHaveBeenCalledTimes(1);
+      expect(FileHelpers.writeToFile).toHaveBeenCalledTimes(1);
+      expect((FileHelpers.writeToFile as jest.Mock).mock.calls[0]).toEqual([
+        'content',
+        '/test/Undefined.java',
+      ]);
+    });
+  });
+
+  describe('generateFullOutput()', () => {
+    const doc = {
+      $id: 'CustomClass',
+      type: 'object',
+      additionalProperties: true,
+      properties: {
+        someProp: { type: 'string' },
+        someEnum: {
+          $id: 'CustomEnum',
+          type: 'string',
+          enum: ['Texas', 'Alabama', 'California'],
+        }
+      }
+    };
+    test('should not be able to use reserved keywords as package name', async () => {
+      generator = new JavaGenerator();
+      await expect(generator.generateFullOutput(doc, 'package')).rejects.toEqual('You cannot use reserved Java keyword (package) as package name, please use another.');
     });
     test('should generate models to files', async () => {
       generator = new JavaGenerator();
       jest.spyOn(FileHelpers, 'writeToFile').mockResolvedValue(undefined);
-      await generator.generateToFile(doc, '/test/', 'SomePackage');
-      expect(FileHelpers.writeToFile).toHaveBeenCalledTimes(2);
-      expect((FileHelpers.writeToFile as jest.Mock).mock.calls[0]).toMatchSnapshot();
-      expect((FileHelpers.writeToFile as jest.Mock).mock.calls[1]).toMatchSnapshot();
+      const output = await generator.generateFullOutput(doc, 'SomePackage');
+      expect(output).toHaveLength(2);
+      expect(output[0].result).toMatchSnapshot();
+      expect(output[1].result).toMatchSnapshot();
     });
   });
 });

--- a/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
+++ b/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
@@ -1,8 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`JavaGenerator generateToFile() should generate models to files 1`] = `
-Array [
-  "package SomePackage;
+exports[`JavaGenerator generateFullOutput() should generate models to files 1`] = `
+"package SomePackage;
 import SomePackage.CustomEnum;
 import java.util.Map;
 public class CustomClass {
@@ -19,14 +18,11 @@ public class CustomClass {
   public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
   public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
 }
-",
-  "/test/CustomClass.java",
-]
+"
 `;
 
-exports[`JavaGenerator generateToFile() should generate models to files 2`] = `
-Array [
-  "package SomePackage;
+exports[`JavaGenerator generateFullOutput() should generate models to files 2`] = `
+"package SomePackage;
 
 import com.fasterxml.jackson.annotation.*;
 public enum CustomEnum {
@@ -58,7 +54,5 @@ public enum CustomEnum {
     throw new IllegalArgumentException(\\"Unexpected value '\\" + value + \\"'\\");
   }
 }
-",
-  "/test/CustomEnum.java",
-]
+"
 `;

--- a/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
+++ b/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
@@ -17,8 +17,7 @@ public class CustomClass {
 
   public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
   public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
-}
-"
+}"
 `;
 
 exports[`JavaGenerator generateFullOutput() should generate models to files 2`] = `
@@ -53,6 +52,5 @@ public enum CustomEnum {
     }
     throw new IllegalArgumentException(\\"Unexpected value '\\" + value + \\"'\\");
   }
-}
-"
+}"
 `;

--- a/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
+++ b/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
@@ -1,0 +1,64 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`JavaGenerator generateToFile() should generate models to files 1`] = `
+Array [
+  "package SomePackage;
+import SomePackage.CustomEnum;
+import java.util.Map;
+public class CustomClass {
+  private String someProp;
+  private CustomEnum someEnum;
+  private Map<String, Object> additionalProperties;
+
+  public String getSomeProp() { return this.someProp; }
+  public void setSomeProp(String someProp) { this.someProp = someProp; }
+
+  public CustomEnum getSomeEnum() { return this.someEnum; }
+  public void setSomeEnum(CustomEnum someEnum) { this.someEnum = someEnum; }
+
+  public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
+  public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
+}
+",
+  "/test/CustomClass.java",
+]
+`;
+
+exports[`JavaGenerator generateToFile() should generate models to files 2`] = `
+Array [
+  "package SomePackage;
+
+import com.fasterxml.jackson.annotation.*;
+public enum CustomEnum {
+  TEXAS(\\"Texas\\"), ALABAMA(\\"Alabama\\"), CALIFORNIA(\\"California\\");
+
+  private String value;
+
+  CustomEnum(String value) {
+    this.value = value;
+  }
+    
+  @JsonValue
+  public String getValue() {
+    return value;
+  }
+
+  @Override
+  public String toString() {
+    return String.valueOf(value);
+  }
+
+  @JsonCreator
+  public static CustomEnum fromValue(String value) {
+    for (CustomEnum e : CustomEnum.values()) {
+      if (e.value.equals(value)) {
+        return e;
+      }
+    }
+    throw new IllegalArgumentException(\\"Unexpected value '\\" + value + \\"'\\");
+  }
+}
+",
+  "/test/CustomEnum.java",
+]
+`;

--- a/test/helpers/FileHelpers.spec.ts
+++ b/test/helpers/FileHelpers.spec.ts
@@ -1,0 +1,24 @@
+import {promises as fs} from 'fs';
+import { FileHelpers } from '../../src/helpers';
+describe('FileHelpers', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+  describe('writeToFile', () => {
+    test('should write file content to correct location', async () => { 
+      jest.spyOn(fs, 'mkdir').mockResolvedValue(undefined);
+      jest.spyOn(fs, 'writeFile').mockResolvedValue(undefined);
+      await FileHelpers.writeToFile('content', '/test/output.ts');
+      expect(fs.mkdir).toHaveBeenNthCalledWith(1, '/test', { recursive: true });
+      expect(fs.writeFile).toHaveBeenNthCalledWith(1, '/test/output.ts', 'content');
+    });
+    test('should handle rejected promises', async () => { 
+      const error = new Error('Test error');
+      jest.spyOn(fs, 'mkdir').mockRejectedValue(error);
+      jest.spyOn(fs, 'writeFile').mockResolvedValue(undefined);
+      await expect(FileHelpers.writeToFile('content', '/test/output.ts')).rejects.toEqual(error);
+      expect(fs.mkdir).toHaveBeenNthCalledWith(1, '/test', { recursive: true });
+      expect(fs.writeFile).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
**Description**
This PR enables the user to generate Java models directly to files as well as full output.
 
**Related issue(s)**
Partly solves #288 
Fixes https://github.com/asyncapi/modelina/issues/396