### PR TITLE
fix: special cases in enum values for C# generator

### DIFF
--- a/src/generators/csharp/renderers/EnumRenderer.ts
+++ b/src/generators/csharp/renderers/EnumRenderer.ts
@@ -1,6 +1,7 @@
 import { CSharpRenderer } from '../CSharpRenderer';
 import { EnumPreset } from '../../../models';
 import { pascalCase } from 'change-case';
+import { FormatHelpers } from '../../../helpers';
 
 /**
  * Renderer for C#'s `enum` type
@@ -107,7 +108,7 @@ export const CSHARP_DEFAULT_ENUM_PRESET: EnumPreset<EnumRenderer> = {
     return renderer.defaultSelf();
   },
   item({ item }) {
-    let itemName = String(item);
+    let itemName = FormatHelpers.replaceSpecialCharacters(String(item), { exclude: [' '], separator: '_' });
     if (typeof item === 'number' || typeof item === 'bigint') {
       itemName = `Number_${itemName}`;
     } else if (typeof item === 'object') {

--- a/test/generators/csharp/CSharpGenerator.spec.ts
+++ b/test/generators/csharp/CSharpGenerator.spec.ts
@@ -129,16 +129,6 @@ describe('CSharpGenerator', () => {
       enum: ['Texas', 'Alabama', 'California'],
     };
 
-    generator = new CSharpGenerator({ presets: [
-      {
-        enum: {
-          self({ content }) {
-            return content;
-          },
-        }
-      }
-    ] });
-
     const inputModel = await generator.process(doc);
     const model = inputModel.models['CustomEnum'];
     

--- a/test/generators/csharp/CSharpGenerator.spec.ts
+++ b/test/generators/csharp/CSharpGenerator.spec.ts
@@ -150,6 +150,36 @@ describe('CSharpGenerator', () => {
     expect(enumModel.result).toMatchSnapshot();
     expect(enumModel.dependencies).toEqual([]);
   });
+
+  test('should render enums with translated special characters', async () => {
+    const doc = {
+      $id: 'States',
+      type: 'string',
+      enum: ['test+', 'test', 'test-', 'test?!', '*test']
+    };
+    
+    generator = new CSharpGenerator({ presets: [
+      {
+        enum: {
+          self({ content }) {
+            return content;
+          },
+        }
+      }
+    ]});
+
+    const inputModel = await generator.process(doc);
+    const model = inputModel.models['States'];
+
+    let enumModel = await generator.render(model, inputModel);
+    expect(enumModel.result).toMatchSnapshot();
+    expect(enumModel.dependencies).toEqual([]);
+
+    enumModel = await generator.renderEnum(model, inputModel);
+    expect(enumModel.result).toMatchSnapshot();
+    expect(enumModel.dependencies).toEqual([]);
+  });
+
   test('should render models and their dependencies', async () => {
     const doc = {
       $id: 'Address',
@@ -177,6 +207,7 @@ describe('CSharpGenerator', () => {
     expect(models[0].result).toMatchSnapshot();
     expect(models[1].result).toMatchSnapshot();
   });
+
   test('should throw error when reserved keyword is used for package name', async () => {
     const doc = {
       $id: 'Address',

--- a/test/generators/csharp/__snapshots__/CSharpGenerator.spec.ts.snap
+++ b/test/generators/csharp/__snapshots__/CSharpGenerator.spec.ts.snap
@@ -320,6 +320,76 @@ public static class StatesExtensions {
 "
 `;
 
+exports[`CSharpGenerator should render enums with translated special characters 1`] = `
+"public enum States {
+  TestPlus, Test, TestMinus, TestQuestionExclamation, AsteriskTest
+}
+public static class StatesExtensions {
+  public static dynamic GetValue(this States enumValue)
+  {
+    switch (enumValue)
+    {
+      case States.TestPlus: return \\"test+\\";
+      case States.Test: return \\"test\\";
+      case States.TestMinus: return \\"test-\\";
+      case States.TestQuestionExclamation: return \\"test?!\\";
+      case States.AsteriskTest: return \\"*test\\";
+    }
+    return null;
+  }
+
+  public static States? ToStates(dynamic value)
+  {
+    switch (value)
+    {
+      case \\"test+\\": return States.TestPlus;
+      case \\"test\\": return States.Test;
+      case \\"test-\\": return States.TestMinus;
+      case \\"test?!\\": return States.TestQuestionExclamation;
+      case \\"*test\\": return States.AsteriskTest;
+    }
+    return null;
+  }
+}
+
+"
+`;
+
+exports[`CSharpGenerator should render enums with translated special characters 2`] = `
+"public enum States {
+  TestPlus, Test, TestMinus, TestQuestionExclamation, AsteriskTest
+}
+public static class StatesExtensions {
+  public static dynamic GetValue(this States enumValue)
+  {
+    switch (enumValue)
+    {
+      case States.TestPlus: return \\"test+\\";
+      case States.Test: return \\"test\\";
+      case States.TestMinus: return \\"test-\\";
+      case States.TestQuestionExclamation: return \\"test?!\\";
+      case States.AsteriskTest: return \\"*test\\";
+    }
+    return null;
+  }
+
+  public static States? ToStates(dynamic value)
+  {
+    switch (value)
+    {
+      case \\"test+\\": return States.TestPlus;
+      case \\"test\\": return States.Test;
+      case \\"test-\\": return States.TestMinus;
+      case \\"test?!\\": return States.TestQuestionExclamation;
+      case \\"*test\\": return States.AsteriskTest;
+    }
+    return null;
+  }
+}
+
+"
+`;
+
 exports[`CSharpGenerator should render models and their dependencies 1`] = `
 "namespace Test.Package
 {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
I used the helper function `FormatHelpers` similar to #497  to resolve for special characters in the enum renderer for C#. Also wrote down an additional test and updated the jest snapshot.


**Related issue(s)**
Fixes #503 