### PR TITLE
docs: generate Java data models that overwrite hashCode method

### DIFF
--- a/docs/languages/Java.md
+++ b/docs/languages/Java.md
@@ -22,7 +22,9 @@ Check out this [example for a live demonstration](../../examples/java-generate-e
 
 
 ## Include hashCode function for the class
-TODO
+To overwrite the `GetHashCode` method, use the preset `JAVA_COMMON_PRESET` and provide the option `hashCode: true`.
+
+Check out this [example for a live demonstration](../../examples/java-generate-hashcode).
 
 ## Change the collection type for arrays
 TODO

--- a/docs/languages/Java.md
+++ b/docs/languages/Java.md
@@ -22,7 +22,7 @@ Check out this [example for a live demonstration](../../examples/java-generate-e
 
 
 ## Include hashCode function for the class
-To overwrite the `GetHashCode` method, use the preset `JAVA_COMMON_PRESET` and provide the option `hashCode: true`.
+To overwrite the `hashCode` method, use the preset `JAVA_COMMON_PRESET` and provide the option `hashCode: true`.
 
 Check out this [example for a live demonstration](../../examples/java-generate-hashcode).
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -30,3 +30,4 @@ This directory contains a series of self-contained examples that you can use as 
 - [include-custom-function](./include-custom-function) - A basic example where a custom function is included.
 - [java-generate-equals](./java-generate-equals) - A basic example that shows how to generate models that overwrite the `equal` method
 - [generate-csharp-models](./generate-csharp-models) - A basic example to generate C# data models
+- [java-generate-hashcode](./java-generate-hashcode) - A basic example that shows how to generate models that overwrite the `GetHashCode` method

--- a/examples/README.md
+++ b/examples/README.md
@@ -30,4 +30,4 @@ This directory contains a series of self-contained examples that you can use as 
 - [include-custom-function](./include-custom-function) - A basic example where a custom function is included.
 - [java-generate-equals](./java-generate-equals) - A basic example that shows how to generate models that overwrite the `equal` method
 - [generate-csharp-models](./generate-csharp-models) - A basic example to generate C# data models
-- [java-generate-hashcode](./java-generate-hashcode) - A basic example that shows how to generate models that overwrite the `GetHashCode` method
+- [java-generate-hashcode](./java-generate-hashcode) - A basic example that shows how to generate models that overwrite the `hashCode` method

--- a/examples/java-generate-hashcode/README.md
+++ b/examples/java-generate-hashcode/README.md
@@ -1,0 +1,17 @@
+# Java Generate `HashCode`
+
+A basic example on how to generate models that overwrite `GetHashCode` method
+
+## How to run this example
+
+Run this example using:
+
+```sh
+npm i && npm run start
+```
+
+If you are on Windows, use the `start:windows` script instead:
+
+```sh
+npm i && npm run start:windows
+```

--- a/examples/java-generate-hashcode/README.md
+++ b/examples/java-generate-hashcode/README.md
@@ -1,6 +1,6 @@
 # Java Generate `HashCode`
 
-A basic example on how to generate models that overwrite `GetHashCode` method
+A basic example on how to generate models that overwrite `hashCode` method
 
 ## How to run this example
 

--- a/examples/java-generate-hashcode/__snapshots__/index.spec.ts.snap
+++ b/examples/java-generate-hashcode/__snapshots__/index.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Should be able to generate a model to overwrite hashCode method and should log expected output to console 1`] = `
+exports[`Should be able to generate a model to overwrite the hashCode method and should log expected output to console 1`] = `
 Array [
   "public class Root {
   private Object email;

--- a/examples/java-generate-hashcode/__snapshots__/index.spec.ts.snap
+++ b/examples/java-generate-hashcode/__snapshots__/index.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Should be able to generate a model to overwrite the GetHashCode method and should log expected output to console 1`] = `
+exports[`Should be able to generate a model to overwrite hashCode method and should log expected output to console 1`] = `
 Array [
   "public class Root {
   private Object email;

--- a/examples/java-generate-hashcode/__snapshots__/index.spec.ts.snap
+++ b/examples/java-generate-hashcode/__snapshots__/index.spec.ts.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Should be able to generate a model to overwrite the GetHashCode method and should log expected output to console 1`] = `
+Array [
+  "public class Root {
+  private Object email;
+
+  public Object getEmail() { return this.email; }
+  public void setEmail(Object email) { this.email = email; }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash((Object)email);
+  }
+}",
+]
+`;

--- a/examples/java-generate-hashcode/index.spec.ts
+++ b/examples/java-generate-hashcode/index.spec.ts
@@ -1,7 +1,7 @@
 const spy = jest.spyOn(global.console, 'log').mockImplementation(() => { return; });
 import {generate} from './index';
 
-describe('Should be able to generate a model to overwrite the GetHashCode method', () => {
+describe('Should be able to generate a model to overwrite the hashCode method', () => {
   afterAll(() => {
     jest.restoreAllMocks();
   });

--- a/examples/java-generate-hashcode/index.spec.ts
+++ b/examples/java-generate-hashcode/index.spec.ts
@@ -1,0 +1,14 @@
+const spy = jest.spyOn(global.console, 'log').mockImplementation(() => { return; });
+import {generate} from './index';
+
+describe('Should be able to generate a model to overwrite the GetHashCode method', () => {
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+  test('and should log expected output to console', async () => {
+    await generate();
+    //Generate is called 2x, so even though we expect 1 model, we double it
+    expect(spy.mock.calls.length).toEqual(2);
+    expect(spy.mock.calls[1]).toMatchSnapshot();
+  });
+});

--- a/examples/java-generate-hashcode/index.ts
+++ b/examples/java-generate-hashcode/index.ts
@@ -1,0 +1,34 @@
+import { JavaGenerator, JAVA_COMMON_PRESET } from '../../src';
+
+const generator = new JavaGenerator({ 
+  presets: [
+    {
+      preset: JAVA_COMMON_PRESET, 
+      options: {
+        equal: false,
+        hashCode: true,
+        classToString: false
+      }
+    }
+  ]
+});
+
+const jsonSchemaDraft7 = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    email: {
+      type: 'string',
+      format: 'email'
+    }
+  }
+};
+
+export async function generate() : Promise<void> {
+  const models = await generator.generate(jsonSchemaDraft7);
+  for (const model of models) {
+    console.log(model.result);
+  }
+}
+generate();

--- a/examples/java-generate-hashcode/package-lock.json
+++ b/examples/java-generate-hashcode/package-lock.json
@@ -1,0 +1,10 @@
+{
+  "name": "java-generate-hashcode",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "hasInstallScript": true
+    }
+  }
+}

--- a/examples/java-generate-hashcode/package.json
+++ b/examples/java-generate-hashcode/package.json
@@ -1,0 +1,10 @@
+{
+  "config" : { "example_name" : "java-generate-hashcode" },
+  "scripts": {
+    "install": "cd ../.. && npm i",
+    "start": "../../node_modules/.bin/ts-node --cwd ../../ ./examples/$npm_package_config_example_name/index.ts",
+    "start:windows": "..\\..\\node_modules\\.bin\\ts-node --cwd ..\\..\\ .\\examples\\%npm_package_config_example_name%\\index.ts",
+    "test": "../../node_modules/.bin/jest --config=../../jest.config.js ./examples/$npm_package_config_example_name/index.spec.ts",
+    "test:windows": "..\\..\\node_modules\\.bin\\jest --config=..\\..\\jest.config.js examples/%npm_package_config_example_name%/index.spec.ts"
+  }
+}


### PR DESCRIPTION
Description
Added example on how to generate a model to overwrite the hashCode method
https://github.com/mahakporwal02/modelina/tree/issue/422/examples/java-generate-hashcode
Updated documentation.
https://github.com/mahakporwal02/modelina/blob/issue/422/examples/java-generate-hashcode/README.md
https://github.com/mahakporwal02/modelina/blob/issue/422/examples/README.md
https://github.com/mahakporwal02/modelina/blob/issue/422/docs/languages/Java.md

Related issue(s)
fixes #422 