### PR TITLE
fix: oneof implementation

### DIFF
--- a/src/generators/typescript/TypeScriptRenderer.ts
+++ b/src/generators/typescript/TypeScriptRenderer.ts
@@ -61,6 +61,9 @@ export abstract class TypeScriptRenderer extends AbstractRenderer<TypeScriptOpti
     if (Array.isArray(model.type)) {
       return [... new Set(model.type.map(t => this.toTsType(t, model)))].join(' | ');
     }
+    if (Array.isArray(model.items) && model.originalInput.oneOf !== undefined) {
+      return model.items.map(t => this.renderType(t)).join(' | ');
+    }
     return this.toTsType(model.type, model);
   }
 

--- a/src/interpreter/InterpretOneOf.ts
+++ b/src/interpreter/InterpretOneOf.ts
@@ -1,0 +1,21 @@
+import { CommonModel } from '../models/CommonModel';
+import { Interpreter, InterpreterOptions, InterpreterSchemaType } from './Interpreter';
+
+/**
+ * Interpreter function for oneOf keyword.
+ * 
+ * It puts the schema reference into the items field.
+ * 
+ * @param schema 
+ * @param model 
+ * @param interpreter 
+ * @param interpreterOptions to control the interpret process
+ */
+export default function interpretOneOf(schema: InterpreterSchemaType, model: CommonModel, interpreter : Interpreter, interpreterOptions: InterpreterOptions = Interpreter.defaultInterpreterOptions): void {
+  if (typeof schema === 'boolean' || schema.oneOf === undefined) {return;}
+  for (const [index, oneOfSchema] of schema.oneOf.entries()) {  
+    const oneOfModel = interpreter.interpret(oneOfSchema, interpreterOptions);
+    if (oneOfModel === undefined) {continue;}
+    model.addItemTuple(oneOfModel, schema, index);
+  }
+}

--- a/src/interpreter/Interpreter.ts
+++ b/src/interpreter/Interpreter.ts
@@ -2,6 +2,7 @@ import { CommonModel, Draft6Schema, Draft4Schema, SwaggerV2Schema, AsyncapiV2Sch
 import { interpretName, isEnum, isModelObject } from './Utils';
 import interpretProperties from './InterpretProperties';
 import interpretAllOf from './InterpretAllOf';
+import interpretOneOf from './InterpretOneOf';
 import interpretConst from './InterpretConst';
 import interpretEnum from './InterpretEnum';
 import interpretAdditionalProperties from './InterpretAdditionalProperties';
@@ -78,11 +79,11 @@ export class Interpreter {
     interpretItems(schema, model, this, interpreterOptions);
     interpretProperties(schema, model, this, interpreterOptions);
     interpretAllOf(schema, model, this, interpreterOptions);
+    interpretOneOf(schema, model, this, interpreterOptions);
     interpretDependencies(schema, model, this, interpreterOptions);
     interpretConst(schema, model);
     interpretEnum(schema, model);
 
-    this.interpretAndCombineMultipleSchemas(schema.oneOf, model, schema, interpreterOptions);
     this.interpretAndCombineMultipleSchemas(schema.anyOf, model, schema, interpreterOptions);
     if (!(schema instanceof Draft4Schema) && !(schema instanceof Draft6Schema)) {
       this.interpretAndCombineSchema(schema.then, model, schema, interpreterOptions);

--- a/test/generators/go/GoGenerator.spec.ts
+++ b/test/generators/go/GoGenerator.spec.ts
@@ -69,7 +69,7 @@ type Address struct {
   State string
   HouseNumber float64
   Marriage bool
-  Members []interface{}
+  Members interface{}
   TupleType []interface{}
   ArrayType []string
   AdditionalProperties map[string]string

--- a/test/generators/go/__snapshots__/GoGenerator.spec.ts.snap
+++ b/test/generators/go/__snapshots__/GoGenerator.spec.ts.snap
@@ -13,7 +13,7 @@ type Address struct {
   State string
   HouseNumber float64
   Marriage bool
-  Members []interface{}
+  Members interface{}
   ArrayType []interface{}
   OtherModel *OtherModel
   AdditionalProperties map[string][]interface{}
@@ -45,7 +45,7 @@ type Address struct {
   State string
   HouseNumber float64
   Marriage bool
-  Members []interface{}
+  Members interface{}
   ArrayType []interface{}
   OtherModel *OtherModel
   AdditionalProperties map[string][]interface{}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
Currently oneOf and anyOf are treated equally https://github.com/asyncapi/modelina/blob/7a2394956f8f82670e10859efd6b1c67c4487033/src/interpreter/Interpreter.ts#L85-L86

This PR aims to handle correctly oneOf in accordance to the OpenAPI specs https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not/#anyof-vs-oneof

I needed to update one of the tests because there's no reason for oneOf to generate an array type implicitly in the datamodel definition

```
Test Suites: 115 passed, 115 total
Tests:       699 passed, 699 total
Snapshots:   123 passed, 123 total
Time:        40.322 s
Ran all test suites.
```

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, othewise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->
Fixes #367