### PR TITLE
docs: fix example link, files not file

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -18,7 +18,7 @@ This directory contains a series of self-contained examples that you can use as 
 - [java-generate-javax-constraint-annotation](./java-generate-javax-constraint-annotation) - A basic example that shows how Java data models having `javax.validation.constraints` annotations can be generated.
 - [java-generate-javadoc](./java-generate-javadoc) - A basic example of how to generate Java models including JavaDocs.
 - [custom-logging](./custom-logging) - A basic example where a custom logger is used.
-- [generate-to-file](./generate-to-file) - A basic example that shows how you can generate the models directly to files.
+- [generate-to-files](./generate-to-files) - A basic example that shows how you can generate the models directly to files.
 - [TEMPLATE](./TEMPLATE) - A basic template used to create new examples.
 - [java-generate-tostring](./java-generate-tostring) - A basic example that shows how to generate models that overwrite the `toString` method
 - [csharp-generate-equals-and-hashcode](./csharp-generate-equals-and-hashcode) - A basic example on how to generate models that overwrite the `Equal` and `GetHashCode` methods


### PR DESCRIPTION
Small spelling mistake (which broke the link)