### PR TITLE
feat: trigger new release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asyncapi/modelina",
-  "version": "1.0.0-next.1",
+  "version": "1.0.0-next.2",
   "description": "Library for generating data models based on inputs such as AsyncAPI, OpenAPI, or JSON Schema documents.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/asyncapi/modelina",


### PR DESCRIPTION
**Description**
This PR tries again to trigger a new release by switching the version to `v1.0.0-next.2` as I was unable to remove the existing tag for `v1.0.0-next.1` (missing permissions and everyone on holiday)... See https://github.com/asyncapi/modelina/runs/7601164827?check_suite_focus=true