### PR TITLE
fix: support net 6.0 for serialization and pass serialization options

### DIFF
--- a/examples/csharp-generate-serializer/__snapshots__/index.spec.ts.snap
+++ b/examples/csharp-generate-serializer/__snapshots__/index.spec.ts.snap
@@ -62,7 +62,7 @@ internal class RootConverter : JsonConverter<Root>
   {
     if (value == null)
     {
-      JsonSerializer.Serialize(writer, null);
+      JsonSerializer.Serialize(writer, null, options);
       return;
     }
     var properties = value.GetType().GetProperties();
@@ -72,7 +72,7 @@ internal class RootConverter : JsonConverter<Root>
     if(value.Email != null) { 
       // write property name and let the serializer serialize the value itself
       writer.WritePropertyName(\\"email\\");
-      JsonSerializer.Serialize(writer, value.Email);
+      JsonSerializer.Serialize(writer, value.Email, options);
     }
 
 

--- a/src/generators/csharp/presets/JsonSerializerPreset.ts
+++ b/src/generators/csharp/presets/JsonSerializerPreset.ts
@@ -13,7 +13,7 @@ function renderSerializeProperty(modelInstanceVariable: string, model: CommonMod
       value = `${value}.GetValue()`;
     }
   }
-  return `JsonSerializer.Serialize(writer, ${value});`;
+  return `JsonSerializer.Serialize(writer, ${value}, options);`;
 }
 
 function renderSerializeAdditionalProperties(model: CommonModel, renderer: CSharpRenderer, inputModel: CommonInputModel) {
@@ -116,7 +116,7 @@ function renderSerialize({ renderer, model, inputModel }: {
 {
   if (value == null)
   {
-    JsonSerializer.Serialize(writer, null);
+    JsonSerializer.Serialize(writer, null, options);
     return;
   }
   ${propertiesList}

--- a/test/generators/csharp/presets/__snapshots__/JsonSerializerPreset.spec.ts.snap
+++ b/test/generators/csharp/presets/__snapshots__/JsonSerializerPreset.spec.ts.snap
@@ -71,7 +71,7 @@ internal class NestedTestConverter : JsonConverter<NestedTest>
   {
     if (value == null)
     {
-      JsonSerializer.Serialize(writer, null);
+      JsonSerializer.Serialize(writer, null, options);
       return;
     }
     var properties = value.GetType().GetProperties().Where(prop => prop.Name != \\"AdditionalProperties\\");
@@ -81,7 +81,7 @@ internal class NestedTestConverter : JsonConverter<NestedTest>
     if(value.StringProp != null) { 
       // write property name and let the serializer serialize the value itself
       writer.WritePropertyName(\\"stringProp\\");
-      JsonSerializer.Serialize(writer, value.StringProp);
+      JsonSerializer.Serialize(writer, value.StringProp, options);
     }
 
 
@@ -98,7 +98,7 @@ internal class NestedTestConverter : JsonConverter<NestedTest>
         }
         // write property name and let the serializer serialize the value itself
         writer.WritePropertyName(additionalProperty.Key);
-        JsonSerializer.Serialize(writer, additionalProperty.Value);
+        JsonSerializer.Serialize(writer, additionalProperty.Value, options);
       }
     }
 
@@ -233,7 +233,7 @@ internal class TestConverter : JsonConverter<Test>
   {
     if (value == null)
     {
-      JsonSerializer.Serialize(writer, null);
+      JsonSerializer.Serialize(writer, null, options);
       return;
     }
     var properties = value.GetType().GetProperties().Where(prop => prop.Name != \\"AdditionalProperties\\" && prop.Name != \\"STestPatternProperties\\");
@@ -243,22 +243,22 @@ internal class TestConverter : JsonConverter<Test>
     if(value.StringProp != null) { 
       // write property name and let the serializer serialize the value itself
       writer.WritePropertyName(\\"string prop\\");
-      JsonSerializer.Serialize(writer, value.StringProp);
+      JsonSerializer.Serialize(writer, value.StringProp, options);
     }
     if(value.NumberProp != null) { 
       // write property name and let the serializer serialize the value itself
       writer.WritePropertyName(\\"numberProp\\");
-      JsonSerializer.Serialize(writer, value.NumberProp);
+      JsonSerializer.Serialize(writer, value.NumberProp, options);
     }
     if(value.EnumProp != null) { 
       // write property name and let the serializer serialize the value itself
       writer.WritePropertyName(\\"enumProp\\");
-      JsonSerializer.Serialize(writer, value.EnumProp.GetValue());
+      JsonSerializer.Serialize(writer, value.EnumProp.GetValue(), options);
     }
     if(value.ObjectProp != null) { 
       // write property name and let the serializer serialize the value itself
       writer.WritePropertyName(\\"objectProp\\");
-      JsonSerializer.Serialize(writer, value.ObjectProp);
+      JsonSerializer.Serialize(writer, value.ObjectProp, options);
     }
 
 
@@ -273,7 +273,7 @@ internal class TestConverter : JsonConverter<Test>
         }
         // write property name and let the serializer serialize the value itself
         writer.WritePropertyName(patternProp.Key);
-        JsonSerializer.Serialize(writer, patternProp.Value);
+        JsonSerializer.Serialize(writer, patternProp.Value, options);
       }
     }
 
@@ -288,7 +288,7 @@ internal class TestConverter : JsonConverter<Test>
         }
         // write property name and let the serializer serialize the value itself
         writer.WritePropertyName(additionalProperty.Key);
-        JsonSerializer.Serialize(writer, additionalProperty.Value);
+        JsonSerializer.Serialize(writer, additionalProperty.Value, options);
       }
     }
 


### PR DESCRIPTION
**Description**
I decided to **not** go for the solution proposed earlier in #701. I believe it makes more sense to pass the options block trough to the `Serialize` function. 

This fixes two bugs:
1. Removes the ambiguity introduced in .NET6.0 and will now compile. The function signature used in this fix is supported since the initial release of `JsonSerializer` in .NET Core 3.0 so it should be compatible with all versions.
2. Before during serialization it used the default options to serialize the fields. After this fix the options given during the call to `JsonSerializer.Serialize()` are passed trough. The new output is more inline of what would be expected.

For bug 2 let's take the example: https://github.com/u-packs/modelina-example/blob/example/Models/Auth/AuthMsg.cs
``` c#
AuthMsg msg = new() { Type = 5};

var options = new JsonSerializerOptions()
{
     NumberHandling = System.Text.Json.Serialization.JsonNumberHandling.WriteAsString,
};

JsonSerializer.SerializeToUtf8Bytes(msg, options);
```

Would result in `{"type": 5}` while using this fix it would correctly return `{"type": "5"}`

**Related issue(s)**
Fixes #701 