### PR TITLE
fix: correctly store already converted schemas while parsing AsyncApi schema (#548)

### DIFF
--- a/src/processors/AsyncAPIInputProcessor.ts
+++ b/src/processors/AsyncAPIInputProcessor.ts
@@ -55,10 +55,10 @@ export class AsyncAPIInputProcessor extends AbstractInputProcessor {
     if (alreadyIteratedSchemas.has(schemaUid)) {
       return alreadyIteratedSchemas.get(schemaUid) as AsyncapiV2Schema; 
     }
-    let convertedSchema = new AsyncapiV2Schema();
-    alreadyIteratedSchemas.set(schemaUid, convertedSchema);
-    convertedSchema = Object.assign({}, schema.json());
+
+    const convertedSchema = Object.assign(new AsyncapiV2Schema(), schema.json());
     convertedSchema[this.MODELGEN_INFFERED_NAME] = schemaUid;
+    alreadyIteratedSchemas.set(schemaUid, convertedSchema);
 
     if (schema.allOf() !== null) {
       convertedSchema.allOf = schema.allOf().map((item) => this.convertToInternalSchema(item, alreadyIteratedSchemas));

--- a/test/processors/AsyncAPIInputProcessor.spec.ts
+++ b/test/processors/AsyncAPIInputProcessor.spec.ts
@@ -130,5 +130,14 @@ describe('AsyncAPIInputProcessor', () => {
       expect(expected.anyOf[1]['x-modelgen-inferred-name']).toEqual('<anonymous-schema-17>');
       expect(expected.anyOf[1].properties.prop['x-modelgen-inferred-name']).toEqual('<anonymous-schema-18>');
     });
+    test('should correctly convert when schema has more than one properties referencing one other schema', async () => {
+      const basicDocString = fs.readFileSync(path.resolve(__dirname, './AsyncAPIInputProcessor/schema_with_2_properties_referencing_one_schema.json'), 'utf8');
+      const doc = await parse(basicDocString, {} as ParserOptions);
+      const schema = doc.channels()['/user/signedup'].subscribe().message().payload();
+      const result = AsyncAPIInputProcessor.convertToInternalSchema(schema) as any;
+
+      expect(result.properties['lastName']).not.toEqual({});
+      expect(result.properties['firstName']).toEqual(result.properties['lastName']);
+    });
   });
 });

--- a/test/processors/AsyncAPIInputProcessor/schema_with_2_properties_referencing_one_schema.json
+++ b/test/processors/AsyncAPIInputProcessor/schema_with_2_properties_referencing_one_schema.json
@@ -1,0 +1,49 @@
+{
+  "asyncapi": "2.2.0",
+  "info": {
+    "title": "Account Service",
+    "version": "1.0.0",
+    "description": "This service is in charge of processing user signups"
+  },
+  "channels": {
+    "/user/signedup": {
+      "subscribe": {
+        "message": {
+          "$ref": "#/components/messages/UserSignedUp"
+        }
+      }
+    }
+  },
+  "components": {
+    "messages": {
+      "UserSignedUp": {
+        "payload": {
+          "type": "object",
+          "properties": {
+            "firstName": {
+              "$ref": "#/components/schemas/PersonName"
+            },
+            "lastName": {
+              "$ref": "#/components/schemas/PersonName"
+            },
+            "email": {
+              "type": "string",
+              "format": "email",
+              "description": "Email of the user"
+            }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "PersonName": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
**Description**
Simple change - correctly save converted schemas in `alreadyIteratedSchemas`

**Related issue(s)**
Fixes #548 