### PR TITLE
refactor: add object property model 

### DIFF
--- a/src/generators/csharp/constrainer/PropertyKeyConstrainer.ts
+++ b/src/generators/csharp/constrainer/PropertyKeyConstrainer.ts
@@ -30,8 +30,8 @@ export const DefaultPropertyKeyConstraints: PropertyKeyConstraintOptions = {
 export function defaultPropertyKeyConstraints(customConstraints?: Partial<PropertyKeyConstraintOptions>): PropertyKeyConstraint {
   const constraints = {...DefaultPropertyKeyConstraints, ...customConstraints};
 
-  return ({propertyKey, constrainedObjectModel, objectModel}) => {
-    let constrainedPropertyKey = propertyKey;
+  return ({objectPropertyModel, constrainedObjectModel, objectModel}) => {
+    let constrainedPropertyKey = objectPropertyModel.propertyName;
 
     constrainedPropertyKey = constraints.NO_SPECIAL_CHAR(constrainedPropertyKey);
     constrainedPropertyKey = constraints.NO_NUMBER_START_CHAR(constrainedPropertyKey);

--- a/src/generators/go/constrainer/PropertyKeyConstrainer.ts
+++ b/src/generators/go/constrainer/PropertyKeyConstrainer.ts
@@ -30,8 +30,8 @@ export const DefaultPropertyKeyConstraints: PropertyKeyConstraintOptions = {
 export function defaultPropertyKeyConstraints(customConstraints?: Partial<PropertyKeyConstraintOptions>): PropertyKeyConstraint {
   const constraints = {...DefaultPropertyKeyConstraints, ...customConstraints};
 
-  return ({propertyKey, constrainedObjectModel, objectModel}) => {
-    let constrainedPropertyKey = propertyKey;
+  return ({objectPropertyModel, constrainedObjectModel, objectModel}) => {
+    let constrainedPropertyKey = objectPropertyModel.propertyName;
 
     constrainedPropertyKey = constraints.NO_SPECIAL_CHAR(constrainedPropertyKey);
     constrainedPropertyKey = constraints.NO_NUMBER_START_CHAR(constrainedPropertyKey);

--- a/src/generators/java/constrainer/PropertyKeyConstrainer.ts
+++ b/src/generators/java/constrainer/PropertyKeyConstrainer.ts
@@ -30,8 +30,8 @@ export const DefaultPropertyKeyConstraints: PropertyKeyConstraintOptions = {
 export function defaultPropertyKeyConstraints(customConstraints?: Partial<PropertyKeyConstraintOptions>): PropertyKeyConstraint {
   const constraints = {...DefaultPropertyKeyConstraints, ...customConstraints};
 
-  return ({propertyKey, constrainedObjectModel, objectModel}) => {
-    let constrainedPropertyKey = propertyKey;
+  return ({objectPropertyModel, constrainedObjectModel, objectModel}) => {
+    let constrainedPropertyKey = objectPropertyModel.propertyName;
 
     constrainedPropertyKey = constraints.NO_SPECIAL_CHAR(constrainedPropertyKey);
     constrainedPropertyKey = constraints.NO_NUMBER_START_CHAR(constrainedPropertyKey);

--- a/src/generators/javascript/constrainer/PropertyKeyConstrainer.ts
+++ b/src/generators/javascript/constrainer/PropertyKeyConstrainer.ts
@@ -30,8 +30,8 @@ export const DefaultPropertyKeyConstraints: PropertyKeyConstraintOptions = {
 export function defaultPropertyKeyConstraints(customConstraints?: Partial<PropertyKeyConstraintOptions>): PropertyKeyConstraint {
   const constraints = {...DefaultPropertyKeyConstraints, ...customConstraints};
 
-  return ({propertyKey, constrainedObjectModel, objectModel}) => {
-    let constrainedPropertyKey = propertyKey;
+  return ({objectPropertyModel, constrainedObjectModel, objectModel}) => {
+    let constrainedPropertyKey = objectPropertyModel.propertyName;
 
     constrainedPropertyKey = constraints.NO_SPECIAL_CHAR(constrainedPropertyKey);
     constrainedPropertyKey = constraints.NO_NUMBER_START_CHAR(constrainedPropertyKey);

--- a/src/generators/typescript/constrainer/PropertyKeyConstrainer.ts
+++ b/src/generators/typescript/constrainer/PropertyKeyConstrainer.ts
@@ -29,8 +29,8 @@ export const DefaultPropertyKeyConstraints: PropertyKeyConstraintOptions = {
 export function defaultPropertyKeyConstraints(customConstraints?: Partial<PropertyKeyConstraintOptions>): PropertyKeyConstraint {
   const constraints = {...DefaultPropertyKeyConstraints, ...customConstraints};
 
-  return ({propertyKey, constrainedObjectModel, objectModel}) => {
-    let constrainedPropertyKey = propertyKey;
+  return ({objectPropertyModel, constrainedObjectModel, objectModel}) => {
+    let constrainedPropertyKey = objectPropertyModel.propertyName;
 
     constrainedPropertyKey = constraints.NO_SPECIAL_CHAR(constrainedPropertyKey);
     constrainedPropertyKey = constraints.NO_NUMBER_START_CHAR(constrainedPropertyKey);

--- a/src/helpers/ConstrainHelpers.ts
+++ b/src/helpers/ConstrainHelpers.ts
@@ -1,6 +1,6 @@
 import { AbstractRenderer } from '../generators';
-import { ConstrainedAnyModel, ConstrainedBooleanModel, ConstrainedFloatModel, ConstrainedIntegerModel, ConstrainedMetaModel, ConstrainedObjectModel, ConstrainedReferenceModel, ConstrainedStringModel, ConstrainedTupleModel, ConstrainedTupleValueModel, ConstrainedArrayModel, ConstrainedUnionModel, ConstrainedEnumModel, ConstrainedDictionaryModel, ConstrainedEnumValueModel } from '../models/ConstrainedMetaModel';
-import { AnyModel, BooleanModel, FloatModel, IntegerModel, ObjectModel, ReferenceModel, StringModel, TupleModel, ArrayModel, UnionModel, EnumModel, DictionaryModel, MetaModel } from '../models/MetaModel';
+import { ConstrainedAnyModel, ConstrainedBooleanModel, ConstrainedFloatModel, ConstrainedIntegerModel, ConstrainedMetaModel, ConstrainedObjectModel, ConstrainedReferenceModel, ConstrainedStringModel, ConstrainedTupleModel, ConstrainedTupleValueModel, ConstrainedArrayModel, ConstrainedUnionModel, ConstrainedEnumModel, ConstrainedDictionaryModel, ConstrainedEnumValueModel, ConstrainedObjectPropertyModel } from '../models/ConstrainedMetaModel';
+import { AnyModel, BooleanModel, FloatModel, IntegerModel, ObjectModel, ReferenceModel, StringModel, TupleModel, ArrayModel, UnionModel, EnumModel, DictionaryModel, MetaModel, ObjectPropertyModel } from '../models/MetaModel';
 import { getTypeFromMapping, TypeMapping } from './TypeHelpers';
 
 export type ConstrainContext<R extends AbstractRenderer, M extends MetaModel> = {
@@ -30,7 +30,8 @@ export type ModelNameContext = {
 export type ModelNameConstraint = (context: ModelNameContext) => string;
 
 export type PropertyKeyContext = {
-  propertyKey: string,
+  constrainedObjectPropertyModel: ConstrainedObjectPropertyModel,
+  objectPropertyModel: ObjectPropertyModel,
   constrainedObjectModel: ConstrainedObjectModel,
   objectModel: ObjectModel
 }
@@ -148,10 +149,13 @@ function constrainDictionaryModel<R extends AbstractRenderer>(typeMapping: TypeM
 
 function constrainObjectModel<R extends AbstractRenderer>(typeMapping: TypeMapping<R>, constrainRules: Constraints, context: ConstrainContext<R, ObjectModel>): ConstrainedObjectModel {
   const constrainedModel = new ConstrainedObjectModel(context.constrainedName, context.metaModel.originalInput, '', {});
-  for (const [propertyKey, propertyMetaModel] of Object.entries(context.metaModel.properties)) {
-    const constrainedPropertyName = constrainRules.propertyKey({propertyKey, constrainedObjectModel: constrainedModel, objectModel: context.metaModel});
-    const constrainedProperty = constrainMetaModel(typeMapping, constrainRules, {...context, metaModel: propertyMetaModel, propertyKey: constrainedPropertyName});
-    constrainedModel.properties[String(constrainedPropertyName)] = constrainedProperty;
+  for (const propertyMetaModel of Object.values(context.metaModel.properties)) {
+    const constrainedPropertyModel = new ConstrainedObjectPropertyModel('', propertyMetaModel.required, constrainedModel);
+    const constrainedPropertyName = constrainRules.propertyKey({objectPropertyModel: propertyMetaModel, constrainedObjectPropertyModel: constrainedPropertyModel, constrainedObjectModel: constrainedModel, objectModel: context.metaModel});
+    constrainedPropertyModel.propertyName = constrainedPropertyName;
+    const constrainedProperty = constrainMetaModel(typeMapping, constrainRules, {...context, metaModel: context.metaModel, propertyKey: constrainedPropertyName});
+    constrainedPropertyModel.property = constrainedProperty;
+    constrainedModel.properties[String(constrainedPropertyName)] = constrainedPropertyModel;
   }
   constrainedModel.type = getTypeFromMapping(typeMapping, {
     constrainedModel,

--- a/src/helpers/Splitter.ts
+++ b/src/helpers/Splitter.ts
@@ -51,8 +51,8 @@ const trySplitModel = (model: MetaModel, options: SplitOptions, models: MetaMode
 export const split = (model: MetaModel, options: SplitOptions, models: MetaModel[] = [model]): MetaModel[] => {
   if (model instanceof ObjectModel) {
     for (const [prop, propModel] of Object.entries(model.properties)) {
-      model.properties[String(prop)] = trySplitModel(propModel, options, models);
-      split(propModel, options, models);
+      model.properties[String(prop)].property = trySplitModel(propModel.property, options, models);
+      split(propModel.property, options, models);
     }
   } else if (model instanceof UnionModel) {
     for (let index = 0; index < model.union.length; index++) {

--- a/src/models/ConstrainedMetaModel.ts
+++ b/src/models/ConstrainedMetaModel.ts
@@ -38,12 +38,19 @@ export class ConstrainedTupleModel extends ConstrainedMetaModel {
     super(name, originalInput, type);
   }
 }
+export class ConstrainedObjectPropertyModel {
+  constructor(
+    public propertyName: string,
+    public required: boolean,
+    public property: ConstrainedMetaModel) {
+  }
+}
 export class ConstrainedObjectModel extends ConstrainedMetaModel {
   constructor(
     name: string,
     originalInput: any, 
     type: string, 
-    public properties: { [key: string]: ConstrainedMetaModel; }) {
+    public properties: { [key: string]: ConstrainedObjectPropertyModel; }) {
     super(name, originalInput, type);
   }
 }

--- a/src/models/MetaModel.ts
+++ b/src/models/MetaModel.ts
@@ -32,11 +32,18 @@ export class TupleModel extends MetaModel {
     super(name, originalInput);
   }
 }
+export class ObjectPropertyModel {
+  constructor(
+    public propertyName: string,
+    public required: boolean,
+    public property: MetaModel) {
+  }
+}
 export class ObjectModel extends MetaModel {
   constructor(
     name: string,
     originalInput: any,
-    public properties: { [key: string]: MetaModel; }) {
+    public properties: { [key: string]: ObjectPropertyModel; }) {
     super(name, originalInput);
   }
 }

--- a/test/generators/csharp/constrainer/PropertyKeyConstrainer.spec.ts
+++ b/test/generators/csharp/constrainer/PropertyKeyConstrainer.spec.ts
@@ -1,35 +1,43 @@
 import { CSharpDefaultConstraints } from '../../../../src/generators/csharp/CSharpConstrainer';
-import { ConstrainedObjectModel, ObjectModel } from '../../../../src';
+import { ConstrainedObjectModel, ConstrainedObjectPropertyModel, ObjectModel, ObjectPropertyModel } from '../../../../src';
 import { DefaultPropertyKeyConstraints, defaultPropertyKeyConstraints, PropertyKeyConstraintOptions } from '../../../../src/generators/csharp/constrainer/PropertyKeyConstrainer';
 describe('PropertyKeyConstrainer', () => {
   const objectModel = new ObjectModel('test', undefined, {});
   const constrainedObjectModel = new ConstrainedObjectModel('test', undefined, '', {});
 
+  const constrainPropertyName = (propertyName: string) => {
+    const objectPropertyModel = new ObjectPropertyModel(propertyName, false, objectModel);
+    const constrainedObjectPropertyModel = new ConstrainedObjectPropertyModel('', objectPropertyModel.required, constrainedObjectModel);
+    return CSharpDefaultConstraints.propertyKey({constrainedObjectModel, objectModel, objectPropertyModel, constrainedObjectPropertyModel });
+  };
+
   test('should never render special chars', () => {
-    const constrainedKey = CSharpDefaultConstraints.propertyKey({constrainedObjectModel, objectModel, propertyKey: '%'});
+    const constrainedKey = constrainPropertyName('%');
     expect(constrainedKey).toEqual('Percent');
   });
   test('should not render number as start char', () => {
-    const constrainedKey = CSharpDefaultConstraints.propertyKey({constrainedObjectModel, objectModel, propertyKey: '1'});
+    const constrainedKey = constrainPropertyName('1');
     expect(constrainedKey).toEqual('Number_1');
   });
   test('should never contain empty name', () => {
-    const constrainedKey = CSharpDefaultConstraints.propertyKey({constrainedObjectModel, objectModel, propertyKey: ''});
+    const constrainedKey = constrainPropertyName('');
     expect(constrainedKey).toEqual('Empty');
   });
   test('should use constant naming format', () => {
-    const constrainedKey = CSharpDefaultConstraints.propertyKey({constrainedObjectModel, objectModel, propertyKey: 'some weird_value!"#2'});
+    const constrainedKey = constrainPropertyName('some weird_value!"#2');
     expect(constrainedKey).toEqual('SomeWeirdValueExclamationQuotationHash_2');
   });
   test('should not contain duplicate properties', () => {
     const objectModel = new ObjectModel('test', undefined, {});
-    const propertyModel = new ConstrainedObjectModel('SomeProperty', undefined, '', {});
-    const constrainedObjectModel = new ConstrainedObjectModel('test', undefined, '', {SomeProperty: propertyModel});
-    const constrainedKey = CSharpDefaultConstraints.propertyKey({constrainedObjectModel, objectModel, propertyKey: 'SomeProperty'});
+    const constrainedObjectModel = new ConstrainedObjectModel('test', undefined, '', {});
+    const objectPropertyModel = new ObjectPropertyModel('SomeProperty', false, objectModel);
+    const constrainedObjectPropertyModel = new ConstrainedObjectPropertyModel('SomeProperty', objectPropertyModel.required, constrainedObjectModel);
+    constrainedObjectModel.properties['SomeProperty'] = constrainedObjectPropertyModel;
+    const constrainedKey = CSharpDefaultConstraints.propertyKey({constrainedObjectModel, objectModel, objectPropertyModel, constrainedObjectPropertyModel});
     expect(constrainedKey).toEqual('ReservedSomeProperty');
   });
   test('should never render reserved keywords', () => {
-    const constrainedKey = CSharpDefaultConstraints.propertyKey({constrainedObjectModel, objectModel, propertyKey: 'return'});
+    const constrainedKey = constrainPropertyName('return');
     expect(constrainedKey).toEqual('ReservedReturn');
   });
   describe('custom constraints', () => {
@@ -43,7 +51,9 @@ describe('PropertyKeyConstrainer', () => {
         NO_DUPLICATE_PROPERTIES: jest.fn().mockReturnValue('')
       };
       const constrainFunction = defaultPropertyKeyConstraints(mockedConstraintCallbacks);
-      constrainFunction({constrainedObjectModel, objectModel, propertyKey: ''});
+      const objectPropertyModel = new ObjectPropertyModel('', false, objectModel);
+      const constrainedObjectPropertyModel = new ConstrainedObjectPropertyModel('', objectPropertyModel.required, constrainedObjectModel);
+      constrainFunction({constrainedObjectModel, objectModel, objectPropertyModel, constrainedObjectPropertyModel});
       //Expect all callbacks to be called
       for (const jestMockCallback of Object.values(mockedConstraintCallbacks)) {
         expect(jestMockCallback).toHaveBeenCalled();
@@ -60,7 +70,9 @@ describe('PropertyKeyConstrainer', () => {
       ];
       const jestCallback = jest.fn().mockReturnValue('');
       const constrainFunction = defaultPropertyKeyConstraints({NAMING_FORMATTER: jestCallback});
-      const constrainedValue = constrainFunction({constrainedObjectModel, objectModel, propertyKey: ''});
+      const objectPropertyModel = new ObjectPropertyModel('', false, objectModel);
+      const constrainedObjectPropertyModel = new ConstrainedObjectPropertyModel('', objectPropertyModel.required, constrainedObjectModel);
+      const constrainedValue = constrainFunction({constrainedObjectModel, objectModel, objectPropertyModel, constrainedObjectPropertyModel});
       expect(constrainedValue).toEqual('');
       for (const jestMockCallback of spies) {
         expect(jestMockCallback).toHaveBeenCalled();

--- a/test/generators/go/constrainer/PropertyKeyConstrainer.spec.ts
+++ b/test/generators/go/constrainer/PropertyKeyConstrainer.spec.ts
@@ -1,35 +1,43 @@
 import { GoDefaultConstraints } from '../../../../src/generators/go/GoConstrainer';
-import { ConstrainedObjectModel, ObjectModel } from '../../../../src';
+import { ConstrainedObjectModel, ConstrainedObjectPropertyModel, ObjectModel, ObjectPropertyModel } from '../../../../src';
 import { DefaultPropertyKeyConstraints, defaultPropertyKeyConstraints, PropertyKeyConstraintOptions } from '../../../../src/generators/go/constrainer/PropertyKeyConstrainer';
 describe('PropertyKeyConstrainer', () => {
   const objectModel = new ObjectModel('test', undefined, {});
   const constrainedObjectModel = new ConstrainedObjectModel('test', undefined, '', {});
 
+  const constrainPropertyName = (propertyName: string) => {
+    const objectPropertyModel = new ObjectPropertyModel(propertyName, false, objectModel);
+    const constrainedObjectPropertyModel = new ConstrainedObjectPropertyModel('', objectPropertyModel.required, constrainedObjectModel);
+    return GoDefaultConstraints.propertyKey({constrainedObjectModel, objectModel, objectPropertyModel, constrainedObjectPropertyModel });
+  };
+
   test('should never render special chars', () => {
-    const constrainedKey = GoDefaultConstraints.propertyKey({constrainedObjectModel, objectModel, propertyKey: '%'});
+    const constrainedKey = constrainPropertyName('%');
     expect(constrainedKey).toEqual('Percent');
   });
   test('should not render number as start char', () => {
-    const constrainedKey = GoDefaultConstraints.propertyKey({constrainedObjectModel, objectModel, propertyKey: '1'});
+    const constrainedKey = constrainPropertyName('1');
     expect(constrainedKey).toEqual('Number_1');
   });
   test('should never contain empty name', () => {
-    const constrainedKey = GoDefaultConstraints.propertyKey({constrainedObjectModel, objectModel, propertyKey: ''});
+    const constrainedKey = constrainPropertyName('');
     expect(constrainedKey).toEqual('Empty');
   });
   test('should use constant naming format', () => {
-    const constrainedKey = GoDefaultConstraints.propertyKey({constrainedObjectModel, objectModel, propertyKey: 'some weird_value!"#2'});
+    const constrainedKey = constrainPropertyName('some weird_value!"#2');
     expect(constrainedKey).toEqual('SomeWeirdValueExclamationQuotationHash_2');
   });
   test('should not contain duplicate properties', () => {
     const objectModel = new ObjectModel('test', undefined, {});
-    const propertyModel = new ConstrainedObjectModel('SomeProperty', undefined, '', {});
-    const constrainedObjectModel = new ConstrainedObjectModel('test', undefined, '', {SomeProperty: propertyModel});
-    const constrainedKey = GoDefaultConstraints.propertyKey({constrainedObjectModel, objectModel, propertyKey: 'SomeProperty'});
+    const constrainedObjectModel = new ConstrainedObjectModel('test', undefined, '', {});
+    const objectPropertyModel = new ObjectPropertyModel('SomeProperty', false, objectModel);
+    const constrainedObjectPropertyModel = new ConstrainedObjectPropertyModel('SomeProperty', objectPropertyModel.required, constrainedObjectModel);
+    constrainedObjectModel.properties['SomeProperty'] = constrainedObjectPropertyModel;
+    const constrainedKey = GoDefaultConstraints.propertyKey({constrainedObjectModel, objectModel, objectPropertyModel, constrainedObjectPropertyModel});
     expect(constrainedKey).toEqual('ReservedSomeProperty');
   });
   test('should never render reserved keywords', () => {
-    const constrainedKey = GoDefaultConstraints.propertyKey({constrainedObjectModel, objectModel, propertyKey: 'return'});
+    const constrainedKey = constrainPropertyName('return');
     expect(constrainedKey).toEqual('ReservedReturn');
   });
   describe('custom constraints', () => {
@@ -43,7 +51,9 @@ describe('PropertyKeyConstrainer', () => {
         NO_DUPLICATE_PROPERTIES: jest.fn().mockReturnValue('')
       };
       const constrainFunction = defaultPropertyKeyConstraints(mockedConstraintCallbacks);
-      constrainFunction({constrainedObjectModel, objectModel, propertyKey: ''});
+      const objectPropertyModel = new ObjectPropertyModel('', false, objectModel);
+      const constrainedObjectPropertyModel = new ConstrainedObjectPropertyModel('', objectPropertyModel.required, constrainedObjectModel);
+      constrainFunction({constrainedObjectModel, objectModel, objectPropertyModel, constrainedObjectPropertyModel});
       //Expect all callbacks to be called
       for (const jestMockCallback of Object.values(mockedConstraintCallbacks)) {
         expect(jestMockCallback).toHaveBeenCalled();
@@ -60,7 +70,9 @@ describe('PropertyKeyConstrainer', () => {
       ];
       const jestCallback = jest.fn().mockReturnValue('');
       const constrainFunction = defaultPropertyKeyConstraints({NAMING_FORMATTER: jestCallback});
-      const constrainedValue = constrainFunction({constrainedObjectModel, objectModel, propertyKey: ''});
+      const objectPropertyModel = new ObjectPropertyModel('', false, objectModel);
+      const constrainedObjectPropertyModel = new ConstrainedObjectPropertyModel('', objectPropertyModel.required, constrainedObjectModel);
+      const constrainedValue = constrainFunction({constrainedObjectModel, objectModel, objectPropertyModel, constrainedObjectPropertyModel});
       expect(constrainedValue).toEqual('');
       for (const jestMockCallback of spies) {
         expect(jestMockCallback).toHaveBeenCalled();

--- a/test/generators/java/constrainer/PropertyKeyConstrainer.spec.ts
+++ b/test/generators/java/constrainer/PropertyKeyConstrainer.spec.ts
@@ -1,35 +1,43 @@
 import { JavaDefaultConstraints } from '../../../../src/generators/java/JavaConstrainer';
-import { ConstrainedObjectModel, ObjectModel } from '../../../../src';
+import { ConstrainedObjectModel, ConstrainedObjectPropertyModel, ObjectModel, ObjectPropertyModel } from '../../../../src';
 import { DefaultPropertyKeyConstraints, defaultPropertyKeyConstraints, PropertyKeyConstraintOptions } from '../../../../src/generators/java/constrainer/PropertyKeyConstrainer';
 describe('PropertyKeyConstrainer', () => {
   const objectModel = new ObjectModel('test', undefined, {});
   const constrainedObjectModel = new ConstrainedObjectModel('test', undefined, '', {});
 
+  const constrainPropertyName = (propertyName: string) => {
+    const objectPropertyModel = new ObjectPropertyModel(propertyName, false, objectModel);
+    const constrainedObjectPropertyModel = new ConstrainedObjectPropertyModel('', objectPropertyModel.required, constrainedObjectModel);
+    return JavaDefaultConstraints.propertyKey({constrainedObjectModel, objectModel, objectPropertyModel, constrainedObjectPropertyModel });
+  };
+
   test('should never render special chars', () => {
-    const constrainedKey = JavaDefaultConstraints.propertyKey({constrainedObjectModel, objectModel, propertyKey: '%'});
+    const constrainedKey = constrainPropertyName('%');
     expect(constrainedKey).toEqual('Percent');
   });
   test('should not render number as start char', () => {
-    const constrainedKey = JavaDefaultConstraints.propertyKey({constrainedObjectModel, objectModel, propertyKey: '1'});
+    const constrainedKey = constrainPropertyName('1');
     expect(constrainedKey).toEqual('Number_1');
   });
   test('should never contain empty name', () => {
-    const constrainedKey = JavaDefaultConstraints.propertyKey({constrainedObjectModel, objectModel, propertyKey: ''});
+    const constrainedKey = constrainPropertyName('');
     expect(constrainedKey).toEqual('Empty');
   });
   test('should use constant naming format', () => {
-    const constrainedKey = JavaDefaultConstraints.propertyKey({constrainedObjectModel, objectModel, propertyKey: 'some weird_value!"#2'});
+    const constrainedKey = constrainPropertyName('some weird_value!"#2');
     expect(constrainedKey).toEqual('SomeWeirdValueExclamationQuotationHash_2');
   });
   test('should not contain duplicate properties', () => {
     const objectModel = new ObjectModel('test', undefined, {});
-    const propertyModel = new ConstrainedObjectModel('SomeProperty', undefined, '', {});
-    const constrainedObjectModel = new ConstrainedObjectModel('test', undefined, '', {SomeProperty: propertyModel});
-    const constrainedKey = JavaDefaultConstraints.propertyKey({constrainedObjectModel, objectModel, propertyKey: 'SomeProperty'});
+    const constrainedObjectModel = new ConstrainedObjectModel('test', undefined, '', {});
+    const objectPropertyModel = new ObjectPropertyModel('SomeProperty', false, objectModel);
+    const constrainedObjectPropertyModel = new ConstrainedObjectPropertyModel('SomeProperty', objectPropertyModel.required, constrainedObjectModel);
+    constrainedObjectModel.properties['SomeProperty'] = constrainedObjectPropertyModel;
+    const constrainedKey = JavaDefaultConstraints.propertyKey({constrainedObjectModel, objectModel, objectPropertyModel, constrainedObjectPropertyModel});
     expect(constrainedKey).toEqual('ReservedSomeProperty');
   });
   test('should never render reserved keywords', () => {
-    const constrainedKey = JavaDefaultConstraints.propertyKey({constrainedObjectModel, objectModel, propertyKey: 'return'});
+    const constrainedKey = constrainPropertyName('return');
     expect(constrainedKey).toEqual('ReservedReturn');
   });
   describe('custom constraints', () => {
@@ -43,7 +51,9 @@ describe('PropertyKeyConstrainer', () => {
         NO_DUPLICATE_PROPERTIES: jest.fn().mockReturnValue('')
       };
       const constrainFunction = defaultPropertyKeyConstraints(mockedConstraintCallbacks);
-      constrainFunction({constrainedObjectModel, objectModel, propertyKey: ''});
+      const objectPropertyModel = new ObjectPropertyModel('', false, objectModel);
+      const constrainedObjectPropertyModel = new ConstrainedObjectPropertyModel('', objectPropertyModel.required, constrainedObjectModel);
+      constrainFunction({constrainedObjectModel, objectModel, objectPropertyModel, constrainedObjectPropertyModel});
       //Expect all callbacks to be called
       for (const jestMockCallback of Object.values(mockedConstraintCallbacks)) {
         expect(jestMockCallback).toHaveBeenCalled();
@@ -60,7 +70,9 @@ describe('PropertyKeyConstrainer', () => {
       ];
       const jestCallback = jest.fn().mockReturnValue('');
       const constrainFunction = defaultPropertyKeyConstraints({NAMING_FORMATTER: jestCallback});
-      const constrainedValue = constrainFunction({constrainedObjectModel, objectModel, propertyKey: ''});
+      const objectPropertyModel = new ObjectPropertyModel('', false, objectModel);
+      const constrainedObjectPropertyModel = new ConstrainedObjectPropertyModel('', objectPropertyModel.required, constrainedObjectModel);
+      const constrainedValue = constrainFunction({constrainedObjectModel, objectModel, objectPropertyModel, constrainedObjectPropertyModel});
       expect(constrainedValue).toEqual('');
       for (const jestMockCallback of spies) {
         expect(jestMockCallback).toHaveBeenCalled();

--- a/test/generators/javascript/constrainer/PropertyKeyConstrainer.spec.ts
+++ b/test/generators/javascript/constrainer/PropertyKeyConstrainer.spec.ts
@@ -1,35 +1,43 @@
 import { JavaScriptDefaultConstraints } from '../../../../src/generators/javascript/JavaScriptConstrainer';
-import { ConstrainedObjectModel, ObjectModel } from '../../../../src';
+import { ConstrainedObjectModel, ConstrainedObjectPropertyModel, ObjectModel, ObjectPropertyModel } from '../../../../src';
 import { DefaultPropertyKeyConstraints, defaultPropertyKeyConstraints, PropertyKeyConstraintOptions } from '../../../../src/generators/javascript/constrainer/PropertyKeyConstrainer';
 describe('PropertyKeyConstrainer', () => {
   const objectModel = new ObjectModel('test', undefined, {});
   const constrainedObjectModel = new ConstrainedObjectModel('test', undefined, '', {});
 
+  const constrainPropertyName = (propertyName: string) => {
+    const objectPropertyModel = new ObjectPropertyModel(propertyName, false, objectModel);
+    const constrainedObjectPropertyModel = new ConstrainedObjectPropertyModel('', objectPropertyModel.required, constrainedObjectModel);
+    return JavaScriptDefaultConstraints.propertyKey({constrainedObjectModel, objectModel, objectPropertyModel, constrainedObjectPropertyModel });
+  };
+
   test('should never render special chars', () => {
-    const constrainedKey = JavaScriptDefaultConstraints.propertyKey({constrainedObjectModel, objectModel, propertyKey: '%'});
+    const constrainedKey = constrainPropertyName('%');
     expect(constrainedKey).toEqual('Percent');
   });
   test('should not render number as start char', () => {
-    const constrainedKey = JavaScriptDefaultConstraints.propertyKey({constrainedObjectModel, objectModel, propertyKey: '1'});
+    const constrainedKey = constrainPropertyName('1');
     expect(constrainedKey).toEqual('Number_1');
   });
   test('should never contain empty name', () => {
-    const constrainedKey = JavaScriptDefaultConstraints.propertyKey({constrainedObjectModel, objectModel, propertyKey: ''});
+    const constrainedKey = constrainPropertyName('');
     expect(constrainedKey).toEqual('Empty');
   });
   test('should use constant naming format', () => {
-    const constrainedKey = JavaScriptDefaultConstraints.propertyKey({constrainedObjectModel, objectModel, propertyKey: 'some weird_value!"#2'});
+    const constrainedKey = constrainPropertyName('some weird_value!"#2');
     expect(constrainedKey).toEqual('SomeWeirdValueExclamationQuotationHash_2');
   });
   test('should not contain duplicate properties', () => {
     const objectModel = new ObjectModel('test', undefined, {});
-    const propertyModel = new ConstrainedObjectModel('SomeProperty', undefined, '', {});
-    const constrainedObjectModel = new ConstrainedObjectModel('test', undefined, '', {SomeProperty: propertyModel});
-    const constrainedKey = JavaScriptDefaultConstraints.propertyKey({constrainedObjectModel, objectModel, propertyKey: 'SomeProperty'});
+    const constrainedObjectModel = new ConstrainedObjectModel('test', undefined, '', {});
+    const objectPropertyModel = new ObjectPropertyModel('SomeProperty', false, objectModel);
+    const constrainedObjectPropertyModel = new ConstrainedObjectPropertyModel('SomeProperty', objectPropertyModel.required, constrainedObjectModel);
+    constrainedObjectModel.properties['SomeProperty'] = constrainedObjectPropertyModel;
+    const constrainedKey = JavaScriptDefaultConstraints.propertyKey({constrainedObjectModel, objectModel, objectPropertyModel, constrainedObjectPropertyModel});
     expect(constrainedKey).toEqual('ReservedSomeProperty');
   });
   test('should never render reserved keywords', () => {
-    const constrainedKey = JavaScriptDefaultConstraints.propertyKey({constrainedObjectModel, objectModel, propertyKey: 'return'});
+    const constrainedKey = constrainPropertyName('return');
     expect(constrainedKey).toEqual('ReservedReturn');
   });
   describe('custom constraints', () => {
@@ -43,7 +51,9 @@ describe('PropertyKeyConstrainer', () => {
         NO_DUPLICATE_PROPERTIES: jest.fn().mockReturnValue('')
       };
       const constrainFunction = defaultPropertyKeyConstraints(mockedConstraintCallbacks);
-      constrainFunction({constrainedObjectModel, objectModel, propertyKey: ''});
+      const objectPropertyModel = new ObjectPropertyModel('', false, objectModel);
+      const constrainedObjectPropertyModel = new ConstrainedObjectPropertyModel('', objectPropertyModel.required, constrainedObjectModel);
+      constrainFunction({constrainedObjectModel, objectModel, objectPropertyModel, constrainedObjectPropertyModel});
       //Expect all callbacks to be called
       for (const jestMockCallback of Object.values(mockedConstraintCallbacks)) {
         expect(jestMockCallback).toHaveBeenCalled();
@@ -60,7 +70,9 @@ describe('PropertyKeyConstrainer', () => {
       ];
       const jestCallback = jest.fn().mockReturnValue('');
       const constrainFunction = defaultPropertyKeyConstraints({NAMING_FORMATTER: jestCallback});
-      const constrainedValue = constrainFunction({constrainedObjectModel, objectModel, propertyKey: ''});
+      const objectPropertyModel = new ObjectPropertyModel('', false, objectModel);
+      const constrainedObjectPropertyModel = new ConstrainedObjectPropertyModel('', objectPropertyModel.required, constrainedObjectModel);
+      const constrainedValue = constrainFunction({constrainedObjectModel, objectModel, objectPropertyModel, constrainedObjectPropertyModel});
       expect(constrainedValue).toEqual('');
       for (const jestMockCallback of spies) {
         expect(jestMockCallback).toHaveBeenCalled();

--- a/test/generators/typescript/constrainer/PropertyKeyConstrainer.spec.ts
+++ b/test/generators/typescript/constrainer/PropertyKeyConstrainer.spec.ts
@@ -1,35 +1,43 @@
 import { TypeScriptDefaultConstraints } from '../../../../src/generators/typescript/TypeScriptConstrainer';
-import { ConstrainedObjectModel, ObjectModel } from '../../../../src';
+import { ConstrainedObjectModel, ConstrainedObjectPropertyModel, ObjectModel, ObjectPropertyModel } from '../../../../src';
 import { DefaultPropertyKeyConstraints, defaultPropertyKeyConstraints, PropertyKeyConstraintOptions } from '../../../../src/generators/typescript/constrainer/PropertyKeyConstrainer';
 describe('PropertyKeyConstrainer', () => {
   const objectModel = new ObjectModel('test', undefined, {});
   const constrainedObjectModel = new ConstrainedObjectModel('test', undefined, '', {});
 
+  const constrainPropertyName = (propertyName: string) => {
+    const objectPropertyModel = new ObjectPropertyModel(propertyName, false, objectModel);
+    const constrainedObjectPropertyModel = new ConstrainedObjectPropertyModel('', objectPropertyModel.required, constrainedObjectModel);
+    return TypeScriptDefaultConstraints.propertyKey({constrainedObjectModel, objectModel, objectPropertyModel, constrainedObjectPropertyModel });
+  };
+
   test('should never render special chars', () => {
-    const constrainedKey = TypeScriptDefaultConstraints.propertyKey({constrainedObjectModel, objectModel, propertyKey: '%'});
+    const constrainedKey = constrainPropertyName('%');
     expect(constrainedKey).toEqual('Percent');
   });
   test('should not render number as start char', () => {
-    const constrainedKey = TypeScriptDefaultConstraints.propertyKey({constrainedObjectModel, objectModel, propertyKey: '1'});
+    const constrainedKey = constrainPropertyName('1');
     expect(constrainedKey).toEqual('Number_1');
   });
   test('should never contain empty name', () => {
-    const constrainedKey = TypeScriptDefaultConstraints.propertyKey({constrainedObjectModel, objectModel, propertyKey: ''});
+    const constrainedKey = constrainPropertyName('');
     expect(constrainedKey).toEqual('Empty');
   });
   test('should use constant naming format', () => {
-    const constrainedKey = TypeScriptDefaultConstraints.propertyKey({constrainedObjectModel, objectModel, propertyKey: 'some weird_value!"#2'});
+    const constrainedKey = constrainPropertyName('some weird_value!"#2');
     expect(constrainedKey).toEqual('SomeWeirdValueExclamationQuotationHash_2');
   });
   test('should not contain duplicate properties', () => {
     const objectModel = new ObjectModel('test', undefined, {});
-    const propertyModel = new ConstrainedObjectModel('SomeProperty', undefined, '', {});
-    const constrainedObjectModel = new ConstrainedObjectModel('test', undefined, '', {SomeProperty: propertyModel});
-    const constrainedKey = TypeScriptDefaultConstraints.propertyKey({constrainedObjectModel, objectModel, propertyKey: 'SomeProperty'});
+    const constrainedObjectModel = new ConstrainedObjectModel('test', undefined, '', {});
+    const objectPropertyModel = new ObjectPropertyModel('SomeProperty', false, objectModel);
+    const constrainedObjectPropertyModel = new ConstrainedObjectPropertyModel('SomeProperty', objectPropertyModel.required, constrainedObjectModel);
+    constrainedObjectModel.properties['SomeProperty'] = constrainedObjectPropertyModel;
+    const constrainedKey = TypeScriptDefaultConstraints.propertyKey({constrainedObjectModel, objectModel, objectPropertyModel, constrainedObjectPropertyModel});
     expect(constrainedKey).toEqual('ReservedSomeProperty');
   });
   test('should never render reserved keywords', () => {
-    const constrainedKey = TypeScriptDefaultConstraints.propertyKey({constrainedObjectModel, objectModel, propertyKey: 'return'});
+    const constrainedKey = constrainPropertyName('return');
     expect(constrainedKey).toEqual('ReservedReturn');
   });
   describe('custom constraints', () => {
@@ -43,7 +51,9 @@ describe('PropertyKeyConstrainer', () => {
         NO_DUPLICATE_PROPERTIES: jest.fn().mockReturnValue('')
       };
       const constrainFunction = defaultPropertyKeyConstraints(mockedConstraintCallbacks);
-      constrainFunction({constrainedObjectModel, objectModel, propertyKey: ''});
+      const objectPropertyModel = new ObjectPropertyModel('', false, objectModel);
+      const constrainedObjectPropertyModel = new ConstrainedObjectPropertyModel('', objectPropertyModel.required, constrainedObjectModel);
+      constrainFunction({constrainedObjectModel, objectModel, objectPropertyModel, constrainedObjectPropertyModel});
       //Expect all callbacks to be called
       for (const jestMockCallback of Object.values(mockedConstraintCallbacks)) {
         expect(jestMockCallback).toHaveBeenCalled();
@@ -60,7 +70,9 @@ describe('PropertyKeyConstrainer', () => {
       ];
       const jestCallback = jest.fn().mockReturnValue('');
       const constrainFunction = defaultPropertyKeyConstraints({NAMING_FORMATTER: jestCallback});
-      const constrainedValue = constrainFunction({constrainedObjectModel, objectModel, propertyKey: ''});
+      const objectPropertyModel = new ObjectPropertyModel('', false, objectModel);
+      const constrainedObjectPropertyModel = new ConstrainedObjectPropertyModel('', objectPropertyModel.required, constrainedObjectModel);
+      const constrainedValue = constrainFunction({constrainedObjectModel, objectModel, objectPropertyModel, constrainedObjectPropertyModel});
       expect(constrainedValue).toEqual('');
       for (const jestMockCallback of spies) {
         expect(jestMockCallback).toHaveBeenCalled();

--- a/test/helpers/Splitter.spec.ts
+++ b/test/helpers/Splitter.spec.ts
@@ -1,13 +1,14 @@
 import { split, SplitOptions } from '../../src/helpers';
-import { ObjectModel, ReferenceModel, StringModel } from '../../src/models';
+import { ObjectModel, ReferenceModel, StringModel, ObjectPropertyModel } from '../../src/models';
 describe('Splitter', () => {
   afterEach(() => {
     jest.restoreAllMocks();
   });
   test('should split models when asked for it', () => { 
     const stringModel = new StringModel('testString', undefined);
+    const propertyModel = new ObjectPropertyModel('test', false, stringModel);
     const model = new ObjectModel('testObj', undefined, {
-      test: stringModel
+      test: propertyModel
     });
     const options: SplitOptions = {
       splitString: true
@@ -15,7 +16,7 @@ describe('Splitter', () => {
     const splittedModels = split(model, options);
     
     const expectedObjectModel = model;
-    expectedObjectModel.properties['test'] = new ReferenceModel(stringModel.name, stringModel.originalInput, stringModel);
+    expectedObjectModel.properties['test'].property = new ReferenceModel(stringModel.name, stringModel.originalInput, stringModel);
     
     expect(splittedModels.length).toEqual(2);
     expect(splittedModels[0] instanceof ObjectModel).toEqual(true);
@@ -24,8 +25,9 @@ describe('Splitter', () => {
   });
   test('should not split models when not asked for', () => { 
     const stringModel = new StringModel('testString', undefined);
+    const propertyModel = new ObjectPropertyModel('test', false, stringModel);
     const model = new ObjectModel('testObj', undefined, {
-      test: stringModel
+      test: propertyModel
     });
     const options: SplitOptions = {
       splitString: false
@@ -37,8 +39,9 @@ describe('Splitter', () => {
   });
   test('should not split models when asked for something else', () => { 
     const stringModel = new StringModel('testString', undefined);
+    const propertyModel = new ObjectPropertyModel('test', false, stringModel);
     const model = new ObjectModel('testObj', undefined, {
-      test: stringModel
+      test: propertyModel
     });
     const options: SplitOptions = {
       splitBoolean: true


### PR DESCRIPTION
**Description**

Two issues I want to solve with this change:
1. In the presets, you need access to the original, non-constrained property, for serialization functionality, and that is not possible with the current setup.
2. Keep it consistent, as we already have the same setup for `EnumValueModel` and `TupleValueModel`.
