### PR TITLE
fix: generate Jackson annotations for Java enums only with Jackson Preset

### DIFF
--- a/src/generators/java/JavaPreset.ts
+++ b/src/generators/java/JavaPreset.ts
@@ -1,11 +1,17 @@
 /* eslint-disable @typescript-eslint/ban-types */
-import { Preset, ClassPreset, EnumPreset } from '../../models';
+import { Preset, ClassPreset, EnumPreset, PresetArgs, EnumArgs } from '../../models';
 import { ClassRenderer, JAVA_DEFAULT_CLASS_PRESET } from './renderers/ClassRenderer';
 import { EnumRenderer, JAVA_DEFAULT_ENUM_PRESET } from './renderers/EnumRenderer';
 
+export interface JavaEnumPreset<O extends object = any> extends EnumPreset<EnumRenderer, O> {
+  ctor?: (args: PresetArgs<EnumRenderer, O> & EnumArgs) => string;
+  getValue?: (args: PresetArgs<EnumRenderer, O> & EnumArgs) => string;
+  fromValue?: (args: PresetArgs<EnumRenderer, O> & EnumArgs) => string;
+}
+
 export type JavaPreset<O extends object = any> = Preset<{
   class: ClassPreset<ClassRenderer, O>;
-  enum: EnumPreset<EnumRenderer, O>;
+  enum: JavaEnumPreset<O>;
 }>;
 
 export const JAVA_DEFAULT_PRESET: JavaPreset = {

--- a/src/generators/java/presets/JacksonPreset.ts
+++ b/src/generators/java/presets/JacksonPreset.ts
@@ -19,5 +19,43 @@ export const JAVA_JACKSON_PRESET: JavaPreset = {
       }
       return renderer.renderBlock([content]);
     },
+  },
+  enum: {
+    self({renderer, content}) {
+      renderer.addDependency('import com.fasterxml.jackson.annotation.*;');
+      return content;
+    },
+    additionalContent({ renderer, model }) {
+      const enumName = renderer.nameType(model.$id);
+      const type = Array.isArray(model.type) ? 'Object' : model.type;
+      const classType = renderer.toClassType(renderer.toJavaType(type, model));
+
+      return `private ${classType} value;
+    
+${enumName}(${classType} value) {
+  this.value = value;
+}
+    
+@JsonValue
+public ${classType} getValue() {
+  return value;
+}
+
+@Override
+public String toString() {
+  return String.valueOf(value);
+}
+
+@JsonCreator
+public static ${enumName} fromValue(${classType} value) {
+  for (${enumName} e : ${enumName}.values()) {
+    if (e.value.equals(value)) {
+      return e;
+    }
+  }
+  throw new IllegalArgumentException("Unexpected value '" + value + "'");
+}`;
+    },
+
   }
 };

