### PR TITLE
fix: change package.json `prepublishOnly` script to `prepare` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "generate:readme:toc": "markdown-toc -i README.md && markdown-toc -i ./docs/usage.md && markdown-toc -i ./docs/integration.md && markdown-toc -i ./docs/advanced.md && markdown-toc -i ./docs/languages/TypeScript.md && markdown-toc -i ./docs/languages/Java.md && markdown-toc -i ./docs/languages/JavaScript.md && markdown-toc -i ./docs/languages/Csharp.md && markdown-toc -i ./docs/README.md && markdown-toc -i ./docs/generators.md",
     "generate:assets": "npm run build:prod && npm run docs && npm run generate:readme:toc",
     "bump:version": "npm --no-git-tag-version --allow-same-version version $VERSION",
-    "prepublishOnly": "npm run build:prod && npm run generate:readme:toc"
+    "prepare": "npm run build:prod && npm run generate:readme:toc"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Proposal: Change build script to run on `prepare` rather than `prepublishOnly`. The difference:

`prepublishOnly`:
> Run BEFORE the package is prepared and packed, ONLY on npm publish.

`prepare`:
> Run both BEFORE the package is packed and published, and on local npm install without any arguments. This is run AFTER prepublish, but BEFORE prepublishOnly.

The latter makes it easier to add the dependency from github (say from a fork).

sources:
https://docs.npmjs.com/cli/v8/using-npm/scripts#prepare-and-prepublish
https://stackoverflow.com/questions/40528053/npm-install-and-build-of-forked-github-repo/57829251#57829251