### PR TITLE
chore: fix contains property check failing

### DIFF
--- a/src/models/ConstrainedMetaModel.ts
+++ b/src/models/ConstrainedMetaModel.ts
@@ -202,8 +202,8 @@ export class ConstrainedObjectModel extends ConstrainedMetaModel {
    */
   containsPropertyType<T>(propertyType: { new(...args: any[]): T }) : boolean {
     const foundPropertiesWithType = Object.values(this.properties).filter((property) => {
-      return property instanceof propertyType;
+      return property.property instanceof propertyType;
     });
-    return foundPropertiesWithType.length === 0;
+    return foundPropertiesWithType.length !== 0;
   }
 }

--- a/test/models/ConstrainedMetaModel.spec.ts
+++ b/test/models/ConstrainedMetaModel.spec.ts
@@ -4,17 +4,6 @@ import { mockedConstraints, mockedTypeMapping } from '../TestUtils/TestConstrain
 
 
 describe('ConstrainedMetaModel', () => {
-  describe('containsPropertyType', () => {
-    test('should find present property type and those who are not', () => {
-      const stringModel = new ConstrainedStringModel('', undefined, '');
-      const stringObjectPropertyModel = new ConstrainedObjectPropertyModel('string', '', false, stringModel);
-      const rawModel = new ConstrainedObjectModel('test', undefined, '', {
-        string: stringObjectPropertyModel
-      });
-      expect(rawModel.containsPropertyType(ConstrainedStringModel)).toEqual(true);
-      expect(rawModel.containsPropertyType(ConstrainedBooleanModel)).toEqual(false);
-    });
-  });
   describe('ReferenceModel', () => {
     test('should return no dependencies', () => {
       const stringModel = new StringModel('', undefined);
@@ -131,6 +120,18 @@ describe('ConstrainedMetaModel', () => {
       const dependencies = model.getNearestDependencies();
       expect(dependencies).toHaveLength(1);
       expect(dependencies[0]).toEqual(model.properties['reference'].property);
+    });
+
+    describe('containsPropertyType', () => {
+      test('should find present property type and those who are not', () => {
+        const stringModel = new ConstrainedStringModel('', undefined, '');
+        const stringObjectPropertyModel = new ConstrainedObjectPropertyModel('string', '', false, stringModel);
+        const rawModel = new ConstrainedObjectModel('test', undefined, '', {
+          string: stringObjectPropertyModel
+        });
+        expect(rawModel.containsPropertyType(ConstrainedStringModel)).toEqual(true);
+        expect(rawModel.containsPropertyType(ConstrainedBooleanModel)).toEqual(false);
+      });
     });
   });
   describe('EnumModel', () => {

--- a/test/models/ConstrainedMetaModel.spec.ts
+++ b/test/models/ConstrainedMetaModel.spec.ts
@@ -1,8 +1,20 @@
 import { constrainMetaModel } from '../../src/helpers';
-import { AnyModel, ArrayModel, BooleanModel, ConstrainedArrayModel, ConstrainedDictionaryModel, ConstrainedEnumModel, ConstrainedObjectModel, ConstrainedReferenceModel, ConstrainedTupleModel, ConstrainedUnionModel, DictionaryModel, EnumModel, EnumValueModel, FloatModel, IntegerModel, ObjectModel, ObjectPropertyModel, ReferenceModel, StringModel, TupleModel, TupleValueModel, UnionModel } from '../../src/models';
+import { AnyModel, ArrayModel, BooleanModel, ConstrainedArrayModel, ConstrainedBooleanModel, ConstrainedDictionaryModel, ConstrainedEnumModel, ConstrainedObjectModel, ConstrainedObjectPropertyModel, ConstrainedReferenceModel, ConstrainedStringModel, ConstrainedTupleModel, ConstrainedUnionModel, DictionaryModel, EnumModel, EnumValueModel, FloatModel, IntegerModel, ObjectModel, ObjectPropertyModel, ReferenceModel, StringModel, TupleModel, TupleValueModel, UnionModel } from '../../src/models';
 import { mockedConstraints, mockedTypeMapping } from '../TestUtils/TestConstrainer';
 
+
 describe('ConstrainedMetaModel', () => {
+  describe('containsPropertyType', () => {
+    test('should find present property type and those who are not', () => {
+      const stringModel = new ConstrainedStringModel('', undefined, '');
+      const stringObjectPropertyModel = new ConstrainedObjectPropertyModel('string', '', false, stringModel);
+      const rawModel = new ConstrainedObjectModel('test', undefined, '', {
+        string: stringObjectPropertyModel
+      });
+      expect(rawModel.containsPropertyType(ConstrainedStringModel)).toEqual(true);
+      expect(rawModel.containsPropertyType(ConstrainedBooleanModel)).toEqual(false);
+    });
+  });
   describe('ReferenceModel', () => {
     test('should return no dependencies', () => {
       const stringModel = new StringModel('', undefined);


### PR DESCRIPTION
**Description**
This PR fixes and tests the `containsPropertyType` function from the ObjectModel