### PR TITLE
chore: rename schema ids for asyncapi

### DIFF
--- a/src/processors/AsyncAPIInputProcessor.ts
+++ b/src/processors/AsyncAPIInputProcessor.ts
@@ -60,7 +60,11 @@ export class AsyncAPIInputProcessor extends AbstractInputProcessor {
     alreadyIteratedSchemas: Map<string, AsyncapiV2Schema> = new Map()
   ): AsyncapiV2Schema | boolean {
     if (typeof schema === 'boolean') {return schema;}
-    const schemaUid = schema.uid();
+    let schemaUid = schema.uid();
+    //Because the constraint functionality of generators cannot handle -, <, >, we remove them from the id if it's an anonymous schema.
+    if (schemaUid.includes('<anonymous-schema')) {
+      schemaUid = schemaUid.replace('<', '').replaceAll('-', '_').replace('>', '');
+    }
     if (alreadyIteratedSchemas.has(schemaUid)) {
       return alreadyIteratedSchemas.get(schemaUid) as AsyncapiV2Schema; 
     }


### PR DESCRIPTION
**Description**
Because of the new constraint functionality, the old format for anonymous schema ids `<anonymous-schema-1>` is interpreted as `LessAnonymousMinusSchemaMinus1Greater` in some languages, which does not really make much sense. This change the format to `anonymous_schema_1` which gives `AnonymousSchema1`.

Todo:
- [ ] Update examples with AsyncAPI and tests