### PR TITLE
ci: fix coverage problems with checkout

### DIFF
--- a/.github/workflows/coverall.yml
+++ b/.github/workflows/coverall.yml
@@ -10,7 +10,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Setup Node.js
       uses: actions/setup-node@v1
       with:


### PR DESCRIPTION
**Description**
Sometimes, the CI check fails, for weird reasons, almost because it can't find the coverage report, apparently, it is the fault of checkout@v1. https://github.com/coverallsapp/github-action/issues/55
