### PR TITLE
fix: wrong property name in JavaCommonPresetOptions interface (#544)

### DIFF
--- a/src/generators/java/presets/CommonPreset.ts
+++ b/src/generators/java/presets/CommonPreset.ts
@@ -6,7 +6,7 @@ import { CommonModel } from '../../../models';
 
 export interface JavaCommonPresetOptions {
   equal: boolean;
-  hash: boolean;
+  hashCode: boolean;
   classToString: boolean;
 }
 

--- a/test/generators/java/presets/CommonPreset.spec.ts
+++ b/test/generators/java/presets/CommonPreset.spec.ts
@@ -29,27 +29,6 @@ describe('JAVA_COMMON_PRESET', () => {
     const classModel = await generator.renderClass(model, inputModel);
     expect(classModel.result).toMatchSnapshot();
   });
-  test('should not render any functions when all 3 options are disabled', async () => {
-    const options: JavaCommonPresetOptions = {
-      equal: false,
-      hashCode: false,
-      classToString: false,
-    };
-
-    const generator = new JavaGenerator(
-      {
-        presets: [{
-          preset: JAVA_COMMON_PRESET,
-          options
-        }]
-      }
-    );
-    const inputModel = await generator.process(doc);
-    const model = inputModel.models['Clazz'];
-
-    const classModel = await generator.renderClass(model, inputModel);
-    expect(classModel.result).toMatchSnapshot();
-  });
   describe('with option', () => {
     test('should render all functions', async () => {
       const generator = new JavaGenerator(
@@ -70,6 +49,27 @@ describe('JAVA_COMMON_PRESET', () => {
       const classModel = await generator.renderClass(model, inputModel);
       expect(classModel.result).toMatchSnapshot();
       expect(classModel.dependencies.includes('import java.util.Objects;')).toEqual(true);
+    });
+    test('should not render any functions when all 3 options are disabled', async () => {
+      const options: JavaCommonPresetOptions = {
+        equal: false,
+        hashCode: false,
+        classToString: false,
+      };
+
+      const generator = new JavaGenerator(
+        {
+          presets: [{
+            preset: JAVA_COMMON_PRESET,
+            options
+          }]
+        }
+      );
+      const inputModel = await generator.process(doc);
+      const model = inputModel.models['Clazz'];
+
+      const classModel = await generator.renderClass(model, inputModel);
+      expect(classModel.result).toMatchSnapshot();
     });
     test('should render equals', async () => {
       const generator = new JavaGenerator(

--- a/test/generators/java/presets/CommonPreset.spec.ts
+++ b/test/generators/java/presets/CommonPreset.spec.ts
@@ -1,4 +1,4 @@
-import { JavaGenerator, JAVA_COMMON_PRESET } from '../../../../src/generators'; 
+import {JavaGenerator, JAVA_COMMON_PRESET, JavaCommonPresetOptions} from '../../../../src/generators';
 
 describe('JAVA_COMMON_PRESET', () => {
   const doc = {
@@ -24,6 +24,27 @@ describe('JAVA_COMMON_PRESET', () => {
   test('should render accurately when there is no additional properties', async () => {
     const generator = new JavaGenerator({ presets: [JAVA_COMMON_PRESET] });
     const inputModel = await generator.process({...doc, additionalProperties: false});
+    const model = inputModel.models['Clazz'];
+
+    const classModel = await generator.renderClass(model, inputModel);
+    expect(classModel.result).toMatchSnapshot();
+  });
+  test('should not render any functions when all 3 options are disabled', async () => {
+    const options: JavaCommonPresetOptions = {
+      equal: false,
+      hashCode: false,
+      classToString: false,
+    };
+
+    const generator = new JavaGenerator(
+      {
+        presets: [{
+          preset: JAVA_COMMON_PRESET,
+          options
+        }]
+      }
+    );
+    const inputModel = await generator.process(doc);
     const model = inputModel.models['Clazz'];
 
     const classModel = await generator.renderClass(model, inputModel);

--- a/test/generators/java/presets/__snapshots__/CommonPreset.spec.ts.snap
+++ b/test/generators/java/presets/__snapshots__/CommonPreset.spec.ts.snap
@@ -144,6 +144,35 @@ exports[`JAVA_COMMON_PRESET should render common function in class by common pre
 }"
 `;
 
+exports[`JAVA_COMMON_PRESET should not render any functions when all 3 options are disabled 1`] = `
+"public class Clazz {
+  private Boolean requiredProp;
+  private String stringProp;
+  private Double numberProp;
+  private Boolean booleanProp;
+  private String[] arrayProp;
+  private Map<String, Object> additionalProperties;
+
+  public Boolean getRequiredProp() { return this.requiredProp; }
+  public void setRequiredProp(Boolean requiredProp) { this.requiredProp = requiredProp; }
+
+  public String getStringProp() { return this.stringProp; }
+  public void setStringProp(String stringProp) { this.stringProp = stringProp; }
+
+  public Double getNumberProp() { return this.numberProp; }
+  public void setNumberProp(Double numberProp) { this.numberProp = numberProp; }
+
+  public Boolean getBooleanProp() { return this.booleanProp; }
+  public void setBooleanProp(Boolean booleanProp) { this.booleanProp = booleanProp; }
+
+  public String[] getArrayProp() { return this.arrayProp; }
+  public void setArrayProp(String[] arrayProp) { this.arrayProp = arrayProp; }
+
+  public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
+  public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
+}"
+`;
+
 exports[`JAVA_COMMON_PRESET with option should render all functions 1`] = `
 "public class Clazz {
   private Boolean requiredProp;

--- a/test/generators/java/presets/__snapshots__/CommonPreset.spec.ts.snap
+++ b/test/generators/java/presets/__snapshots__/CommonPreset.spec.ts.snap
@@ -144,35 +144,6 @@ exports[`JAVA_COMMON_PRESET should render common function in class by common pre
 }"
 `;
 
-exports[`JAVA_COMMON_PRESET should not render any functions when all 3 options are disabled 1`] = `
-"public class Clazz {
-  private Boolean requiredProp;
-  private String stringProp;
-  private Double numberProp;
-  private Boolean booleanProp;
-  private String[] arrayProp;
-  private Map<String, Object> additionalProperties;
-
-  public Boolean getRequiredProp() { return this.requiredProp; }
-  public void setRequiredProp(Boolean requiredProp) { this.requiredProp = requiredProp; }
-
-  public String getStringProp() { return this.stringProp; }
-  public void setStringProp(String stringProp) { this.stringProp = stringProp; }
-
-  public Double getNumberProp() { return this.numberProp; }
-  public void setNumberProp(Double numberProp) { this.numberProp = numberProp; }
-
-  public Boolean getBooleanProp() { return this.booleanProp; }
-  public void setBooleanProp(Boolean booleanProp) { this.booleanProp = booleanProp; }
-
-  public String[] getArrayProp() { return this.arrayProp; }
-  public void setArrayProp(String[] arrayProp) { this.arrayProp = arrayProp; }
-
-  public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
-  public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
-}"
-`;
-
 exports[`JAVA_COMMON_PRESET with option should render all functions 1`] = `
 "public class Clazz {
   private Boolean requiredProp;
@@ -245,6 +216,36 @@ exports[`JAVA_COMMON_PRESET with option should render all functions 1`] = `
     }
     return o.toString().replace(\\"\\\\n\\", \\"\\\\n    \\");
   }
+}"
+`;
+
+
+exports[`JAVA_COMMON_PRESET with option should not render any functions when all 3 options are disabled 1`] = `
+"public class Clazz {
+  private Boolean requiredProp;
+  private String stringProp;
+  private Double numberProp;
+  private Boolean booleanProp;
+  private String[] arrayProp;
+  private Map<String, Object> additionalProperties;
+
+  public Boolean getRequiredProp() { return this.requiredProp; }
+  public void setRequiredProp(Boolean requiredProp) { this.requiredProp = requiredProp; }
+
+  public String getStringProp() { return this.stringProp; }
+  public void setStringProp(String stringProp) { this.stringProp = stringProp; }
+
+  public Double getNumberProp() { return this.numberProp; }
+  public void setNumberProp(Double numberProp) { this.numberProp = numberProp; }
+
+  public Boolean getBooleanProp() { return this.booleanProp; }
+  public void setBooleanProp(Boolean booleanProp) { this.booleanProp = booleanProp; }
+
+  public String[] getArrayProp() { return this.arrayProp; }
+  public void setArrayProp(String[] arrayProp) { this.arrayProp = arrayProp; }
+
+  public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
+  public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
 }"
 `;
 


### PR DESCRIPTION
**Description**
Changed wrong `hash` property in `JavaCommonPresetOptions` to `hashCode` as that the value that is actually used.

**Related issue(s)**
Fixes #544 