### PR TITLE
feat: new `accessorBuilder` preset hook for C# class renderer

### DIFF
--- a/docs/presets.md
+++ b/docs/presets.md
@@ -211,6 +211,7 @@ There are no additional methods.
 |---|---|---|
 | `ctor` | A method to extend rendered constructor for a given class. | - |
 | `property` | A method to extend rendered given property. | `propertyName` as a name of a given property, `property` object as a [`CommonModel`](../src/models/CommonModel.ts) instance. |
+| `accessorFactory` | A method to extend rendered given property accessor factory. | `propertyName` as a name of a given property, `property` object as a [`CommonModel`](../src/models/CommonModel.ts) instance. |
 | `setter` | A method to extend setter for a given property. | `propertyName` as a name of a given property, `property` object as a [`CommonModel`](../src/models/CommonModel.ts) instance. |
 | `getter` | A method to extend getter for a given property. | `propertyName` as a name of a given property, `property` object as a [`CommonModel`](../src/models/CommonModel.ts) instance. |
 

--- a/src/generators/csharp/CSharpPreset.ts
+++ b/src/generators/csharp/CSharpPreset.ts
@@ -1,10 +1,14 @@
-/* eslint-disable @typescript-eslint/ban-types */
-import { Preset, EnumPreset, ClassPreset } from '../../models';
+import { Preset, EnumPreset, ClassPreset, PresetArgs, PropertyArgs } from '../../models';
 import { ClassRenderer, CSHARP_DEFAULT_CLASS_PRESET } from './renderers/ClassRenderer';
 import { CSHARP_DEFAULT_ENUM_PRESET, EnumRenderer } from './renderers/EnumRenderer';
 
+// Our class preset uses custom `accessorFactory` hook to craft getter and setters.
+export interface CsharpClassPreset extends ClassPreset<ClassRenderer> {
+  accessorFactory?: (args: PresetArgs<ClassRenderer, any> & PropertyArgs) => Promise<string> | string;
+}
+
 export type CSharpPreset = Preset<{
-  class: ClassPreset<ClassRenderer>;
+  class: CsharpClassPreset;
   enum: EnumPreset<EnumRenderer>
 }>;
 

--- a/test/generators/csharp/CSharpGenerator.spec.ts
+++ b/test/generators/csharp/CSharpGenerator.spec.ts
@@ -63,36 +63,6 @@ describe('CSharpGenerator', () => {
     expect(classModel.dependencies).toEqual(['using System.Collections.Generic;']);
   });
 
