### PR TITLE
fix(c#): generated enum extension methods lead to invalid references

### DIFF
--- a/src/generators/csharp/presets/JsonSerializerPreset.ts
+++ b/src/generators/csharp/presets/JsonSerializerPreset.ts
@@ -139,7 +139,7 @@ function renderDeserializeProperty(type: string, model: CommonModel, inputModel:
     const propertyModelKind = TypeHelpers.extractKind(resolvedModel);
     //Referenced enums is the only one who need custom serialization
     if (propertyModelKind === ModelKind.ENUM) {
-      return `${type}Extension.To${type}(JsonSerializer.Deserialize<dynamic>(ref reader, options))`;
+      return `${type}Extensions.To${type}(JsonSerializer.Deserialize<dynamic>(ref reader, options))`;
     }
   }
   return `JsonSerializer.Deserialize<${type}>(ref reader, options)`;

--- a/test/generators/csharp/presets/__snapshots__/JsonSerializerPreset.spec.ts.snap
+++ b/test/generators/csharp/presets/__snapshots__/JsonSerializerPreset.spec.ts.snap
@@ -201,7 +201,7 @@ internal class TestConverter : JsonConverter<Test>
       }
       if (propertyName == \\"enumProp\\")
       {
-        var value = EnumTestExtension.ToEnumTest(JsonSerializer.Deserialize<dynamic>(ref reader, options));
+        var value = EnumTestExtensions.ToEnumTest(JsonSerializer.Deserialize<dynamic>(ref reader, options));
         instance.EnumProp = value;
         continue;
       }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
As mentioned in #700 the generated serializer code using enums did not match with the enum generated code.
This led to invalid code that required manual fixing. This tiny PR aligns both generators.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, othewise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->
Fixes #700 