### PR TITLE
chore: refactored model setup to support generators

### DIFF
--- a/src/helpers/ConstrainHelpers.ts
+++ b/src/helpers/ConstrainHelpers.ts
@@ -1,13 +1,12 @@
-import { AbstractRenderer } from '../generators';
 import { ConstrainedAnyModel, ConstrainedBooleanModel, ConstrainedFloatModel, ConstrainedIntegerModel, ConstrainedMetaModel, ConstrainedObjectModel, ConstrainedReferenceModel, ConstrainedStringModel, ConstrainedTupleModel, ConstrainedTupleValueModel, ConstrainedArrayModel, ConstrainedUnionModel, ConstrainedEnumModel, ConstrainedDictionaryModel, ConstrainedEnumValueModel, ConstrainedObjectPropertyModel } from '../models/ConstrainedMetaModel';
 import { AnyModel, BooleanModel, FloatModel, IntegerModel, ObjectModel, ReferenceModel, StringModel, TupleModel, ArrayModel, UnionModel, EnumModel, DictionaryModel, MetaModel, ObjectPropertyModel } from '../models/MetaModel';
 import { getTypeFromMapping, TypeMapping } from './TypeHelpers';
 
-export type ConstrainContext<R extends AbstractRenderer, M extends MetaModel> = {
+export type ConstrainContext<Options, M extends MetaModel> = {
   propertyKey?: string,
   metaModel: M,
   constrainedName: string,
-  renderer: R
+  options: Options
 }
 
 export type EnumKeyContext = {
@@ -45,62 +44,62 @@ export interface Constraints {
   propertyKey: PropertyKeyConstraint,
 }
 
-function constrainReferenceModel<R extends AbstractRenderer>(typeMapping: TypeMapping<R>, constrainRules: Constraints, context: ConstrainContext<R, ReferenceModel>): ConstrainedReferenceModel {
+function constrainReferenceModel<Options>(typeMapping: TypeMapping<Options>, constrainRules: Constraints, context: ConstrainContext<Options, ReferenceModel>): ConstrainedReferenceModel {
   const constrainedRefModel = constrainMetaModel(typeMapping, constrainRules, {...context, metaModel: context.metaModel.ref, propertyKey: undefined});
   const constrainedModel = new ConstrainedReferenceModel(context.constrainedName, context.metaModel.originalInput, '', constrainedRefModel);
   constrainedModel.type = getTypeFromMapping(typeMapping, {
     constrainedModel,
-    renderer: context.renderer,
+    options: context.options,
     propertyKey: context.propertyKey
   });
   return constrainedModel;
 }
-function constrainAnyModel<R extends AbstractRenderer>(typeMapping: TypeMapping<R>, context: ConstrainContext<R, AnyModel>): ConstrainedAnyModel {
+function constrainAnyModel<Options>(typeMapping: TypeMapping<Options>, context: ConstrainContext<Options, AnyModel>): ConstrainedAnyModel {
   const constrainedModel = new ConstrainedAnyModel(context.constrainedName, context.metaModel.originalInput, '');
   constrainedModel.type = getTypeFromMapping(typeMapping, {
     constrainedModel,
-    renderer: context.renderer,
+    options: context.options,
     propertyKey: context.propertyKey
   });
   return constrainedModel; 
 }
-function constrainFloatModel<R extends AbstractRenderer>(typeMapping: TypeMapping<R>, context: ConstrainContext<R, FloatModel>): ConstrainedFloatModel {
+function constrainFloatModel<Options>(typeMapping: TypeMapping<Options>, context: ConstrainContext<Options, FloatModel>): ConstrainedFloatModel {
   const constrainedModel = new ConstrainedFloatModel(context.constrainedName, context.metaModel.originalInput, '');
   constrainedModel.type = getTypeFromMapping(typeMapping, {
     constrainedModel,
-    renderer: context.renderer,
+    options: context.options,
     propertyKey: context.propertyKey
   });
   return constrainedModel;
 }
-function constrainIntegerModel<R extends AbstractRenderer>(typeMapping: TypeMapping<R>, context: ConstrainContext<R, IntegerModel>): ConstrainedIntegerModel {
+function constrainIntegerModel<Options>(typeMapping: TypeMapping<Options>, context: ConstrainContext<Options, IntegerModel>): ConstrainedIntegerModel {
   const constrainedModel = new ConstrainedIntegerModel(context.constrainedName, context.metaModel.originalInput, '');
   constrainedModel.type = getTypeFromMapping(typeMapping, {
     constrainedModel,
-    renderer: context.renderer,
+    options: context.options,
     propertyKey: context.propertyKey
   });
   return constrainedModel;
 }
-function constrainStringModel<R extends AbstractRenderer>(typeMapping: TypeMapping<R>, context: ConstrainContext<R, StringModel>): ConstrainedStringModel {
+function constrainStringModel<Options>(typeMapping: TypeMapping<Options>, context: ConstrainContext<Options, StringModel>): ConstrainedStringModel {
   const constrainedModel = new ConstrainedStringModel(context.constrainedName, context.metaModel.originalInput, '');
   constrainedModel.type = getTypeFromMapping(typeMapping, {
     constrainedModel,
-    renderer: context.renderer,
+    options: context.options,
     propertyKey: context.propertyKey
   });
   return constrainedModel;
 }
-function constrainBooleanModel<R extends AbstractRenderer>(typeMapping: TypeMapping<R>, context: ConstrainContext<R, BooleanModel>): ConstrainedBooleanModel {
+function constrainBooleanModel<Options>(typeMapping: TypeMapping<Options>, context: ConstrainContext<Options, BooleanModel>): ConstrainedBooleanModel {
   const constrainedModel = new ConstrainedBooleanModel(context.constrainedName, context.metaModel.originalInput, '');
   constrainedModel.type = getTypeFromMapping(typeMapping, {
     constrainedModel,
-    renderer: context.renderer,
+    options: context.options,
     propertyKey: context.propertyKey
   });
   return constrainedModel;
 }
-function constrainTupleModel<R extends AbstractRenderer>(typeMapping: TypeMapping<R>, constrainRules: Constraints, context: ConstrainContext<R, TupleModel>): ConstrainedTupleModel {
+function constrainTupleModel<Options>(typeMapping: TypeMapping<Options>, constrainRules: Constraints, context: ConstrainContext<Options, TupleModel>): ConstrainedTupleModel {
   const constrainedTupleModels = context.metaModel.tuple.map((tupleValue) => {
     const tupleType = constrainMetaModel(typeMapping, constrainRules, {...context, metaModel: tupleValue.value, propertyKey: undefined});
     return new ConstrainedTupleValueModel(tupleValue.index, tupleType);
@@ -108,46 +107,46 @@ function constrainTupleModel<R extends AbstractRenderer>(typeMapping: TypeMappin
   const constrainedModel = new ConstrainedTupleModel(context.constrainedName, context.metaModel.originalInput, '', constrainedTupleModels);
   constrainedModel.type = getTypeFromMapping(typeMapping, {
     constrainedModel,
-    renderer: context.renderer,
+    options: context.options,
     propertyKey: context.propertyKey
   });
   return constrainedModel;
 }
-function constrainArrayModel<R extends AbstractRenderer>(typeMapping: TypeMapping<R>, constrainRules: Constraints, context: ConstrainContext<R, ArrayModel>): ConstrainedArrayModel {
+function constrainArrayModel<Options>(typeMapping: TypeMapping<Options>, constrainRules: Constraints, context: ConstrainContext<Options, ArrayModel>): ConstrainedArrayModel {
   const constrainedValueModel = constrainMetaModel(typeMapping, constrainRules, {...context, metaModel: context.metaModel.valueModel, propertyKey: undefined});
   const constrainedModel = new ConstrainedArrayModel(context.constrainedName, context.metaModel.originalInput, '', constrainedValueModel);
   constrainedModel.type = getTypeFromMapping(typeMapping, {
     constrainedModel,
-    renderer: context.renderer,
+    options: context.options,
     propertyKey: context.propertyKey
   });
   return constrainedModel;
 }
-function constrainUnionModel<R extends AbstractRenderer>(typeMapping: TypeMapping<R>, constrainRules: Constraints, context: ConstrainContext<R, UnionModel>): ConstrainedUnionModel {
+function constrainUnionModel<Options>(typeMapping: TypeMapping<Options>, constrainRules: Constraints, context: ConstrainContext<Options, UnionModel>): ConstrainedUnionModel {
   const constrainedUnionModels = context.metaModel.union.map((unionValue) => {
     return constrainMetaModel(typeMapping, constrainRules, {...context, metaModel: unionValue, propertyKey: undefined});
   });
   const constrainedModel = new ConstrainedUnionModel(context.constrainedName, context.metaModel.originalInput, '', constrainedUnionModels);
   constrainedModel.type = getTypeFromMapping(typeMapping, {
     constrainedModel,
-    renderer: context.renderer,
+    options: context.options,
     propertyKey: context.propertyKey
   });
   return constrainedModel;
 }
-function constrainDictionaryModel<R extends AbstractRenderer>(typeMapping: TypeMapping<R>, constrainRules: Constraints, context: ConstrainContext<R, DictionaryModel>): ConstrainedDictionaryModel {
+function constrainDictionaryModel<Options>(typeMapping: TypeMapping<Options>, constrainRules: Constraints, context: ConstrainContext<Options, DictionaryModel>): ConstrainedDictionaryModel {
   const keyModel = constrainMetaModel(typeMapping, constrainRules, {...context, metaModel: context.metaModel.key, propertyKey: undefined});
   const valueModel = constrainMetaModel(typeMapping, constrainRules, {...context, metaModel: context.metaModel.value, propertyKey: undefined});
   const constrainedModel = new ConstrainedDictionaryModel(context.constrainedName, context.metaModel.originalInput, '', keyModel, valueModel, context.metaModel.serializationType);
   constrainedModel.type = getTypeFromMapping(typeMapping, {
     constrainedModel,
-    renderer: context.renderer,
+    options: context.options,
     propertyKey: context.propertyKey
   });
   return constrainedModel;
 }
 
-function constrainObjectModel<R extends AbstractRenderer>(typeMapping: TypeMapping<R>, constrainRules: Constraints, context: ConstrainContext<R, ObjectModel>): ConstrainedObjectModel {
+function constrainObjectModel<Options>(typeMapping: TypeMapping<Options>, constrainRules: Constraints, context: ConstrainContext<Options, ObjectModel>): ConstrainedObjectModel {
   const constrainedModel = new ConstrainedObjectModel(context.constrainedName, context.metaModel.originalInput, '', {});
   for (const propertyMetaModel of Object.values(context.metaModel.properties)) {
     const constrainedPropertyModel = new ConstrainedObjectPropertyModel('', propertyMetaModel.required, constrainedModel);
@@ -159,27 +158,27 @@ function constrainObjectModel<R extends AbstractRenderer>(typeMapping: TypeMappi
   }
   constrainedModel.type = getTypeFromMapping(typeMapping, {
     constrainedModel,
-    renderer: context.renderer,
+    options: context.options,
     propertyKey: context.propertyKey
   });
   return constrainedModel;
 }
 
-function ConstrainEnumModel<R extends AbstractRenderer>(typeMapping: TypeMapping<R>, constrainRules: Constraints, context: ConstrainContext<R, EnumModel>): ConstrainedEnumModel {
+function ConstrainEnumModel<Options>(typeMapping: TypeMapping<Options>, constrainRules: Constraints, context: ConstrainContext<Options, EnumModel>): ConstrainedEnumModel {
   const constrainedModel = new ConstrainedEnumModel(context.constrainedName, context.metaModel.originalInput, '', []);
 
   for (const enumValue of context.metaModel.values) {
     const constrainedEnumKey = constrainRules.enumKey({enumKey: String(enumValue.key), enumModel: context.metaModel, constrainedEnumModel: constrainedModel});
-    const constrainedEnumValue = constrainRules.enumKey({enumKey: String(enumValue.key), enumModel: context.metaModel, constrainedEnumModel: constrainedModel});
+    const constrainedEnumValue = constrainRules.enumValue({enumValue: String(enumValue.value), enumModel: context.metaModel, constrainedEnumModel: constrainedModel});
 
     const constrainedEnumValueModel = new ConstrainedEnumValueModel(constrainedEnumKey, constrainedEnumValue);
     constrainedModel.values.push(constrainedEnumValueModel);
   }
-  constrainedModel.type = getTypeFromMapping(typeMapping, {constrainedModel, renderer: context.renderer, propertyKey: context.propertyKey});
+  constrainedModel.type = getTypeFromMapping(typeMapping, {constrainedModel, options: context.options, propertyKey: context.propertyKey});
   return constrainedModel;
 }
 
-export function constrainMetaModel<R extends AbstractRenderer>(typeMapping: TypeMapping<R>, constrainRules: Constraints, context: ConstrainContext<R, MetaModel>): ConstrainedMetaModel {
+export function constrainMetaModel(typeMapping: TypeMapping<any>, constrainRules: Constraints, context: ConstrainContext<any, MetaModel>): ConstrainedMetaModel {
   const constrainedName = constrainRules.modelName({modelName: context.metaModel.name});
   const newContext = {...context, constrainedName};
   if (newContext.metaModel instanceof ObjectModel) {

--- a/src/helpers/TypeHelpers.ts
+++ b/src/helpers/TypeHelpers.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-unused-vars */
-import { AbstractRenderer } from '../generators';
 import { CommonModel } from '../models';
 import { ConstrainedAnyModel, ConstrainedBooleanModel, ConstrainedFloatModel, ConstrainedIntegerModel, ConstrainedMetaModel, ConstrainedObjectModel, ConstrainedReferenceModel, ConstrainedStringModel, ConstrainedTupleModel, ConstrainedArrayModel, ConstrainedUnionModel, ConstrainedEnumModel, ConstrainedDictionaryModel } from '../models/ConstrainedMetaModel';
 
@@ -26,30 +24,30 @@ export class TypeHelpers {
   }
 }
 
-export type TypeContext<T extends ConstrainedMetaModel, R extends AbstractRenderer> = {
+export type TypeContext<T extends ConstrainedMetaModel, Options> = {
   propertyKey?: string,
-  renderer: R,
+  options: Options,
   constrainedModel: T,
 }
 
-export type TypeMappingFunction<T extends ConstrainedMetaModel, R extends AbstractRenderer> = (context: TypeContext<T, R>) => string;
+export type TypeMappingFunction<T extends ConstrainedMetaModel, Options> = (context: TypeContext<T, Options>) => string;
 
-export type TypeMapping<R extends AbstractRenderer> = {
-  Object: TypeMappingFunction<ConstrainedObjectModel, R>,
-  Reference: TypeMappingFunction<ConstrainedReferenceModel, R>,
-  Any: TypeMappingFunction<ConstrainedAnyModel, R>,
-  Float: TypeMappingFunction<ConstrainedFloatModel, R>,
-  Integer: TypeMappingFunction<ConstrainedIntegerModel, R>,
-  String: TypeMappingFunction<ConstrainedStringModel, R>,
-  Boolean: TypeMappingFunction<ConstrainedBooleanModel, R>,
-  Tuple: TypeMappingFunction<ConstrainedTupleModel, R>,
-  Array: TypeMappingFunction<ConstrainedArrayModel, R>,
-  Enum: TypeMappingFunction<ConstrainedEnumModel, R>,
-  Union: TypeMappingFunction<ConstrainedUnionModel, R>,
-  Dictionary: TypeMappingFunction<ConstrainedDictionaryModel, R>
+export type TypeMapping<Options> = {
+  Object: TypeMappingFunction<ConstrainedObjectModel, Options>,
+  Reference: TypeMappingFunction<ConstrainedReferenceModel, Options>,
+  Any: TypeMappingFunction<ConstrainedAnyModel, Options>,
+  Float: TypeMappingFunction<ConstrainedFloatModel, Options>,
+  Integer: TypeMappingFunction<ConstrainedIntegerModel, Options>,
+  String: TypeMappingFunction<ConstrainedStringModel, Options>,
+  Boolean: TypeMappingFunction<ConstrainedBooleanModel, Options>,
+  Tuple: TypeMappingFunction<ConstrainedTupleModel, Options>,
+  Array: TypeMappingFunction<ConstrainedArrayModel, Options>,
+  Enum: TypeMappingFunction<ConstrainedEnumModel, Options>,
+  Union: TypeMappingFunction<ConstrainedUnionModel, Options>,
+  Dictionary: TypeMappingFunction<ConstrainedDictionaryModel, Options>
 };
 
-export function getTypeFromMapping<T extends ConstrainedMetaModel, R extends AbstractRenderer>(typeMapping: TypeMapping<R>, context: TypeContext<T, R>): string {
+export function getTypeFromMapping<T extends ConstrainedMetaModel, Options>(typeMapping: TypeMapping<Options>, context: TypeContext<T, Options>): string {
   if (context.constrainedModel instanceof ConstrainedObjectModel) {
     return typeMapping.Object({...context, constrainedModel: context.constrainedModel});
   } else if (context.constrainedModel instanceof ConstrainedReferenceModel) {

--- a/src/models/CommonInputModel.ts
+++ b/src/models/CommonInputModel.ts
@@ -1,9 +1,0 @@
-import { CommonModel } from './CommonModel';
-
-/**
- * This class is the wrapper for simplified models and the rest of the context needed for further generate typed models.
- */
-export class CommonInputModel {
-  models: {[key: string]: CommonModel} = {};
-  originalInput: any = {};
-}

--- a/src/models/ConstrainedMetaModel.ts
+++ b/src/models/ConstrainedMetaModel.ts
@@ -7,6 +7,11 @@ export abstract class ConstrainedMetaModel extends MetaModel {
     public type: string) {
     super(name, originalInput);
   }
+  /**
+   * Get the nearest constrained meta models for the constrained model.
+   * 
+   * This is often used when you want to know which other models you are referencing.
+   */
   abstract getNearestDependencies(): ConstrainedMetaModel[]
 }
 

--- a/src/models/InputMetaModel.ts
+++ b/src/models/InputMetaModel.ts
@@ -1,0 +1,9 @@
+import { MetaModel } from './MetaModel';
+
+/**
+ * Since each input processor can create multiple meta models this is a wrapper to a MetaModel to make that possible.
+ */
+export class InputMetaModel {
+  models: {[key: string]: MetaModel} = {};
+  originalInput: any = {};
+}

--- a/src/models/OutputModel.ts
+++ b/src/models/OutputModel.ts
@@ -1,11 +1,11 @@
-import { CommonInputModel } from './CommonInputModel';
-import { CommonModel } from './CommonModel';
+import { InputMetaModel } from './InputMetaModel';
+import { ConstrainedMetaModel } from './ConstrainedMetaModel';
 
 export interface ToOutputModelArg {
   result: string;
-  model: CommonModel;
+  model: ConstrainedMetaModel;
   modelName: string;
-  inputModel: CommonInputModel;
+  inputModel: InputMetaModel;
   dependencies: string[];
 }
 
@@ -15,9 +15,9 @@ export interface ToOutputModelArg {
 export class OutputModel {
   constructor(
     public readonly result: string,
-    public readonly model: CommonModel,
+    public readonly model: ConstrainedMetaModel,
     public readonly modelName: string,
-    public readonly inputModel: CommonInputModel,
+    public readonly inputModel: InputMetaModel,
     public readonly dependencies: string[]
   ) {}
 

--- a/src/models/Preset.ts
+++ b/src/models/Preset.ts
@@ -1,19 +1,19 @@
 /* eslint-disable @typescript-eslint/ban-types */
 import { AbstractRenderer } from '../generators/AbstractRenderer';
-import { CommonInputModel } from './CommonInputModel';
-import { CommonModel } from './CommonModel';
+import { InputMetaModel } from './InputMetaModel';
+import { ConstrainedEnumModel, ConstrainedEnumValueModel, ConstrainedMetaModel, ConstrainedObjectModel, ConstrainedObjectPropertyModel } from './ConstrainedMetaModel';
 
-export interface PresetArgs<R extends AbstractRenderer, O extends object = any> {
-  model: CommonModel;
-  inputModel: CommonInputModel;
+export interface PresetArgs<R extends AbstractRenderer, O, M extends ConstrainedMetaModel> {
+  model: M;
+  inputModel: InputMetaModel;
   renderer: R;
   options: O;
   content: string;
 }
 
-export interface CommonPreset<R extends AbstractRenderer, O extends object = any> {
-  self?: (args: PresetArgs<R, O>) => Promise<string> | string;
-  additionalContent?: (args: PresetArgs<R, O>) => Promise<string> | string;
+export interface CommonPreset<R extends AbstractRenderer, O, M extends ConstrainedMetaModel> {
+  self?: (args: PresetArgs<R, O, M>) => Promise<string> | string;
+  additionalContent?: (args: PresetArgs<R, O, M>) => Promise<string> | string;
 }
 
 export enum PropertyType {
@@ -22,31 +22,29 @@ export enum PropertyType {
   patternProperties
 }
 export interface PropertyArgs {
-  propertyName: string;
-  property: CommonModel;
-  type: PropertyType;
+  property: ConstrainedObjectPropertyModel;
 }
 
-export interface ClassPreset<R extends AbstractRenderer, O extends object = any> extends CommonPreset<R, O> {
-  ctor?: (args: PresetArgs<R, O>) => Promise<string> | string;
-  property?: (args: PresetArgs<R, O> & PropertyArgs) => Promise<string> | string;
-  getter?: (args: PresetArgs<R, O> & PropertyArgs) => Promise<string> | string;
-  setter?: (args: PresetArgs<R, O> & PropertyArgs) => Promise<string> | string;
+export interface ClassPreset<R extends AbstractRenderer, O> extends CommonPreset<R, O, ConstrainedObjectModel> {
+  ctor?: (args: PresetArgs<R, O, ConstrainedObjectModel>) => Promise<string> | string;
+  property?: (args: PresetArgs<R, O, ConstrainedObjectModel> & PropertyArgs) => Promise<string> | string;
+  getter?: (args: PresetArgs<R, O, ConstrainedObjectModel> & PropertyArgs) => Promise<string> | string;
+  setter?: (args: PresetArgs<R, O, ConstrainedObjectModel> & PropertyArgs) => Promise<string> | string;
 }
 
-export interface InterfacePreset<R extends AbstractRenderer, O extends object = any> extends CommonPreset<R, O> {
-  property?: (args: PresetArgs<R, O> & PropertyArgs) => Promise<string> | string;
+export interface InterfacePreset<R extends AbstractRenderer, O> extends CommonPreset<R, O, ConstrainedObjectModel> {
+  property?: (args: PresetArgs<R, O, ConstrainedObjectModel> & PropertyArgs) => Promise<string> | string;
 }
 
 export interface EnumArgs {
-  item: any;
+  item: ConstrainedEnumValueModel;
 }
 
-export interface EnumPreset<R extends AbstractRenderer, O extends object = any> extends CommonPreset<R, O> {
-  item?: (args: PresetArgs<R, O> & EnumArgs) => string;
+export interface EnumPreset<R extends AbstractRenderer, O> extends CommonPreset<R, O, ConstrainedEnumModel> {
+  item?: (args: PresetArgs<R, O, ConstrainedEnumModel> & EnumArgs) => string;
 }
 
-export type Preset<C extends Record<string, CommonPreset<any, any>> = any> = Partial<C>;
+export type Preset<C extends Record<string, CommonPreset<any, any, any>> = any> = Partial<C>;
 export type PresetWithOptions<P extends Preset = Preset, O = any> = {
   preset: P,
   options: O,

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,4 +1,4 @@
-export * from './CommonInputModel';
+export * from './InputMetaModel';
 export * from './CommonModel';
 export * from './RenderOutput';
 export * from './OutputModel';
@@ -12,4 +12,3 @@ export * from './SwaggerV2Schema';
 export * from './OpenapiV3Schema';
 export * from './MetaModel';
 export * from './ConstrainedMetaModel';
-


### PR DESCRIPTION
**This PR breaks compilation and jobs will fail which is expected until all the generators have been refactored. So failing jobs are from now on to be ignored.**

**Description**
This PR introduces a couple of changes:
1. Constrainers no longer have access to the renderer, as they have no reason to and it overcomplicates the entire setup with recursive dependencies. The only reason it was added, was because they needed access to the underlying options, that are now passed along instead.
2. Core models have gotten a new function called `getNearestDependencies` same as the last core model which is to be used to find the nearest dependencies. I am not 100% sure about the implementation and still need to add tests, but with a broken source code, this will be changed later.
3. Introduces `InputMetaModel` to replace `CommonInputModel`. 