-  test('should work custom preset for `class` type', async () => {
-    const doc = {
-      $id: 'CustomClass',
-      type: 'object',
-      properties: {
-        property: { type: 'string' },
-      },
-      additionalProperties: {
-        type: 'string'
-      }
-    };
-
-    generator = new CSharpGenerator({ presets: [
-      {
-        class: {
-          property({ propertyName, property, renderer }) {
-            return `private ${propertyName} ${renderer.renderType(property)}`;
-          },
-        }
-      }
-    ] });
-
-    const inputModel = await generator.process(doc);
-    const model = inputModel.models['CustomClass'];
-    
-    const classModel = await generator.render(model, inputModel);
-    expect(classModel.result).toMatchSnapshot();
-    expect(classModel.dependencies).toEqual(['using System.Collections.Generic;']);
-  });
-
   test.each([
     {
       name: 'with enums sharing same type',
@@ -148,15 +118,7 @@ describe('CSharpGenerator', () => {
       enum: ['test+', 'test', 'test-', 'test?!', '*test']
     };
     
-    generator = new CSharpGenerator({ presets: [
-      {
-        enum: {
-          self({ content }) {
-            return content;
-          },
-        }
-      }
-    ]});
+    generator = new CSharpGenerator();
 
     const inputModel = await generator.process(doc);
     const model = inputModel.models['States'];
@@ -221,5 +183,69 @@ describe('CSharpGenerator', () => {
     const config = {namespace: 'true'};
     const expectedError = new Error('You cannot use reserved CSharp keyword (true) as namespace, please use another.');
     await expect(generator.generateCompleteModels(doc, config)).rejects.toEqual(expectedError);
+  });
+
+  test('should render custom type', async () => {
+    const doc = {
+      $id: 'Node',
+      type: 'object',
+      properties: {
+        Instructions: { 
+          additionalProperties: true
+        }
+      },
+      additionalProperties: false
+    };
+    const generator = new CSharpGenerator();
+    const inputModel = await generator.generate(doc);
+    expect(inputModel[0].result).toMatchSnapshot();
+  });
+  describe('class renderer', () => {
+    const doc = {
+      $id: 'CustomClass',
+      type: 'object',
+      properties: {
+        property: { type: 'string' },
+      },
+      additionalProperties: {
+        type: 'string'
+      }
+    };
+
+    test('should be able to overwrite accessorFactory preset hook', async () => {
+      generator = new CSharpGenerator({ presets: [
+        {
+          class: {
+            accessorFactory() {
+              return 'my own custom factory';
+            }
+          }
+        }
+      ] });
+  
+      const inputModel = await generator.process(doc);
+      const model = inputModel.models['CustomClass'];
+      
+      const classModel = await generator.render(model, inputModel);
+      expect(classModel.result).toMatchSnapshot();
+    });
+
+    test('should be able to overwrite property preset hook', async () => {
+      generator = new CSharpGenerator({ presets: [
+        {
+          class: {
+            property() {
+              return 'my own property';
+            },
+          }
+        }
+      ] });
+
+      const inputModel = await generator.process(doc);
+      const model = inputModel.models['CustomClass'];
+      
+      const classModel = await generator.render(model, inputModel);
+      expect(classModel.result).toMatchSnapshot();
+    });
   });
 });

--- a/test/generators/csharp/__snapshots__/CSharpGenerator.spec.ts.snap
+++ b/test/generators/csharp/__snapshots__/CSharpGenerator.spec.ts.snap
@@ -1,5 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`CSharpGenerator class renderer should be able to overwrite accessorFactory preset hook 1`] = `
+"public class CustomClass {
+  private string property;
+  private Dictionary<string, string> additionalProperties;
+
+  my own custom factory
+
+  my own custom factory
+}"
+`;
+
+exports[`CSharpGenerator class renderer should be able to overwrite property preset hook 1`] = `
+"public class CustomClass {
+  my own property
+  my own property
+
+  public string Property 
+  {
+    get { return property; }
+    set { property = value; }
+  }
+
+  public Dictionary<string, string> AdditionalProperties 
+  {
+    get { return additionalProperties; }
+    set { additionalProperties = value; }
+  }
+}"
+`;
+
 exports[`CSharpGenerator should not render reserved keyword 1`] = `
 "public class Address {
   private string reservedReservedEnum;
@@ -320,6 +350,18 @@ public static class StatesExtensions {
 "
 `;
 
+exports[`CSharpGenerator should render custom type 1`] = `
+"public class Node {
+  private dynamic instructions;
+
+  public dynamic Instructions 
+  {
+    get { return instructions; }
+    set { instructions = value; }
+  }
+}"
+`;
+
 exports[`CSharpGenerator should render enums with translated special characters 1`] = `
 "public enum States {
   TestPlus, Test, TestMinus, TestQuestionExclamation, AsteriskTest
@@ -489,25 +531,6 @@ exports[`CSharpGenerator should render models and their dependencies 2`] = `
     set { additionalProperties = value; }
   }
 }
-}"
-`;
-
-exports[`CSharpGenerator should work custom preset for \`class\` type 1`] = `
-"public class CustomClass {
-  private property string
-  private additionalProperties string
-
-  public string Property 
-  {
-    get { return property; }
-    set { property = value; }
-  }
-
-  public Dictionary<string, string> AdditionalProperties 
-  {
-    get { return additionalProperties; }
-    set { additionalProperties = value; }
-  }
 }"
 `;
 


### PR DESCRIPTION
**Description**
This PR adds a new preset hook called `accessorBuilder` which is used to overwrite the accessor builder code that wraps the getter and setter methods.

This is needed if you want to disable the entire accessor code.

**Related issue(s)**
Related to #615 