### PR TITLE
chore: remove unnecessary common model test

### DIFF
--- a/test/models/CommonModel.spec.ts
+++ b/test/models/CommonModel.spec.ts
@@ -532,42 +532,6 @@ describe('CommonModel', () => {
         expect(doc1.additionalItems).toBeUndefined();
       });
     });
-
-    describe('patternProperties', () => {
-      test('should be merged when only right side is defined', () => {
-        const doc = { };
-        let doc1 = CommonModel.toCommonModel(doc);
-        const doc2 = CommonModel.toCommonModel(doc);
-        doc2.patternProperties = {pattern1: CommonModel.toCommonModel({type: 'string'})};
-        doc1 = CommonModel.mergeCommonModels(doc1, doc2, doc);
-        expect(doc1.patternProperties).toEqual(doc2.patternProperties);
-      });
-      test('should be merged when both sides are defined', () => {
-        const doc = { };
-        let doc1 = CommonModel.toCommonModel(doc);
-        const doc2 = CommonModel.toCommonModel(doc);
-        doc2.patternProperties = {pattern1: CommonModel.toCommonModel({type: 'string'})};
-        doc1.patternProperties = {pattern2: CommonModel.toCommonModel({type: 'number'})};
-        doc1 = CommonModel.mergeCommonModels(doc1, doc2, doc);
-        expect(doc1.patternProperties).toEqual({pattern1: {type: 'string'}, pattern2: {type: 'number'}});
-      });
-      test('should be merged together when both sides are defined', () => {
-        const doc = { };
-        let doc1 = CommonModel.toCommonModel(doc);
-        const doc2 = CommonModel.toCommonModel(doc);
-        doc2.patternProperties = {pattern1: CommonModel.toCommonModel({type: 'string'})};
-        doc1.patternProperties = {pattern1: CommonModel.toCommonModel({type: 'number'})};
-        doc1 = CommonModel.mergeCommonModels(doc1, doc2, doc);
-        expect(doc1.patternProperties).toEqual({pattern1: {type: ['number', 'string'], originalInput: {}}});
-      });
-      test('should not change if nothing is defined', () => {
-        const doc = { };
-        let doc1 = CommonModel.toCommonModel(doc);
-        const doc2 = CommonModel.toCommonModel(doc);
-        doc1 = CommonModel.mergeCommonModels(doc1, doc2, doc);
-        expect(doc1.patternProperties).toBeUndefined();
-      });
-    });
   });
   
   describe('addItem', () => {
@@ -756,33 +720,6 @@ describe('CommonModel', () => {
       model.addAdditionalItems(additionalItemsModel, {});
       expect(model.additionalItems).toEqual(additionalItemsModel);
       expect(CommonModel.mergeCommonModels).toHaveBeenNthCalledWith(1, additionalItemsModel, additionalItemsModel, {});
-    });
-  });
-  describe('addPatternProperty', () => {
-    beforeAll(() => {
-      jest.spyOn(CommonModel, 'mergeCommonModels');
-    });
-    afterEach(() => {
-      jest.clearAllMocks();
-    });
-    test('should add patternProperty to model', () => {
-      const patternPropertyModel = new CommonModel();
-      const pattern = 'TestPattern';
-      patternPropertyModel.$id = 'test'; 
-      const model = new CommonModel(); 
-      model.addPatternProperty(pattern, patternPropertyModel, {});
-      expect(model.patternProperties).toEqual({TestPattern: patternPropertyModel});
-      expect(CommonModel.mergeCommonModels).not.toHaveBeenCalled();
-    });
-    test('should merge additionalProperties together', () => {
-      const patternPropertyModel = new CommonModel();
-      const pattern = 'TestPattern';
-      patternPropertyModel.$id = 'test'; 
-      const model = new CommonModel(); 
-      model.addPatternProperty(pattern, patternPropertyModel, {});
-      model.addPatternProperty(pattern, patternPropertyModel, {});
-      expect(model.patternProperties).toEqual({TestPattern: patternPropertyModel});
-      expect(CommonModel.mergeCommonModels).toHaveBeenNthCalledWith(1, patternPropertyModel, patternPropertyModel, {});
     });
   });
   describe('addEnum', () => {


### PR DESCRIPTION
**Description**
As we removed the patternProperty for CommonModel this test is no longer needed.