### PR TITLE
fix: unwrapping dictionaries not working in marshalling preset

### DIFF
--- a/src/generators/typescript/presets/CommonPreset.ts
+++ b/src/generators/typescript/presets/CommonPreset.ts
@@ -27,7 +27,7 @@ function renderMarshalProperties(model: ConstrainedObjectModel) {
   const unwrapDictionaryProperties = [];
   const normalProperties = [];
   for (const entry of propertyKeys) {
-    if (entry[1] instanceof ConstrainedDictionaryModel && entry[1].serializationType === 'unwrap') {
+    if (entry[1].property instanceof ConstrainedDictionaryModel && entry[1].property.serializationType === 'unwrap') {
       unwrapDictionaryProperties.push(entry);
     } else {
       normalProperties.push(entry);
@@ -91,7 +91,7 @@ function renderUnmarshalProperties(model: ConstrainedObjectModel) {
   const unwrapDictionaryProperties = [];
   const normalProperties = [];
   for (const entry of propertyKeys) {
-    if (entry[1] instanceof ConstrainedDictionaryModel && entry[1].serializationType === 'unwrap') {
+    if (entry[1].property instanceof ConstrainedDictionaryModel && entry[1].property.serializationType === 'unwrap') {
       unwrapDictionaryProperties.push(entry);
     } else {
       normalProperties.push(entry);

--- a/test/generators/typescript/preset/__snapshots__/MarshallingPreset.spec.ts.snap
+++ b/test/generators/typescript/preset/__snapshots__/MarshallingPreset.spec.ts.snap
@@ -42,10 +42,13 @@ exports[`Marshalling preset should render un/marshal code 1`] = `
     if(this.numberProp !== undefined) {
       json += \`\\"numberProp\\": \${typeof this.numberProp === 'number' || typeof this.numberProp === 'boolean' ? this.numberProp : JSON.stringify(this.numberProp)},\`; 
     }
-    if(this.additionalProperties !== undefined) {
-      json += \`\\"additionalProperties\\": \${typeof this.additionalProperties === 'number' || typeof this.additionalProperties === 'boolean' ? this.additionalProperties : JSON.stringify(this.additionalProperties)},\`; 
+    if(this.additionalProperties !== undefined) { 
+    for (const [key, value] of this.additionalProperties.entries()) {
+      //Only unwrap those who are not already a property in the JSON object
+      if(Object.keys(this).includes(String(key))) continue;
+        json += \`\\"\${key}\\": \${typeof value === 'number' || typeof value === 'boolean' ? value : JSON.stringify(value)},\`;
+      }
     }
-
 
     //Remove potential last comma 
     return \`\${json.charAt(json.length-1) === ',' ? json.slice(0, json.length-1) : json}}\`;
@@ -64,11 +67,11 @@ exports[`Marshalling preset should render un/marshal code 1`] = `
     if (obj[\\"numberProp\\"] !== undefined) {
       instance.numberProp = obj[\\"numberProp\\"];
     }
-    if (obj[\\"additionalProperties\\"] !== undefined) {
-      instance.additionalProperties = obj[\\"additionalProperties\\"];
-    }
 
-
+    if (instance.additionalProperties === undefined) {instance.additionalProperties = new Map();}
+      for (const [key, value] of Object.entries(obj).filter((([key,]) => {return ![\\"stringProp\\",\\"enumProp\\",\\"numberProp\\",\\"additionalProperties\\"].includes(key);}))) {
+        instance.additionalProperties.set(key, value as any);
+      }
 
     return instance;
   }
@@ -108,10 +111,13 @@ exports[`Marshalling preset should render un/marshal code 3`] = `
     if(this.stringProp !== undefined) {
       json += \`\\"stringProp\\": \${typeof this.stringProp === 'number' || typeof this.stringProp === 'boolean' ? this.stringProp : JSON.stringify(this.stringProp)},\`; 
     }
-    if(this.additionalProperties !== undefined) {
-      json += \`\\"additionalProperties\\": \${typeof this.additionalProperties === 'number' || typeof this.additionalProperties === 'boolean' ? this.additionalProperties : JSON.stringify(this.additionalProperties)},\`; 
+    if(this.additionalProperties !== undefined) { 
+    for (const [key, value] of this.additionalProperties.entries()) {
+      //Only unwrap those who are not already a property in the JSON object
+      if(Object.keys(this).includes(String(key))) continue;
+        json += \`\\"\${key}\\": \${typeof value === 'number' || typeof value === 'boolean' ? value : JSON.stringify(value)},\`;
+      }
     }
-
 
     //Remove potential last comma 
     return \`\${json.charAt(json.length-1) === ',' ? json.slice(0, json.length-1) : json}}\`;
@@ -124,11 +130,11 @@ exports[`Marshalling preset should render un/marshal code 3`] = `
     if (obj[\\"stringProp\\"] !== undefined) {
       instance.stringProp = obj[\\"stringProp\\"];
     }
-    if (obj[\\"additionalProperties\\"] !== undefined) {
-      instance.additionalProperties = obj[\\"additionalProperties\\"];
-    }
 
-
+    if (instance.additionalProperties === undefined) {instance.additionalProperties = new Map();}
+      for (const [key, value] of Object.entries(obj).filter((([key,]) => {return ![\\"stringProp\\",\\"additionalProperties\\"].includes(key);}))) {
+        instance.additionalProperties.set(key, value as any);
+      }
 
     return instance;
   }


### PR DESCRIPTION
**Description**
This PR fixes an issue with dictionaries that should be unwrapped and are not in the TypeScript preset.