### PR TITLE
fix: model dependencies not needed for C# generator

### DIFF
--- a/src/generators/csharp/CSharpGenerator.ts
+++ b/src/generators/csharp/CSharpGenerator.ts
@@ -50,13 +50,8 @@ export class CSharpGenerator extends AbstractGenerator<CSharpOptions, CSharpRend
     }
 
     const outputModel = await this.render(model, inputModel);
-    const modelDependencies = model.getNearestDependencies().map((dependencyModelName) => { 
-      const formattedDependencyModelName = this.options.namingConvention?.type ? this.options.namingConvention.type(dependencyModelName, {inputModel, model: inputModel.models[String(dependencyModelName)], reservedKeywordCallback: isReservedCSharpKeyword}) : dependencyModelName;
-      return `using ${options.namespace}.${formattedDependencyModelName};`;
-    });
     const outputContent = `namespace ${options.namespace}
 {
-  ${modelDependencies.join('\n')}
   ${outputModel.dependencies.join('\n')}
   ${outputModel.result}
 }`;

--- a/test/blackbox/blackbox.spec.ts
+++ b/test/blackbox/blackbox.spec.ts
@@ -7,7 +7,7 @@
 
 import * as path from 'path';
 import * as fs from 'fs';
-import { TypeScriptGenerator, JavaScriptGenerator, GoGenerator, CSharpGenerator, JavaFileGenerator, JAVA_COMMON_PRESET } from '../../src';
+import { TypeScriptGenerator, JavaScriptGenerator, GoGenerator, CSharpGenerator, JavaFileGenerator, JAVA_COMMON_PRESET, CSharpFileGenerator } from '../../src';
 import { execCommand, generateModels, renderModels, renderModelsToSeparateFiles } from './utils/Utils';
 
 /**
@@ -128,11 +128,14 @@ describe.each(filesToTest)('Should be able to generate with inputs', ({file, out
     });
     describe('should be able to generate and compile C#', () => {
       test('class', async () => {
-        const generator = new CSharpGenerator();
-        const generatedModels = await generateModels(fileToGenerateFor, generator);
-        expect(generatedModels).not.toHaveLength(0);
+        const generator = new CSharpFileGenerator();
+        const inputFileContent = await fs.promises.readFile(fileToGenerateFor);
+        const input = JSON.parse(String(inputFileContent));
         const renderOutputPath = path.resolve(outputDirectoryPath, './csharp');
-        await renderModelsToSeparateFiles(generatedModels, renderOutputPath, 'cs');
+        
+        const generatedModels = await generator.generateToFiles(input, renderOutputPath, {namespace: 'TestNamespace'});
+        expect(generatedModels).not.toHaveLength(0);
+        
         const compileCommand = `csc /target:library /out:${path.resolve(renderOutputPath, './compiled.dll')} ${path.resolve(renderOutputPath, '*.cs')}`;
         await execCommand(compileCommand);
       });

--- a/test/generators/csharp/CSharpGenerator.spec.ts
+++ b/test/generators/csharp/CSharpGenerator.spec.ts
@@ -191,7 +191,7 @@ describe('CSharpGenerator', () => {
       },
       required: ['street_name', 'city', 'state', 'house_number', 'array_type'],
     };
-    const config = {namespace: 'Test.Package'};
+    const config = {namespace: 'Test.Namespace'};
     const models = await generator.generateCompleteModels(doc, config);
     expect(models).toHaveLength(2);
     expect(models[0].result).toMatchSnapshot();

--- a/test/generators/csharp/__snapshots__/CSharpGenerator.spec.ts.snap
+++ b/test/generators/csharp/__snapshots__/CSharpGenerator.spec.ts.snap
@@ -391,9 +391,8 @@ public static class StatesExtensions {
 `;
 
 exports[`CSharpGenerator should render models and their dependencies 1`] = `
-"namespace Test.Package
+"namespace Test.Namespace
 {
-  using Test.Package.OtherModel;
   using System.Collections.Generic;
   public class Address {
   private string streetName;
@@ -471,9 +470,8 @@ exports[`CSharpGenerator should render models and their dependencies 1`] = `
 `;
 
 exports[`CSharpGenerator should render models and their dependencies 2`] = `
-"namespace Test.Package
+"namespace Test.Namespace
 {
-  
   using System.Collections.Generic;
   public class OtherModel {
   private string streetName;


### PR DESCRIPTION
**Description**
There is no need for model dependencies as if they are within the same package, they automatically have access to them.