--- a/src/generators/java/presets/JacksonPreset.ts
+++ b/src/generators/java/presets/JacksonPreset.ts
@@ -3,7 +3,7 @@ import { JavaPreset } from '../JavaPreset';
 
 /**
  * Preset which adds `com.fasterxml.jackson` related annotations to class's property getters.
- * 
+ *
  * @implements {JavaPreset}
  */
 export const JAVA_JACKSON_PRESET: JavaPreset = {
@@ -12,7 +12,7 @@ export const JAVA_JACKSON_PRESET: JavaPreset = {
       renderer.addDependency('import com.fasterxml.jackson.annotation.*;');
       return content;
     },
-    getter({ renderer, propertyName, content, type }) {
+    getter({renderer, propertyName, content, type}) {
       if (type === PropertyType.property) {
         const annotation = renderer.renderAnnotation('JsonProperty', `"${propertyName}"`);
         return renderer.renderBlock([annotation, content]);
@@ -25,37 +25,13 @@ export const JAVA_JACKSON_PRESET: JavaPreset = {
       renderer.addDependency('import com.fasterxml.jackson.annotation.*;');
       return content;
     },
-    additionalContent({ renderer, model }) {
-      const enumName = renderer.nameType(model.$id);
-      const type = Array.isArray(model.type) ? 'Object' : model.type;
-      const classType = renderer.toClassType(renderer.toJavaType(type, model));
-
-      return `private ${classType} value;
-    
-${enumName}(${classType} value) {
-  this.value = value;
-}
-    
-@JsonValue
-public ${classType} getValue() {
-  return value;
-}
-
-@Override
-public String toString() {
-  return String.valueOf(value);
-}
-
-@JsonCreator
-public static ${enumName} fromValue(${classType} value) {
-  for (${enumName} e : ${enumName}.values()) {
-    if (e.value.equals(value)) {
-      return e;
-    }
-  }
-  throw new IllegalArgumentException("Unexpected value '" + value + "'");
-}`;
+    getValue({content}) {
+      return `@JsonValue
+${content}`;
     },
-
+    fromValue({content}) {
+      return `@JsonCreator
+${content}`;
+    },
   }
 };

--- a/src/generators/java/renderers/EnumRenderer.ts
+++ b/src/generators/java/renderers/EnumRenderer.ts
@@ -76,7 +76,6 @@ ${this.indent(this.renderBlock(content, 2))}
 
 export const JAVA_DEFAULT_ENUM_PRESET: EnumPreset<EnumRenderer> = {
   self({ renderer }) {
-    renderer.addDependency('import com.fasterxml.jackson.annotation.*;');
     return renderer.defaultSelf();
   },
   item({ renderer, item }) {
@@ -95,7 +94,6 @@ ${enumName}(${classType} value) {
   this.value = value;
 }
     
-@JsonValue
 public ${classType} getValue() {
   return value;
 }
@@ -105,7 +103,6 @@ public String toString() {
   return String.valueOf(value);
 }
 
-@JsonCreator
 public static ${enumName} fromValue(${classType} value) {
   for (${enumName} e : ${enumName}.values()) {
     if (e.value.equals(value)) {

--- a/src/generators/java/renderers/EnumRenderer.ts
+++ b/src/generators/java/renderers/EnumRenderer.ts
@@ -4,13 +4,16 @@ import { FormatHelpers } from '../../../helpers';
 
 /**
  * Renderer for Java's `enum` type
- * 
+ *
  * @extends JavaRenderer
  */
 export class EnumRenderer extends JavaRenderer {
   async defaultSelf(): Promise<string> {
     const content = [
       await this.renderItems(),
+      await this.runCtorPreset(),
+      await this.runGetValuePreset(),
+      await this.runFromValuePreset(),
       await this.runAdditionalContentPreset()
     ];
     const formattedName = this.nameType(this.model.$id);
@@ -49,7 +52,7 @@ ${this.indent(this.renderBlock(content, 2))}
       break;
     }
     default: {
-      key = FormatHelpers.replaceSpecialCharacters(String(value), { exclude: [' ', '_'], separator: '_' });
+      key = FormatHelpers.replaceSpecialCharacters(String(value), {exclude: [' ', '_'], separator: '_'});
       //Ensure no special char can be the beginning letter 
       if (!(/^[a-zA-Z]+$/).test(key.charAt(0))) {
         key = `string_${key}`;
@@ -70,40 +73,53 @@ ${this.indent(this.renderBlock(content, 2))}
   }
 
   runItemPreset(item: any): Promise<string> {
-    return this.runPreset('item', { item });
+    return this.runPreset('item', {item});
+  }
+
+  runCtorPreset(): Promise<string> {
+    return this.runPreset('ctor');
+  }
+
+  runGetValuePreset(): Promise<string> {
+    return this.runPreset('getValue');
+  }
+
+  runFromValuePreset(): Promise<string> {
+    return this.runPreset('fromValue');
   }
 }
 
 export const JAVA_DEFAULT_ENUM_PRESET: EnumPreset<EnumRenderer> = {
-  self({ renderer }) {
+  self({renderer}) {
     return renderer.defaultSelf();
   },
-  item({ renderer, item }) {
+  item({renderer, item}) {
     const key = renderer.normalizeKey(item);
     const value = renderer.normalizeValue(item);
     return `${key}(${value})`;
   },
-  additionalContent({ renderer, model }) {
+  ctor({renderer, model}) {
     const enumName = renderer.nameType(model.$id);
     const type = Array.isArray(model.type) ? 'Object' : model.type;
     const classType = renderer.toClassType(renderer.toJavaType(type, model));
-
     return `private ${classType} value;
 
 ${enumName}(${classType} value) {
   this.value = value;
-}
-    
-public ${classType} getValue() {
+}`;
+  },
+  getValue({renderer, model}) {
+    const type = Array.isArray(model.type) ? 'Object' : model.type;
+    const classType = renderer.toClassType(renderer.toJavaType(type, model));
+    return `public ${classType} getValue() {
   return value;
-}
-
-@Override
-public String toString() {
-  return String.valueOf(value);
-}
-
-public static ${enumName} fromValue(${classType} value) {
+}`;
+  },
+  fromValue({renderer, model}) {
+    const enumName = renderer.nameType(model.$id);
+    const type = Array.isArray(model.type) ? 'Object' : model.type;
+    const classType = renderer.toClassType(renderer.toJavaType(type, model));
+    return `public static ${enumName} fromValue(${classType} value) {
   for (${enumName} e : ${enumName}.values()) {
     if (e.value.equals(value)) {
       return e;
@@ -112,4 +128,10 @@ public static ${enumName} fromValue(${classType} value) {
   throw new IllegalArgumentException("Unexpected value '" + value + "'");
 }`;
   },
+  additionalContent() {
+    return `@Override
+public String toString() {
+  return String.valueOf(value);
+}`;
+  }
 };

--- a/src/generators/java/renderers/EnumRenderer.ts
+++ b/src/generators/java/renderers/EnumRenderer.ts
@@ -1,6 +1,6 @@
 import { JavaRenderer } from '../JavaRenderer';
-import { EnumPreset } from '../../../models';
 import { FormatHelpers } from '../../../helpers';
+import { JavaEnumPreset } from '../JavaPreset';
 
 /**
  * Renderer for Java's `enum` type
@@ -89,7 +89,7 @@ ${this.indent(this.renderBlock(content, 2))}
   }
 }
 
-export const JAVA_DEFAULT_ENUM_PRESET: EnumPreset<EnumRenderer> = {
+export const JAVA_DEFAULT_ENUM_PRESET: JavaEnumPreset = {
   self({renderer}) {
     return renderer.defaultSelf();
   },

--- a/src/models/Preset.ts
+++ b/src/models/Preset.ts
@@ -44,6 +44,9 @@ export interface EnumArgs {
 
 export interface EnumPreset<R extends AbstractRenderer, O extends object = any> extends CommonPreset<R, O> {
   item?: (args: PresetArgs<R, O> & EnumArgs) => string;
+  ctor?: (args: PresetArgs<R, O> & EnumArgs) => string;
+  getValue?: (args: PresetArgs<R, O> & EnumArgs) => string;
+  fromValue?: (args: PresetArgs<R, O> & EnumArgs) => string;
 }
 
 export type Preset<C extends Record<string, CommonPreset<any, any>> = any> = Partial<C>;

--- a/src/models/Preset.ts
+++ b/src/models/Preset.ts
@@ -44,9 +44,6 @@ export interface EnumArgs {
 
 export interface EnumPreset<R extends AbstractRenderer, O extends object = any> extends CommonPreset<R, O> {
   item?: (args: PresetArgs<R, O> & EnumArgs) => string;
-  ctor?: (args: PresetArgs<R, O> & EnumArgs) => string;
-  getValue?: (args: PresetArgs<R, O> & EnumArgs) => string;
-  fromValue?: (args: PresetArgs<R, O> & EnumArgs) => string;
 }
 
 export type Preset<C extends Record<string, CommonPreset<any, any>> = any> = Partial<C>;

--- a/test/generators/java/JavaGenerator.spec.ts
+++ b/test/generators/java/JavaGenerator.spec.ts
@@ -182,14 +182,9 @@ describe('JavaGenerator', () => {
   States(String value) {
     this.value = value;
   }
-    
+
   public String getValue() {
     return value;
-  }
-
-  @Override
-  public String toString() {
-    return String.valueOf(value);
   }
 
   public static States fromValue(String value) {
@@ -199,6 +194,11 @@ describe('JavaGenerator', () => {
       }
     }
     throw new IllegalArgumentException("Unexpected value '" + value + "'");
+  }
+
+  @Override
+  public String toString() {
+    return String.valueOf(value);
   }
 }`;
 
@@ -228,14 +228,9 @@ describe('JavaGenerator', () => {
   Numbers(Integer value) {
     this.value = value;
   }
-    
+
   public Integer getValue() {
     return value;
-  }
-
-  @Override
-  public String toString() {
-    return String.valueOf(value);
   }
 
   public static Numbers fromValue(Integer value) {
@@ -245,6 +240,11 @@ describe('JavaGenerator', () => {
       }
     }
     throw new IllegalArgumentException("Unexpected value '" + value + "'");
+  }
+
+  @Override
+  public String toString() {
+    return String.valueOf(value);
   }
 }`;
 
@@ -274,14 +274,9 @@ describe('JavaGenerator', () => {
   Union(Object value) {
     this.value = value;
   }
-    
+
   public Object getValue() {
     return value;
-  }
-
-  @Override
-  public String toString() {
-    return String.valueOf(value);
   }
 
   public static Union fromValue(Object value) {
@@ -291,6 +286,11 @@ describe('JavaGenerator', () => {
       }
     }
     throw new IllegalArgumentException("Unexpected value '" + value + "'");
+  }
+
+  @Override
+  public String toString() {
+    return String.valueOf(value);
   }
 }`;
 
@@ -321,14 +321,9 @@ public enum CustomEnum {
   CustomEnum(String value) {
     this.value = value;
   }
-    
+
   public String getValue() {
     return value;
-  }
-
-  @Override
-  public String toString() {
-    return String.valueOf(value);
   }
 
   public static CustomEnum fromValue(String value) {
@@ -338,6 +333,11 @@ public enum CustomEnum {
       }
     }
     throw new IllegalArgumentException("Unexpected value '" + value + "'");
+  }
+
+  @Override
+  public String toString() {
+    return String.valueOf(value);
   }
 }`;
 
@@ -377,14 +377,9 @@ public enum CustomEnum {
   States(String value) {
     this.value = value;
   }
-    
+
   public String getValue() {
     return value;
-  }
-
-  @Override
-  public String toString() {
-    return String.valueOf(value);
   }
 
   public static States fromValue(String value) {
@@ -394,6 +389,11 @@ public enum CustomEnum {
       }
     }
     throw new IllegalArgumentException("Unexpected value '" + value + "'");
+  }
+
+  @Override
+  public String toString() {
+    return String.valueOf(value);
   }
 }`;
 

--- a/test/generators/java/JavaGenerator.spec.ts
+++ b/test/generators/java/JavaGenerator.spec.ts
@@ -183,7 +183,6 @@ describe('JavaGenerator', () => {
     this.value = value;
   }
     
-  @JsonValue
   public String getValue() {
     return value;
   }
@@ -193,7 +192,6 @@ describe('JavaGenerator', () => {
     return String.valueOf(value);
   }
 
-  @JsonCreator
   public static States fromValue(String value) {
     for (States e : States.values()) {
       if (e.value.equals(value)) {
@@ -208,13 +206,12 @@ describe('JavaGenerator', () => {
     const model = inputModel.models['States'];
 
     let enumModel = await generator.renderEnum(model, inputModel);
-    const expectedDependencies = ['import com.fasterxml.jackson.annotation.*;'];
     expect(enumModel.result).toEqual(expected);
-    expect(enumModel.dependencies).toEqual(expectedDependencies);
+    expect(enumModel.dependencies.length).toEqual(0);
 
     enumModel = await generator.render(model, inputModel);
     expect(enumModel.result).toEqual(expected);
-    expect(enumModel.dependencies).toEqual(expectedDependencies);
+    expect(enumModel.dependencies.length).toEqual(0);
   });
 
   test('should render `enum` type (integer type)', async () => {
@@ -232,7 +229,6 @@ describe('JavaGenerator', () => {
     this.value = value;
   }
     
-  @JsonValue
   public Integer getValue() {
     return value;
   }
@@ -242,7 +238,6 @@ describe('JavaGenerator', () => {
     return String.valueOf(value);
   }
 
-  @JsonCreator
   public static Numbers fromValue(Integer value) {
     for (Numbers e : Numbers.values()) {
       if (e.value.equals(value)) {
@@ -257,13 +252,12 @@ describe('JavaGenerator', () => {
     const model = inputModel.models['Numbers'];
 
     let enumModel = await generator.renderEnum(model, inputModel);
-    const expectedDependencies = ['import com.fasterxml.jackson.annotation.*;'];
     expect(enumModel.result).toEqual(expected);
-    expect(enumModel.dependencies).toEqual(expectedDependencies);
+    expect(enumModel.dependencies.length).toEqual(0);
 
     enumModel = await generator.render(model, inputModel);
     expect(enumModel.result).toEqual(expected);
-    expect(enumModel.dependencies).toEqual(expectedDependencies);
+    expect(enumModel.dependencies.length).toEqual(0);
   });
 
   test('should render `enum` type (union type)', async () => {
@@ -281,7 +275,6 @@ describe('JavaGenerator', () => {
     this.value = value;
   }
     
-  @JsonValue
   public Object getValue() {
     return value;
   }
@@ -291,7 +284,6 @@ describe('JavaGenerator', () => {
     return String.valueOf(value);
   }
 
-  @JsonCreator
   public static Union fromValue(Object value) {
     for (Union e : Union.values()) {
       if (e.value.equals(value)) {
@@ -306,13 +298,12 @@ describe('JavaGenerator', () => {
     const model = inputModel.models['Union'];
 
     let enumModel = await generator.renderEnum(model, inputModel);
-    const expectedDependencies = ['import com.fasterxml.jackson.annotation.*;'];
     expect(enumModel.result).toEqual(expected);
-    expect(enumModel.dependencies).toEqual(expectedDependencies);
+    expect(enumModel.dependencies.length).toEqual(0);
 
     enumModel = await generator.render(model, inputModel);
     expect(enumModel.result).toEqual(expected);
-    expect(enumModel.dependencies).toEqual(expectedDependencies);
+    expect(enumModel.dependencies.length).toEqual(0);
   });
 
   test('should render custom preset for `enum` type', async () => {
@@ -331,7 +322,6 @@ public enum CustomEnum {
     this.value = value;
   }
     
-  @JsonValue
   public String getValue() {
     return value;
   }
@@ -341,7 +331,6 @@ public enum CustomEnum {
     return String.valueOf(value);
   }
 
-  @JsonCreator
   public static CustomEnum fromValue(String value) {
     for (CustomEnum e : CustomEnum.values()) {
       if (e.value.equals(value)) {
@@ -367,13 +356,12 @@ public enum CustomEnum {
     const model = inputModel.models['CustomEnum'];
     
     let enumModel = await generator.render(model, inputModel);
-    const expectedDependencies = ['import com.fasterxml.jackson.annotation.*;'];
     expect(enumModel.result).toEqual(expected);
-    expect(enumModel.dependencies).toEqual(expectedDependencies);
+    expect(enumModel.dependencies.length).toEqual(0);
     
     enumModel = await generator.renderEnum(model, inputModel);
     expect(enumModel.result).toEqual(expected);
-    expect(enumModel.dependencies).toEqual(expectedDependencies);
+    expect(enumModel.dependencies.length).toEqual(0);
   });
 
   test('should render enums with translated special characters', async () => {
@@ -390,7 +378,6 @@ public enum CustomEnum {
     this.value = value;
   }
     
-  @JsonValue
   public String getValue() {
     return value;
   }
@@ -400,7 +387,6 @@ public enum CustomEnum {
     return String.valueOf(value);
   }
 
-  @JsonCreator
   public static States fromValue(String value) {
     for (States e : States.values()) {
       if (e.value.equals(value)) {
@@ -415,13 +401,12 @@ public enum CustomEnum {
     const model = inputModel.models['States'];
 
     let enumModel = await generator.renderEnum(model, inputModel);
-    const expectedDependencies = ['import com.fasterxml.jackson.annotation.*;'];
     expect(enumModel.result).toEqual(expected);
-    expect(enumModel.dependencies).toEqual(expectedDependencies);
+    expect(enumModel.dependencies.length).toEqual(0);
 
     enumModel = await generator.render(model, inputModel);
     expect(enumModel.result).toEqual(expected);
-    expect(enumModel.dependencies).toEqual(expectedDependencies);
+    expect(enumModel.dependencies.length).toEqual(0);
   });
 
   test('should render List type for collections', async () => {

--- a/test/generators/java/presets/DescriptionPreset.spec.ts
+++ b/test/generators/java/presets/DescriptionPreset.spec.ts
@@ -67,14 +67,9 @@ public enum Enum {
   Enum(String value) {
     this.value = value;
   }
-    
+
   public String getValue() {
     return value;
-  }
-
-  @Override
-  public String toString() {
-    return String.valueOf(value);
   }
 
   public static Enum fromValue(String value) {
@@ -84,6 +79,11 @@ public enum Enum {
       }
     }
     throw new IllegalArgumentException("Unexpected value '" + value + "'");
+  }
+
+  @Override
+  public String toString() {
+    return String.valueOf(value);
   }
 }`;
 

--- a/test/generators/java/presets/DescriptionPreset.spec.ts
+++ b/test/generators/java/presets/DescriptionPreset.spec.ts
@@ -68,7 +68,6 @@ public enum Enum {
     this.value = value;
   }
     
-  @JsonValue
   public String getValue() {
     return value;
   }
@@ -78,7 +77,6 @@ public enum Enum {
     return String.valueOf(value);
   }
 
-  @JsonCreator
   public static Enum fromValue(String value) {
     for (Enum e : Enum.values()) {
       if (e.value.equals(value)) {
@@ -94,6 +92,6 @@ public enum Enum {
 
     const enumModel = await generator.renderEnum(model, inputModel);
     expect(enumModel.result).toEqual(expected);
-    expect(enumModel.dependencies).toEqual(['import com.fasterxml.jackson.annotation.*;']);
+    expect(enumModel.dependencies).toEqual([]);
   });
 });

--- a/test/generators/java/presets/JacksonPreset.spec.ts
+++ b/test/generators/java/presets/JacksonPreset.spec.ts
@@ -56,19 +56,14 @@ describe('JAVA_JACKSON_PRESET', () => {
   ON("on"), OFF("off");
 
   private String value;
-    
+
   Enum(String value) {
     this.value = value;
   }
-    
+
   @JsonValue
   public String getValue() {
     return value;
-  }
-
-  @Override
-  public String toString() {
-    return String.valueOf(value);
   }
 
   @JsonCreator
@@ -79,6 +74,11 @@ describe('JAVA_JACKSON_PRESET', () => {
       }
     }
     throw new IllegalArgumentException("Unexpected value '" + value + "'");
+  }
+
+  @Override
+  public String toString() {
+    return String.valueOf(value);
   }
 }`;
 


### PR DESCRIPTION
**Description**

- generate Jackson annotations for Java enums only with Jackson Preset
- update all relevant tests

**Related issue(s)**
Fixes #812