### PR TITLE
feat: add nullable object in ts generator

### DIFF
--- a/src/generators/typescript/TypeScriptGenerator.ts
+++ b/src/generators/typescript/TypeScriptGenerator.ts
@@ -167,13 +167,14 @@ ${modelCode}`;
     modelObject.type = 'object';
     model.$ref = modelObject.$id;
 
-    const [modelOutput, typeOutput] = await Promise.all([
+    const [modelObjectOutput, modelOutput] = await Promise.all([
       this.renderModelType(modelObject, inputModel),
       this.renderType(model, inputModel),
     ]);
     return RenderOutput.toRenderOutput({
       ...modelOutput,
-      result: `${modelOutput.result}\n${typeOutput.result}`,
+      result: `${modelObjectOutput.result}\n${modelOutput.result}`,
+      dependencies: [...modelObjectOutput.dependencies, ...modelOutput.dependencies],
     });
   }
 

--- a/src/helpers/TypeHelpers.ts
+++ b/src/helpers/TypeHelpers.ts
@@ -22,4 +22,16 @@ export class TypeHelpers {
     if (Array.isArray(model.type)) {return ModelKind.UNION;}
     return ModelKind.PRIMITIVE;
   }
+
+  /**
+   * Returns wether the model is a nullable object (with object and null types)
+   * @param model to check
+   * @returns {boolean}
+   */
+  static isNullableObject(model: CommonModel): boolean {
+    return Array.isArray(model.type) &&
+      model.type.length === 2 &&
+      model.type.includes('object') &&
+      model.type.includes('null');
+  }
 }

--- a/test/generators/typescript/TypeScriptGenerator.spec.ts
+++ b/test/generators/typescript/TypeScriptGenerator.spec.ts
@@ -539,4 +539,62 @@ ${content}`;
     expect(models[0].result).toMatchSnapshot();
     expect(models[1].result).toMatchSnapshot();
   });
+
+  test('should render a nullable object in `interface` type', async () => {
+    const doc = {
+      $id: 'NullableObject',
+      type: ['object', 'null'],
+      properties: {
+        foo: {
+          type: 'string'
+        },
+      },
+      additionalProperties: false,
+    };
+    const expected = `interface NullableObjectInner {
+  foo?: string;
+}
+type NullableObject = NullableObjectInner | null;`;
+
+    const interfaceGenerator = new TypeScriptGenerator({ modelType: 'interface' });
+    const inputModel = await interfaceGenerator.process(doc);
+    const model = inputModel.models['NullableObject'];
+
+    const nullableObjectModel = await interfaceGenerator.render(model, inputModel);
+    expect(nullableObjectModel.result).toEqual(expected);
+    expect(nullableObjectModel.dependencies).toEqual([]);
+  });
+
+  test('should render a nullable object in `class` type', async () => {
+    const doc = {
+      $id: 'NullableObject',
+      type: ['object', 'null'],
+      properties: {
+        foo: {
+          type: 'string'
+        },
+      },
+      additionalProperties: false,
+    };
+    const expected = `class NullableObjectInner {
+  private _foo?: string;
+
+  constructor(input: {
+    foo?: string,
+  }) {
+    this._foo = input.foo;
+  }
+
+  get foo(): string | undefined { return this._foo; }
+  set foo(foo: string | undefined) { this._foo = foo; }
+}
+type NullableObject = NullableObjectInner | null;`;
+
+    const inputModel = await generator.process(doc);
+    const model = inputModel.models['NullableObject'];
+
+    const nullableObjectModel = await generator.render(model, inputModel);
+    expect(nullableObjectModel.result).toEqual(expected);
+    expect(nullableObjectModel.dependencies).toEqual([]);
+  });
 });


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

When a model with a composed type of `['object', 'null']`, the TS generator will generate an _Inner_ type for the object and create a nullable type alias.

Example (from the tests):

The following model,

```js
{
  $id: 'NullableObject',
  type: ['object', 'null'],
  properties: {
    foo: {
      type: 'string'
    },
  },
  additionalProperties: false,
}
```

Will generate the following code:

```ts
interface NullableObjectInner {
  foo?: string;
}
type NullableObject = NullableObjectInner | null;
```

or

```ts
class NullableObjectInner {
  private _foo?: string;

  constructor(input: {
    foo?: string,
  }) {
    this._foo = input.foo;
  }

  get foo(): string | undefined { return this._foo; }
  set foo(foo: string | undefined) { this._foo = foo; }
}
type NullableObject = NullableObjectInner | null;
```

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, othewise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->
Fixes #754 