### PR TITLE
fix: missing namespace for Type in C# JsonSerializerPreset

### DIFF
--- a/examples/csharp-generate-serializer/__snapshots__/index.spec.ts.snap
+++ b/examples/csharp-generate-serializer/__snapshots__/index.spec.ts.snap
@@ -15,12 +15,12 @@ public class Root {
 
 internal class RootConverter : JsonConverter<Root>
 {
-  public override bool CanConvert(Type objectType)
+  public override bool CanConvert(System.Type objectType)
   {
     // this converter can be applied to any type
     return true;
   }
-  public override Root Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+  public override Root Read(ref Utf8JsonReader reader, System.Type typeToConvert, JsonSerializerOptions options)
   {
     if (reader.TokenType != JsonTokenType.StartObject)
     {

--- a/src/generators/csharp/presets/JsonSerializerPreset.ts
+++ b/src/generators/csharp/presets/JsonSerializerPreset.ts
@@ -205,7 +205,7 @@ function renderDeserialize({ renderer, model, inputModel }: {
   const deserializeProperties = renderDeserializeProperties(model, renderer, inputModel);
   const deserializePatternProperties = renderDeserializePatternProperties(model, renderer, inputModel);
   const deserializeAdditionalProperties = renderDeserializeAdditionalProperties(model, renderer, inputModel);
-  return `public override ${formattedModelName} Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+  return `public override ${formattedModelName} Read(ref Utf8JsonReader reader, System.Type typeToConvert, JsonSerializerOptions options)
 {
   if (reader.TokenType != JsonTokenType.StartObject)
   {
@@ -260,7 +260,7 @@ ${content}
 
 internal class ${formattedModelName}Converter : JsonConverter<${formattedModelName}>
 {
-  public override bool CanConvert(Type objectType)
+  public override bool CanConvert(System.Type objectType)
   {
     // this converter can be applied to any type
     return true;

--- a/test/generators/csharp/presets/__snapshots__/JsonSerializerPreset.spec.ts.snap
+++ b/test/generators/csharp/presets/__snapshots__/JsonSerializerPreset.spec.ts.snap
@@ -21,12 +21,12 @@ public class NestedTest {
 
 internal class NestedTestConverter : JsonConverter<NestedTest>
 {
-  public override bool CanConvert(Type objectType)
+  public override bool CanConvert(System.Type objectType)
   {
     // this converter can be applied to any type
     return true;
   }
-  public override NestedTest Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+  public override NestedTest Read(ref Utf8JsonReader reader, System.Type typeToConvert, JsonSerializerOptions options)
   {
     if (reader.TokenType != JsonTokenType.StartObject)
     {
@@ -157,12 +157,12 @@ public class Test {
 
 internal class TestConverter : JsonConverter<Test>
 {
-  public override bool CanConvert(Type objectType)
+  public override bool CanConvert(System.Type objectType)
   {
     // this converter can be applied to any type
     return true;
   }
-  public override Test Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+  public override Test Read(ref Utf8JsonReader reader, System.Type typeToConvert, JsonSerializerOptions options)
   {
     if (reader.TokenType != JsonTokenType.StartObject)
     {


### PR DESCRIPTION
**Description**
The JsonSerializerPreset in C# cant determine the dependency. This PR adds the explicit type.