### PR TITLE
refactor: switch interpretation of pattern properties

### DIFF
--- a/docs/interpretation_of_JSON_Schema.md
+++ b/docs/interpretation_of_JSON_Schema.md
@@ -13,7 +13,7 @@ The order of interpretation:
 - `true` boolean schema infers all model types (`object`, `string`, `number`, `array`, `boolean`, `null`, `integer`) schemas.
 - `type` infers the initial model type.
 - `required` are interpreted as is.
-- `patternProperties` are interpreted as is, where duplicate patterns for the model are [merged](#Merging-models).
+- `patternProperties` are merged together with any additionalProperties, where duplicate additionalProperties are [merged](#Merging-models).
 - `additionalProperties` are interpreted as is, where duplicate additionalProperties for the model are [merged](#Merging-models). If the schema does not define `additionalProperties` it defaults to `true` schema.
 - `additionalItems` are interpreted as is, where duplicate additionalItems for the model are [merged](#Merging-models). If the schema does not define `additionalItems` it defaults to `true` schema.
 - `items` are interpreted as ether tuples or simple array, where more than 1 item are [merged](#Merging-models). Usage of `items` infers `array` model type.
@@ -53,7 +53,6 @@ Because of the recursive nature of the interpreter (and the nested nature of JSO
 
 If only one side has a property defined, it is used as is, if both have it defined they are merged based on the following logic (look [here](./input_processing.md#Internal-model-representation) for more information about the CommonModel and its properties):
 - `additionalProperties` if both models contain it the two are recursively merged together. 
-- `patternProperties` if both models contain a pattern the corresponding models are recursively merged together. 
 - `properties` if both models contain the same property the corresponding models are recursively merged together. 
 - `items` are merged together based on a couple of rules:
     - If both models are simple arrays those item models are merged together as is.

--- a/src/helpers/CommonModelToMetaModel.ts
+++ b/src/helpers/CommonModelToMetaModel.ts
@@ -140,21 +140,6 @@ export function convertToObjectModel(jsonSchemaModel: CommonModel, name: string)
       throw new Error('Property already exists');
     }
   }
-
-  if (jsonSchemaModel.patternProperties !== undefined) {
-    for (const [pattern, patternModel] of Object.entries(jsonSchemaModel.patternProperties)) {
-      const propertyName = `${pattern}_PatternProperty`;
-      if (metaModel.properties[String(propertyName)] === undefined) {
-        const keyModel = new StringModel(propertyName, pattern);
-        const valueModel = convertToMetaModel(patternModel);
-        const dictionaryModel = new DictionaryModel(propertyName, patternModel.originalInput, keyModel, valueModel, 'unwrap');
-        const propertyModel = new ObjectPropertyModel(propertyName, false, dictionaryModel);
-        metaModel.properties[String(propertyName)] = propertyModel;
-      } else {
-        throw new Error('Property already exists');
-      }
-    }
-  }
   return metaModel;
 }
 

--- a/src/interpreter/InterpretPatternProperties.ts
+++ b/src/interpreter/InterpretPatternProperties.ts
@@ -11,10 +11,10 @@ import { Interpreter, InterpreterOptions, InterpreterSchemaType } from './Interp
  */
 export default function interpretPatternProperties(schema: InterpreterSchemaType, model: CommonModel, interpreter : Interpreter, interpreterOptions: InterpreterOptions = Interpreter.defaultInterpreterOptions): void {
   if (typeof schema === 'boolean') {return;}
-  for (const [pattern, patternSchema] of Object.entries(schema.patternProperties || {})) {
+  for (const [,patternSchema] of Object.entries(schema.patternProperties || {})) {
     const patternModel = interpreter.interpret(patternSchema as any, interpreterOptions);
     if (patternModel !== undefined) {
-      model.addPatternProperty(pattern, patternModel, schema);
+      model.addAdditionalProperty(patternModel, schema);
     }
   }
 }

--- a/src/interpreter/PostInterpreter.ts
+++ b/src/interpreter/PostInterpreter.ts
@@ -50,12 +50,6 @@ function ensureModelsAreSplit(model: CommonModel, splitModels: CommonModel[], it
       model.properties[String(prop)] = trySplitModels(propSchema, splitModels, iteratedModels);
     }
   }
-  if (model.patternProperties) {
-    const existingPatternProperties = model.patternProperties;
-    for (const [pattern, patternModel] of Object.entries(existingPatternProperties)) {
-      model.patternProperties[String(pattern)] = trySplitModels(patternModel, splitModels, iteratedModels);
-    }
-  }
   if (model.additionalProperties) {
     model.additionalProperties = trySplitModels(model.additionalProperties, splitModels, iteratedModels);
   }

--- a/src/models/CommonModel.ts
+++ b/src/models/CommonModel.ts
@@ -12,7 +12,6 @@ export class CommonModel {
   items?: CommonModel | CommonModel[];
   properties?: { [key: string]: CommonModel; };
   additionalProperties?: CommonModel;
-  patternProperties?: { [key: string]: CommonModel; };
   $ref?: string;
   required?: string[];
   additionalItems?: CommonModel;
@@ -278,24 +277,6 @@ export class CommonModel {
   }
   
   /**
-   * Adds a patternProperty to the model.
-   * If the pattern already exist the two models are merged.
-   * 
-   * @param pattern 
-   * @param patternModel 
-   * @param originalInput corresponding input that got interpreted to this model 
-   */
-  addPatternProperty(pattern: string, patternModel: CommonModel, originalInput: any): void {
-    if (this.patternProperties === undefined) {this.patternProperties = {};}
-    if (this.patternProperties[`${pattern}`] !== undefined) {
-      Logger.warn(`While trying to add patternProperty to model, duplicate patterns found. Merging pattern models together for pattern ${pattern}`, patternModel, originalInput, this);
-      this.patternProperties[String(pattern)] = CommonModel.mergeCommonModels(this.patternProperties[String(pattern)], patternModel, originalInput);
-    } else {
-      this.patternProperties[String(pattern)] = patternModel;
-    }
-  }
-  
-  /**
    * Adds another model this model should extend.
    * 
    * It is only allowed to extend if the other model have $id and is not already being extended.
@@ -341,11 +322,6 @@ export class CommonModel {
     if (this.properties !== undefined && Object.keys(this.properties).length) {
       for (const property of Object.values(this.properties)) {
         dependsOn.push(...property.getNearestDependencies());
-      }
-    }
-    if (this.patternProperties !== undefined && Object.keys(this.patternProperties).length) {
-      for (const patternProperty of Object.values(this.patternProperties)) {
-        dependsOn.push(...patternProperty.getNearestDependencies());
       }
     }
     if (this.additionalItems !== undefined) {
@@ -417,32 +393,6 @@ export class CommonModel {
       } else {
         Logger.warn(`Found duplicate additionalItems for model. additionalItems from ${mergeFrom.$id || 'unknown'} merged into ${mergeTo.$id || 'unknown'}`, mergeTo, mergeFrom, originalInput);
         mergeTo.additionalItems = CommonModel.mergeCommonModels(mergeToAdditionalItems, mergeFromAdditionalItems, originalInput, alreadyIteratedModels);
-      }
-    }
-  }
-  /**
-   * Merge two common model pattern properties together 
-   * 
-   * @param mergeTo 
-   * @param mergeFrom 
-   * @param originalInput corresponding input that got interpreted to this model 
-   * @param alreadyIteratedModels
-   */
-  private static mergePatternProperties(mergeTo: CommonModel, mergeFrom: CommonModel, originalInput: any, alreadyIteratedModels: Map<CommonModel, CommonModel> = new Map()) {
-    const mergeToPatternProperties = mergeTo.patternProperties;
-    const mergeFromPatternProperties = mergeFrom.patternProperties;
-    if (mergeFromPatternProperties !== undefined) {
-      if (mergeToPatternProperties === undefined) {
-        mergeTo.patternProperties = mergeFromPatternProperties;
-      } else {
-        for (const [pattern, patternModel] of Object.entries(mergeFromPatternProperties)) {
-          if (mergeToPatternProperties[String(pattern)] !== undefined) {
-            Logger.warn(`Found duplicate pattern ${pattern} for model. Model pattern for ${mergeFrom.$id || 'unknown'} merged into ${mergeTo.$id || 'unknown'}`, mergeTo, mergeFrom, originalInput);
-            mergeToPatternProperties[String(pattern)] = CommonModel.mergeCommonModels(mergeToPatternProperties[String(pattern)], patternModel, originalInput, alreadyIteratedModels);
-          } else {
-            mergeToPatternProperties[String(pattern)] = patternModel;
-          }
-        }
       }
     }
   }
@@ -530,7 +480,6 @@ export class CommonModel {
 
     CommonModel.mergeAdditionalProperties(mergeTo, mergeFrom, originalInput, alreadyIteratedModels);
     CommonModel.mergeAdditionalItems(mergeTo, mergeFrom, originalInput, alreadyIteratedModels);
-    CommonModel.mergePatternProperties(mergeTo, mergeFrom, originalInput, alreadyIteratedModels);
     CommonModel.mergeProperties(mergeTo, mergeFrom, originalInput, alreadyIteratedModels);
     CommonModel.mergeItems(mergeTo, mergeFrom, originalInput, alreadyIteratedModels);
     CommonModel.mergeTypes(mergeTo, mergeFrom);

--- a/test/helpers/CommonModelToMetaModel.spec.ts
+++ b/test/helpers/CommonModelToMetaModel.spec.ts
@@ -96,25 +96,6 @@ describe('CommonModelToMetaModel', () => {
     expect(model instanceof ObjectModel).toEqual(true);
     expect((model as ObjectModel).properties['additionalProperties']).not.toBeUndefined();
   });
-  test('should convert to object model with pattern properties', () => { 
-    const spm = new CommonModel();
-    spm.type = 'string';
-    const cm = new CommonModel();
-    cm.type = 'object';
-    cm.$id = 'test';
-    cm.properties = {
-      test: spm
-    };
-    cm.patternProperties = {
-      test: spm
-    };
-    
-    const model = convertToMetaModel(cm);
-
-    expect(model).not.toBeUndefined();
-    expect(model instanceof ObjectModel).toEqual(true);
-    expect((model as ObjectModel).properties['test_PatternProperty']).not.toBeUndefined();
-  });
   test('should convert normal array to array model', () => { 
     const spm = new CommonModel();
     spm.type = 'string';

--- a/test/interpreter/PostInterpreter.spec.ts
+++ b/test/interpreter/PostInterpreter.spec.ts
@@ -201,36 +201,6 @@ describe('PostInterpreter', () => {
       expect(postProcessedModels[0]).toMatchObject(expectedSchema1Model);
       expect(postProcessedModels[1]).toMatchObject(expectedSchema2Model);
     });
-    test('should split models if patternProperties contains model object', () => {
-      const rawModel = {
-        $id: 'schema1',
-        patternProperties: {
-          testPattern: {
-            $id: 'schema2',
-            type: 'object'
-          }
-        }
-      };  
-      const model = CommonModel.toCommonModel(rawModel);
-      (isModelObject as jest.Mock).mockReturnValue(true);
-
-      const postProcessedModels = postInterpretModel(model);
-
-      const expectedSchema1Model = new CommonModel();
-      expectedSchema1Model.$id = 'schema1';
-      const expectedPatternModel = new CommonModel();
-      expectedPatternModel.$ref = 'schema2';
-      expectedSchema1Model.patternProperties = {
-        testPattern: expectedPatternModel
-      };
-      const expectedSchema2Model = new CommonModel();
-      expectedSchema2Model.$id = 'schema2';
-
-      expect(postProcessedModels).toHaveLength(2);
-      expect(isModelObject).toHaveBeenNthCalledWith(1, rawModel.patternProperties!['testPattern']);
-      expect(postProcessedModels[0]).toMatchObject(expectedSchema1Model);
-      expect(postProcessedModels[1]).toMatchObject(expectedSchema2Model);
-    });
     test('should split models if additionalProperties contains model object', () => {
       const rawModel = {
         $id: 'schema1',

--- a/test/interpreter/unit/patternProperties.spec.ts
+++ b/test/interpreter/unit/patternProperties.spec.ts
@@ -22,7 +22,7 @@ describe('Interpretation of patternProperties', () => {
 
     interpretPatternProperties({}, model, interpreter);
 
-    expect(model.addPatternProperty).not.toHaveBeenCalled();
+    expect(model.addAdditionalProperty).not.toHaveBeenCalled();
   });
   test('should not do anything if schema is boolean', () => {
     const model = new CommonModel();
@@ -32,7 +32,7 @@ describe('Interpretation of patternProperties', () => {
 
     interpretPatternProperties(true, model, interpreter);
 
-    expect(model.addPatternProperty).not.toHaveBeenCalled();
+    expect(model.addAdditionalProperty).not.toHaveBeenCalled();
   });
 
   test('should ignore model if interpreter cannot interpret patternProperties schema', () => {
@@ -44,7 +44,7 @@ describe('Interpretation of patternProperties', () => {
 
     interpretPatternProperties(schema, model, interpreter);
 
-    expect(model.addPatternProperty).not.toHaveBeenCalled();
+    expect(model.addAdditionalProperty).not.toHaveBeenCalled();
   });
   test('should use as is', () => {
     const schema: any = { patternProperties: { pattern: { type: 'string' } } };
@@ -56,6 +56,6 @@ describe('Interpretation of patternProperties', () => {
     interpretPatternProperties(schema, model, interpreter);
     
     expect(interpreter.interpret).toHaveBeenNthCalledWith(1, { type: 'string' }, Interpreter.defaultInterpreterOptions);
-    expect(model.addPatternProperty).toHaveBeenNthCalledWith(1, 'pattern', mockedReturnModel, schema);
+    expect(model.addAdditionalProperty).toHaveBeenNthCalledWith(1, mockedReturnModel, schema);
   });
 });


### PR DESCRIPTION
**Description**
This PR changes the functionality for how patternProperties are interpreted, by merging the structures into `additionalProperties` to only have a single property that contains all "extra" properties. 

This change is because Modelina does not have runtime constraints (and might never have, or at least far out in the future), which means you cannot really have multiple dictionaries with unwrapping serialization options. This makes sure JSON Schema never creates that scenario.
