### PR TITLE
fix: rust compile errors

### DIFF
--- a/examples/rust-generate-crate/__snapshots__/index.spec.ts.snap
+++ b/examples/rust-generate-crate/__snapshots__/index.spec.ts.snap
@@ -16,19 +16,19 @@ pub struct Address {
     #[serde(rename=\\"marriage\\", skip_serializing_if = \\"Option::is_none\\")]
     marriage: Option<bool>,
     #[serde(rename=\\"members\\", skip_serializing_if = \\"Option::is_none\\")]
-    members: Option<Box<Members>>,
+    members: Option<Box<crate::Members>>,
     #[serde(rename=\\"tuple_type\\", skip_serializing_if = \\"Option::is_none\\")]
-    tuple_type: Option<Box<TupleType>>,
+    tuple_type: Option<Box<crate::TupleType>>,
     #[serde(rename=\\"array_type\\")]
     array_type: Vec<String>,
     #[serde(rename=\\"enum_type\\", skip_serializing_if = \\"Option::is_none\\")]
-    enum_type: Option<Box<EnumType>>,
+    enum_type: Option<Box<crate::EnumType>>,
     #[serde(rename=\\"additionalProperties\\", skip_serializing_if = \\"Option::is_none\\")]
     additional_properties: Option<std::collections::HashMap<String, String>>,
 }
 
 impl Address {
-    pub fn new(street_name: String, city: String, state: String, house_number: f64, marriage: Option<bool>, members: Option<Members>, tuple_type: Option<TupleType>, array_type: Vec<String>, enum_type: Option<EnumType>, additional_properties: Option<std::collections::HashMap<String, String>>) -> Address {
+    pub fn new(street_name: String, city: String, state: String, house_number: f64, marriage: Option<bool>, members: Option<crate::Members>, tuple_type: Option<crate::TupleType>, array_type: Vec<String>, enum_type: Option<crate::EnumType>, additional_properties: Option<std::collections::HashMap<String, String>>) -> Address {
         Address {
         street_name,
         city,

--- a/examples/rust-generate-crate/__snapshots__/index.spec.ts.snap
+++ b/examples/rust-generate-crate/__snapshots__/index.spec.ts.snap
@@ -16,19 +16,19 @@ pub struct Address {
     #[serde(rename=\\"marriage\\", skip_serializing_if = \\"Option::is_none\\")]
     marriage: Option<bool>,
     #[serde(rename=\\"members\\", skip_serializing_if = \\"Option::is_none\\")]
-    members: Option<Box<crate::Members>>,
+    members: Option<Box<Members>>,
     #[serde(rename=\\"tuple_type\\", skip_serializing_if = \\"Option::is_none\\")]
-    tuple_type: Option<Box<crate::TupleType>>,
+    tuple_type: Option<Box<TupleType>>,
     #[serde(rename=\\"array_type\\")]
     array_type: Vec<String>,
     #[serde(rename=\\"enum_type\\", skip_serializing_if = \\"Option::is_none\\")]
-    enum_type: Option<Box<crate::EnumType>>,
+    enum_type: Option<Box<EnumType>>,
     #[serde(rename=\\"additionalProperties\\", skip_serializing_if = \\"Option::is_none\\")]
     additional_properties: Option<std::collections::HashMap<String, String>>,
 }
 
 impl Address {
-    pub fn new(street_name: String, city: String, state: String, house_number: f64, marriage: Option<bool>, members: Option<crate::Members>, tuple_type: Option<crate::TupleType>, array_type: Vec<String>, enum_type: Option<crate::EnumType>, additional_properties: Option<std::collections::HashMap<String, String>>) -> Address {
+    pub fn new(street_name: String, city: String, state: String, house_number: f64, marriage: Option<bool>, members: Option<Members>, tuple_type: Option<TupleType>, array_type: Vec<String>, enum_type: Option<EnumType>, additional_properties: Option<std::collections::HashMap<String, String>>) -> Address {
         Address {
         street_name,
         city,
@@ -50,7 +50,7 @@ impl Address {
 exports[`Should be able to render Rust Models and should log expected output to console 2`] = `
 Array [
   "// Members represents a union of types: String, f64, bool
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, PartialOrd, Serialize)]
 pub enum Members {
     #[serde(rename=\\"Members0\\")]
     Members0(String),
@@ -67,7 +67,7 @@ pub enum Members {
 exports[`Should be able to render Rust Models and should log expected output to console 3`] = `
 Array [
   "// TupleType represents a TupleType model.
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, PartialOrd, Serialize)]
 pub struct TupleType(String, f64);
 
 impl TupleType {

--- a/src/generators/rust/RustConstrainer.ts
+++ b/src/generators/rust/RustConstrainer.ts
@@ -253,7 +253,8 @@ export const RustDefaultTypeMapping: TypeMapping<RustOptions> = {
     return `${constrainedModel.name}`;
   },
   Array({ constrainedModel }): string {
-    return `Vec<${FormatHelpers.upperFirst(constrainedModel.valueModel.type)}>`;
+    let prefix = (constrainedModel.valueModel instanceof ConstrainedReferenceModel) ? 'crate::' : '';
+    return `Vec<${prefix}${FormatHelpers.upperFirst(constrainedModel.valueModel.type)}>`;
   },
   Enum({ constrainedModel }): string {
     return constrainedModel.name;
@@ -262,7 +263,9 @@ export const RustDefaultTypeMapping: TypeMapping<RustOptions> = {
     return constrainedModel.name;
   },
   Dictionary({ constrainedModel }): string {
-    return `std::collections::HashMap<${constrainedModel.key.type}, ${constrainedModel.value.type}>`;
+    let key_prefix = (constrainedModel.key instanceof ConstrainedReferenceModel) ? 'crate::' : '';
+    let value_prefix = (constrainedModel.value instanceof ConstrainedReferenceModel) ? 'crate::' : '';
+    return `std::collections::HashMap<${key_prefix}${constrainedModel.key.type}, ${value_prefix}${constrainedModel.value.type}>`;
   }
 };
 

--- a/src/generators/rust/RustConstrainer.ts
+++ b/src/generators/rust/RustConstrainer.ts
@@ -264,7 +264,7 @@ export const RustDefaultTypeMapping: TypeMapping<RustOptions> = {
   },
   Dictionary({ constrainedModel }): string {
     const key_prefix = (constrainedModel.key instanceof ConstrainedReferenceModel) ? 'crate::' : '';
-    let value_prefix = (constrainedModel.value instanceof ConstrainedReferenceModel) ? 'crate::' : '';
+    const value_prefix = (constrainedModel.value instanceof ConstrainedReferenceModel) ? 'crate::' : '';
     return `std::collections::HashMap<${key_prefix}${constrainedModel.key.type}, ${value_prefix}${constrainedModel.value.type}>`;
   }
 };

--- a/src/generators/rust/RustConstrainer.ts
+++ b/src/generators/rust/RustConstrainer.ts
@@ -87,7 +87,7 @@ export function derivePartialOrd(model: ConstrainedMetaModel): boolean {
 }
 
 export function deriveOrd(model: ConstrainedMetaModel): boolean {
-  if (!derivePartialOrd(model)) { return false }
+  if (!derivePartialOrd(model)) { return false };
 
   if (
     model instanceof ConstrainedFloatModel ||

--- a/src/generators/rust/RustConstrainer.ts
+++ b/src/generators/rust/RustConstrainer.ts
@@ -263,7 +263,7 @@ export const RustDefaultTypeMapping: TypeMapping<RustOptions> = {
     return constrainedModel.name;
   },
   Dictionary({ constrainedModel }): string {
-    let key_prefix = (constrainedModel.key instanceof ConstrainedReferenceModel) ? 'crate::' : '';
+    const key_prefix = (constrainedModel.key instanceof ConstrainedReferenceModel) ? 'crate::' : '';
     let value_prefix = (constrainedModel.value instanceof ConstrainedReferenceModel) ? 'crate::' : '';
     return `std::collections::HashMap<${key_prefix}${constrainedModel.key.type}, ${value_prefix}${constrainedModel.value.type}>`;
   }

--- a/src/generators/rust/RustConstrainer.ts
+++ b/src/generators/rust/RustConstrainer.ts
@@ -253,7 +253,7 @@ export const RustDefaultTypeMapping: TypeMapping<RustOptions> = {
     return `${constrainedModel.name}`;
   },
   Array({ constrainedModel }): string {
-    let prefix = (constrainedModel.valueModel instanceof ConstrainedReferenceModel) ? 'crate::' : '';
+    const prefix = (constrainedModel.valueModel instanceof ConstrainedReferenceModel) ? 'crate::' : '';
     return `Vec<${prefix}${FormatHelpers.upperFirst(constrainedModel.valueModel.type)}>`;
   },
   Enum({ constrainedModel }): string {

--- a/src/generators/rust/RustConstrainer.ts
+++ b/src/generators/rust/RustConstrainer.ts
@@ -57,7 +57,7 @@ export function derivePartialEq(model: ConstrainedMetaModel): boolean {
 }
 
 export function deriveEq(model: ConstrainedMetaModel): boolean {
-  if (!derivePartialEq(model)) { return false }
+  if (!derivePartialEq(model)) { return false };
 
   if (model instanceof ConstrainedFloatModel || model instanceof ConstrainedAnyModel) { return false; } else if (
     // all contents implement Eq trait

--- a/src/generators/rust/RustFileGenerator.ts
+++ b/src/generators/rust/RustFileGenerator.ts
@@ -40,7 +40,7 @@ export class RustFileGenerator extends RustGenerator implements AbstractFileGene
       const supportOutput = await this.generateCompleteSupport(input, options);
       generatedModels = generatedModels.concat(supportOutput);
       for (const outputModel of supportOutput) {
-        const filePath = path.resolve(outputDirectory, outputModel.modelName);
+        const filePath = path.resolve(outputDirectory, outputModel.model.name);
         await FileHelpers.writerToFileSystem(outputModel.result, filePath);
       }
     }

--- a/src/generators/rust/RustRenderer.ts
+++ b/src/generators/rust/RustRenderer.ts
@@ -2,7 +2,7 @@ import { AbstractRenderer } from '../AbstractRenderer';
 import { RustGenerator, RustOptions } from './RustGenerator';
 import { InputMetaModel, Preset, ConstrainedMetaModel } from '../../models';
 import { FormatHelpers } from '../../helpers/FormatHelpers';
-import { deriveCopy, deriveHash, deriveEq } from './RustConstrainer';
+import { deriveCopy, deriveHash, derivePartialEq, deriveEq, derivePartialOrd, deriveOrd } from './RustConstrainer';
 /**
  * Common renderer for Rust types
  * 
@@ -25,17 +25,24 @@ export abstract class RustRenderer<RendererModelType extends ConstrainedMetaMode
   }
 
   renderMacro(model: ConstrainedMetaModel): string {
-    const derive: string[] = ['Serialize', 'Deserialize', 'PartialEq', 'Clone', 'Debug'];
+    const derive: string[] = ['Serialize', 'Deserialize', 'Clone', 'Debug'];
     if (deriveHash(model)) {
       derive.push('Hash');
     }
     if (deriveCopy(model)) {
       derive.push('Copy');
     }
+    if (derivePartialEq(model)) {
+      derive.push('PartialEq');
+    }
     if (deriveEq(model)) {
       derive.push('Eq');
-      derive.push('Ord');
+    }
+    if (derivePartialOrd(model)) {
       derive.push('PartialOrd');
+    }
+    if (deriveOrd(model)) {
+      derive.push('Ord');
     }
     derive.sort();
     return `#[derive(${derive.join(', ')})]`;

--- a/src/generators/rust/constrainer/ModelNameConstrainer.ts
+++ b/src/generators/rust/constrainer/ModelNameConstrainer.ts
@@ -19,7 +19,7 @@ export const DefaultModelNameConstraints: ModelNameConstraints = {
   NO_NUMBER_START_CHAR,
   NO_EMPTY_VALUE,
   NAMING_FORMATTER: (value: string) => {
-    return FormatHelpers.toPascalCase(value);
+    return FormatHelpers.toPascalCaseMergingNumbers(value);
   },
   NO_RESERVED_KEYWORDS: (value: string) => {
     return NO_RESERVED_KEYWORDS(value, isReservedRustKeyword);

--- a/src/generators/rust/presets/CommonPreset.ts
+++ b/src/generators/rust/presets/CommonPreset.ts
@@ -73,7 +73,11 @@ export const RUST_COMMON_PRESET: RustPreset<RustCommonPresetOptions> = {
 
           if (v.required) {
             args.push(`${v.propertyName}: ${fieldType}`);
-            fields.push(`${v.propertyName},`);
+            if (v.property instanceof ConstrainedReferenceModel) {
+              fields.push(`Box::new(${v.propertyName}),`);
+            } else {
+              fields.push(`${v.propertyName},`);
+            }
             // use map to box reference if field is optional
           } else if (!v.required && (v.property instanceof ConstrainedReferenceModel || v.property instanceof ConstrainedUnionModel)) {
             args.push(`${v.propertyName}: Option<crate::${v.property.type}>`);

--- a/src/generators/rust/presets/CommonPreset.ts
+++ b/src/generators/rust/presets/CommonPreset.ts
@@ -68,7 +68,7 @@ export const RUST_COMMON_PRESET: RustPreset<RustCommonPresetOptions> = {
         const args: string[] = [];
         const fields: string[] = [];
         for (const v of Object.values(properties)) {
-          let prefix = (v.property instanceof ConstrainedReferenceModel) ? 'crate::' : '';
+          const prefix = (v.property instanceof ConstrainedReferenceModel) ? 'crate::' : '';
           let fieldType = prefix + v.property.type;
 
           if (v.required) {

--- a/src/generators/rust/presets/CommonPreset.ts
+++ b/src/generators/rust/presets/CommonPreset.ts
@@ -69,7 +69,7 @@ export const RUST_COMMON_PRESET: RustPreset<RustCommonPresetOptions> = {
         const fields: string[] = [];
         for (const v of Object.values(properties)) {
           const prefix = (v.property instanceof ConstrainedReferenceModel) ? 'crate::' : '';
-          let fieldType = prefix + v.property.type;
+          const fieldType = prefix + v.property.type;
 
           if (v.required) {
             args.push(`${v.propertyName}: ${fieldType}`);

--- a/src/generators/rust/presets/CommonPreset.ts
+++ b/src/generators/rust/presets/CommonPreset.ts
@@ -68,15 +68,18 @@ export const RUST_COMMON_PRESET: RustPreset<RustCommonPresetOptions> = {
         const args: string[] = [];
         const fields: string[] = [];
         for (const v of Object.values(properties)) {
+          let prefix = (v.property instanceof ConstrainedReferenceModel) ? 'crate::' : '';
+          let fieldType = prefix + v.property.type;
+
           if (v.required) {
-            args.push(`${v.propertyName}: ${v.property.type}`);
+            args.push(`${v.propertyName}: ${fieldType}`);
             fields.push(`${v.propertyName},`);
             // use map to box reference if field is optional
           } else if (!v.required && (v.property instanceof ConstrainedReferenceModel || v.property instanceof ConstrainedUnionModel)) {
             args.push(`${v.propertyName}: Option<crate::${v.property.type}>`);
             fields.push(`${v.propertyName}: ${v.propertyName}.map(Box::new),`);
           } else {
-            args.push(`${v.propertyName}: Option<${v.property.type}>`);
+            args.push(`${v.propertyName}: Option<${fieldType}>`);
             fields.push(`${v.propertyName},`);
           }
         }

--- a/src/generators/rust/renderers/StructRenderer.ts
+++ b/src/generators/rust/renderers/StructRenderer.ts
@@ -1,6 +1,6 @@
 import { RustRenderer } from '../RustRenderer';
 import { StructPresetType } from '../RustPreset';
-import { ConstrainedObjectModel, ConstrainedObjectPropertyModel, ConstrainedReferenceModel, ConstrainedUnionModel } from '../../../models';
+import { ConstrainedObjectModel, ConstrainedObjectPropertyModel, ConstrainedReferenceModel } from '../../../models';
 import { RustOptions } from '../RustGenerator';
 
 /**

--- a/src/generators/rust/renderers/StructRenderer.ts
+++ b/src/generators/rust/renderers/StructRenderer.ts
@@ -1,6 +1,6 @@
 import { RustRenderer } from '../RustRenderer';
 import { StructPresetType } from '../RustPreset';
-import { ConstrainedObjectModel, ConstrainedObjectPropertyModel, ConstrainedReferenceModel } from '../../../models';
+import { ConstrainedObjectModel, ConstrainedObjectPropertyModel, ConstrainedReferenceModel, ConstrainedUnionModel } from '../../../models';
 import { RustOptions } from '../RustGenerator';
 
 /**
@@ -69,10 +69,9 @@ export const RUST_DEFAULT_STRUCT_PRESET: StructPresetType<RustOptions> = {
   },
   field({ field }) {
     let fieldType = field.property.type;
-    if (field.property instanceof ConstrainedReferenceModel) {
-      fieldType = `Box<crate::${fieldType}>`;
-    }
-    if (!field.required) {
+    if (!field.required && (field.property instanceof ConstrainedReferenceModel || field.property instanceof ConstrainedUnionModel)) {
+      fieldType = `Option<Box<${fieldType}>>`;
+    } else if (!field.required) {
       fieldType = `Option<${fieldType}>`;
     }
     return `${field.propertyName}: ${fieldType},`;

--- a/src/generators/rust/renderers/StructRenderer.ts
+++ b/src/generators/rust/renderers/StructRenderer.ts
@@ -68,7 +68,9 @@ export const RUST_DEFAULT_STRUCT_PRESET: StructPresetType<RustOptions> = {
     return `#[serde(${serdeArgs.join(', ')})]`;
   },
   field({ field }) {
-    let fieldType = field.property.type;
+    let prefix = (field.property instanceof ConstrainedReferenceModel) ? 'crate::' : '';
+    let fieldType = prefix + field.property.type ;
+
     if (!field.required && (field.property instanceof ConstrainedReferenceModel || field.property instanceof ConstrainedUnionModel)) {
       fieldType = `Option<Box<${fieldType}>>`;
     } else if (!field.required) {

--- a/src/generators/rust/renderers/StructRenderer.ts
+++ b/src/generators/rust/renderers/StructRenderer.ts
@@ -68,12 +68,11 @@ export const RUST_DEFAULT_STRUCT_PRESET: StructPresetType<RustOptions> = {
     return `#[serde(${serdeArgs.join(', ')})]`;
   },
   field({ field }) {
-    let prefix = (field.property instanceof ConstrainedReferenceModel) ? 'crate::' : '';
-    let fieldType = prefix + field.property.type ;
-
-    if (!field.required && (field.property instanceof ConstrainedReferenceModel || field.property instanceof ConstrainedUnionModel)) {
-      fieldType = `Option<Box<${fieldType}>>`;
-    } else if (!field.required) {
+    let fieldType = field.property.type;
+    if (field.property instanceof ConstrainedReferenceModel) {
+      fieldType = `Box<crate::${fieldType}>`;
+    }
+    if (!field.required) {
       fieldType = `Option<${fieldType}>`;
     }
     return `${field.propertyName}: ${fieldType},`;

--- a/src/generators/rust/renderers/UnionRenderer.ts
+++ b/src/generators/rust/renderers/UnionRenderer.ts
@@ -1,5 +1,5 @@
 import { RustRenderer } from '../RustRenderer';
-import { ConstrainedUnionModel, ConstrainedMetaModel } from '../../../models';
+import { ConstrainedUnionModel, ConstrainedMetaModel, ConstrainedReferenceModel } from '../../../models';
 import { UnionPresetType } from '../RustPreset';
 import { RustOptions } from '../RustGenerator';
 
@@ -54,6 +54,10 @@ export const RUST_DEFAULT_UNION_PRESET: UnionPresetType<RustOptions> = {
     return `#[serde(${serdeArgs.join(', ')})]`;
   },
   item({ item }) {
-    return `${item.name}(${item.type})`;
+    if (item instanceof ConstrainedReferenceModel) {
+      return `${item.name}(${item.ref.type})`;
+    } else {
+      return `${item.name}(${item.type})`;
+    }
   }
 };

--- a/src/generators/rust/renderers/UnionRenderer.ts
+++ b/src/generators/rust/renderers/UnionRenderer.ts
@@ -55,7 +55,7 @@ export const RUST_DEFAULT_UNION_PRESET: UnionPresetType<RustOptions> = {
   },
   item({ item }) {
     if (item instanceof ConstrainedReferenceModel) {
-      return `${item.name}(${item.ref.type})`;
+      return `${item.name}(crate::${item.ref.type})`;
     } else {
       return `${item.name}(${item.type})`;
     }

--- a/src/generators/rust/renderers/UnionRenderer.ts
+++ b/src/generators/rust/renderers/UnionRenderer.ts
@@ -56,8 +56,7 @@ export const RUST_DEFAULT_UNION_PRESET: UnionPresetType<RustOptions> = {
   item({ item }) {
     if (item instanceof ConstrainedReferenceModel) {
       return `${item.name}(crate::${item.ref.type})`;
-    } else {
-      return `${item.name}(${item.type})`;
     }
+    return `${item.name}(${item.type})`;
   }
 };

--- a/src/helpers/FormatHelpers.ts
+++ b/src/helpers/FormatHelpers.ts
@@ -3,7 +3,8 @@ import {
   pascalCase,
   paramCase,
   constantCase,
-  snakeCase
+  snakeCase,
+  pascalCaseTransformMerge,
 } from 'change-case';
 
 export enum IndentationTypes {
@@ -81,6 +82,16 @@ export class FormatHelpers {
    * @returns {string}
    */
   static toPascalCase = pascalCase;
+
+  /**
+   * Transform into a string of capitalized words without separators
+   * merging numbers.
+   * @param {string} value to transform
+   * @returns {string}
+   */
+  static toPascalCaseMergingNumbers(value: string): string {
+    return pascalCase(value, { transform: pascalCaseTransformMerge })
+  }
 
   /**
    * Transform into a lower cased string with dashes between words.

--- a/src/helpers/FormatHelpers.ts
+++ b/src/helpers/FormatHelpers.ts
@@ -90,7 +90,7 @@ export class FormatHelpers {
    * @returns {string}
    */
   static toPascalCaseMergingNumbers(value: string): string {
-    return pascalCase(value, { transform: pascalCaseTransformMerge })
+    return pascalCase(value, { transform: pascalCaseTransformMerge });
   }
 
   /**

--- a/src/processors/AsyncAPIInputProcessor.ts
+++ b/src/processors/AsyncAPIInputProcessor.ts
@@ -63,7 +63,7 @@ export class AsyncAPIInputProcessor extends AbstractInputProcessor {
     
     let schemaUid = schema.uid();
     //Because the constraint functionality of generators cannot handle -, <, >, we remove them from the id if it's an anonymous schema.
-    if (schemaUid.includes('<anonymous-schema')) {
+    if (typeof schemaUid !== 'undefined' && schemaUid.includes('<anonymous-schema')) {
       schemaUid = schemaUid.replace('<', '').replace(/-/g, '_').replace('>', '');
     }
     

--- a/test/generators/rust/RustGenerator.spec.ts
+++ b/test/generators/rust/RustGenerator.spec.ts
@@ -36,7 +36,7 @@ describe('RustGenerator', () => {
 
     test('should render `enum` with mixed types (union type)', async () => {
       const doc = {
-        $id: 'Things',
+        $id: 'Things_123',
         enum: ['Texas', 1, '1', false, { test: 'test' }],
       };
       const models = await generator.generate(doc);

--- a/test/generators/rust/RustRenderer.spec.ts
+++ b/test/generators/rust/RustRenderer.spec.ts
@@ -22,7 +22,8 @@ describe('RustRenderer', () => {
     const stringModel = new ConstrainedStringModel('test', undefined, 'String');
     const f64Model = new ConstrainedFloatModel('test', undefined, '');
     const f32Model = new ConstrainedFloatModel('test', { format: 'float32' }, '');
-    const dictModel = new ConstrainedDictionaryModel('test', undefined, '', f32Model, f64Model);
+    const dictModel = new ConstrainedDictionaryModel('test', undefined, '', i32Model, i64Model);
+    const floatDictModel = new ConstrainedDictionaryModel('test', undefined, '', f32Model, f64Model);
     const anyModel = new ConstrainedAnyModel('test', undefined, '');
 
     test('Should derive all traits', () => {
@@ -80,7 +81,8 @@ describe('RustRenderer', () => {
       expect(renderer.renderMacro(enumModel)).toEqual('#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]');
       expect(renderer.renderMacro(objectModel)).toEqual('#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]');
     });
-    test('Should not derive Hash, Eq, Ord, PartialEq traits', () => {
+    test('Should not derive Hash, Eq, Ord traits', () => {
+      // float does not implement Hash, Eq, Ord
       const tupleModel = new ConstrainedTupleModel('test', undefined, '', [new ConstrainedTupleValueModel(0, f32Model), new ConstrainedTupleValueModel(1, f64Model)]);
       const arrayModel = new ConstrainedArrayModel('test', undefined, '', f64Model);
       const enumModel = new ConstrainedEnumModel('test', undefined, '', [new ConstrainedEnumValueModel('one', f64Model,), new ConstrainedEnumValueModel('two', f32Model)]);
@@ -102,9 +104,90 @@ describe('RustRenderer', () => {
 
       });
 
-      expect(renderer.renderMacro(arrayModel)).toEqual('#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]');
-      expect(renderer.renderMacro(enumModel)).toEqual('#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]');
-      expect(renderer.renderMacro(objectModel)).toEqual('#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]');
+      expect(renderer.renderMacro(arrayModel)).toEqual('#[derive(Clone, Copy, Debug, Deserialize, PartialEq, PartialOrd, Serialize)]');
+      expect(renderer.renderMacro(enumModel)).toEqual('#[derive(Clone, Copy, Debug, Deserialize, PartialEq, PartialOrd, Serialize)]');
+      expect(renderer.renderMacro(objectModel)).toEqual('#[derive(Clone, Copy, Debug, Deserialize, PartialEq, PartialOrd, Serialize)]');
+    });
+    test('Should not derive Hash, Copy, PartialOrd, Ord traits', () => {
+      // dict (HashMap) does not implement Copy, PartialOrd, Ord
+      const tupleModel = new ConstrainedTupleModel('test', undefined, '', [new ConstrainedTupleValueModel(0, boolModel), new ConstrainedTupleValueModel(1, boolModel)]);
+      const arrayModel = new ConstrainedArrayModel('test', undefined, '', dictModel);
+      const enumModel = new ConstrainedEnumModel('test', undefined, '', [new ConstrainedEnumValueModel('one', i32Model,), new ConstrainedEnumValueModel('two', dictModel)]);
+      const unionModel = new ConstrainedUnionModel('test', undefined, '', [
+        i32Model,
+        i64Model,
+        boolModel,
+        tupleModel,
+        arrayModel,
+        enumModel
+      ]);
+      const objectModel = new ConstrainedObjectModel('test', undefined, '', {
+        i32Model: new ConstrainedObjectPropertyModel('test', 'test', true, i32Model),
+        i64Model: new ConstrainedObjectPropertyModel('test', 'test', true, i64Model),
+        boolProp: new ConstrainedObjectPropertyModel('test', 'test', true, boolModel),
+        tupleModel: new ConstrainedObjectPropertyModel('test', 'test', true, tupleModel),
+        unionModel: new ConstrainedObjectPropertyModel('test', 'test', true, unionModel),
+        enumModel: new ConstrainedObjectPropertyModel('test', 'test', true, enumModel),
+
+      });
+
+      expect(renderer.renderMacro(arrayModel)).toEqual('#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]');
+      expect(renderer.renderMacro(enumModel)).toEqual('#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]');
+      expect(renderer.renderMacro(objectModel)).toEqual('#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]');
+    });
+    test('Should not derive Hash, Copy, PartialOrd, Ord, PartialEq, traits', () => {
+      // dict (HashMap) + float does not implement Copy, PartialOrd, Ord, Eq
+      const tupleModel = new ConstrainedTupleModel('test', undefined, '', [new ConstrainedTupleValueModel(0, boolModel), new ConstrainedTupleValueModel(1, f32Model)]);
+      const arrayModel = new ConstrainedArrayModel('test', undefined, '', floatDictModel);
+      const enumModel = new ConstrainedEnumModel('test', undefined, '', [new ConstrainedEnumValueModel('one', f32Model,), new ConstrainedEnumValueModel('two', dictModel)]);
+      const unionModel = new ConstrainedUnionModel('test', undefined, '', [
+        i32Model,
+        i64Model,
+        boolModel,
+        tupleModel,
+        arrayModel,
+        enumModel
+      ]);
+      const objectModel = new ConstrainedObjectModel('test', undefined, '', {
+        i32Model: new ConstrainedObjectPropertyModel('test', 'test', true, i32Model),
+        i64Model: new ConstrainedObjectPropertyModel('test', 'test', true, i64Model),
+        boolProp: new ConstrainedObjectPropertyModel('test', 'test', true, boolModel),
+        tupleModel: new ConstrainedObjectPropertyModel('test', 'test', true, tupleModel),
+        unionModel: new ConstrainedObjectPropertyModel('test', 'test', true, unionModel),
+        enumModel: new ConstrainedObjectPropertyModel('test', 'test', true, enumModel),
+
+      });
+
+      expect(renderer.renderMacro(arrayModel)).toEqual('#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]');
+      expect(renderer.renderMacro(enumModel)).toEqual('#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]');
+      expect(renderer.renderMacro(objectModel)).toEqual('#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]');
+    });
+    test('Should not derive Hash, Copy, PartialOrd, Ord, PartialEq, Eq', () => {
+      // any prevents those traits
+      const tupleModel = new ConstrainedTupleModel('test', undefined, '', [new ConstrainedTupleValueModel(0, boolModel), new ConstrainedTupleValueModel(1, anyModel)]);
+      const arrayModel = new ConstrainedArrayModel('test', undefined, '', anyModel);
+      const enumModel = new ConstrainedEnumModel('test', undefined, '', [new ConstrainedEnumValueModel('one', i32Model,), new ConstrainedEnumValueModel('two', anyModel)]);
+      const unionModel = new ConstrainedUnionModel('test', undefined, '', [
+        i32Model,
+        i64Model,
+        boolModel,
+        tupleModel,
+        arrayModel,
+        enumModel
+      ]);
+      const objectModel = new ConstrainedObjectModel('test', undefined, '', {
+        i32Model: new ConstrainedObjectPropertyModel('test', 'test', true, i32Model),
+        i64Model: new ConstrainedObjectPropertyModel('test', 'test', true, i64Model),
+        boolProp: new ConstrainedObjectPropertyModel('test', 'test', true, boolModel),
+        tupleModel: new ConstrainedObjectPropertyModel('test', 'test', true, tupleModel),
+        unionModel: new ConstrainedObjectPropertyModel('test', 'test', true, unionModel),
+        enumModel: new ConstrainedObjectPropertyModel('test', 'test', true, enumModel),
+
+      });
+
+      expect(renderer.renderMacro(arrayModel)).toEqual('#[derive(Clone, Debug, Deserialize, Serialize)]');
+      expect(renderer.renderMacro(enumModel)).toEqual('#[derive(Clone, Debug, Deserialize, Serialize)]');
+      expect(renderer.renderMacro(objectModel)).toEqual('#[derive(Clone, Debug, Deserialize, Serialize)]');
     });
   });
 });

--- a/test/generators/rust/__snapshots__/RustGenerator.spec.ts.snap
+++ b/test/generators/rust/__snapshots__/RustGenerator.spec.ts.snap
@@ -136,9 +136,9 @@ pub struct Address {
     #[serde(rename=\\"marriage\\", skip_serializing_if = \\"Option::is_none\\")]
     marriage: Option<bool>,
     #[serde(rename=\\"members\\", skip_serializing_if = \\"Option::is_none\\")]
-    members: Option<Box<Members>>,
+    members: Option<Box<crate::Members>>,
     #[serde(rename=\\"tuple_type\\", skip_serializing_if = \\"Option::is_none\\")]
-    tuple_type: Option<Box<TupleType>>,
+    tuple_type: Option<Box<crate::TupleType>>,
     #[serde(rename=\\"array_type\\")]
     array_type: Vec<String>,
     #[serde(rename=\\"additionalProperties\\", skip_serializing_if = \\"Option::is_none\\")]
@@ -185,9 +185,9 @@ pub struct Address {
     #[serde(rename=\\"marriage\\", skip_serializing_if = \\"Option::is_none\\")]
     marriage: Option<bool>,
     #[serde(rename=\\"members\\", skip_serializing_if = \\"Option::is_none\\")]
-    members: Option<Box<Members>>,
+    members: Option<Box<crate::Members>>,
     #[serde(rename=\\"tuple_type\\", skip_serializing_if = \\"Option::is_none\\")]
-    tuple_type: Option<Box<TupleType>>,
+    tuple_type: Option<Box<crate::TupleType>>,
     #[serde(rename=\\"array_type\\")]
     array_type: Vec<String>,
     #[serde(rename=\\"additionalProperties\\", skip_serializing_if = \\"Option::is_none\\")]

--- a/test/generators/rust/__snapshots__/RustGenerator.spec.ts.snap
+++ b/test/generators/rust/__snapshots__/RustGenerator.spec.ts.snap
@@ -27,9 +27,9 @@ pub enum Numbers {
 `;
 
 exports[`RustGenerator Enum should render \`enum\` with mixed types (union type) 1`] = `
-"// Things represents a Things model.
+"// Things123 represents a Things123 model.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum Things {
+pub enum Things123 {
     #[serde(rename=\\"Texas\\")]
     Texas,
     #[serde(rename=\\"1\\")]

--- a/test/generators/rust/__snapshots__/RustGenerator.spec.ts.snap
+++ b/test/generators/rust/__snapshots__/RustGenerator.spec.ts.snap
@@ -136,9 +136,9 @@ pub struct Address {
     #[serde(rename=\\"marriage\\", skip_serializing_if = \\"Option::is_none\\")]
     marriage: Option<bool>,
     #[serde(rename=\\"members\\", skip_serializing_if = \\"Option::is_none\\")]
-    members: Option<Box<crate::Members>>,
+    members: Option<Box<Members>>,
     #[serde(rename=\\"tuple_type\\", skip_serializing_if = \\"Option::is_none\\")]
-    tuple_type: Option<Box<crate::TupleType>>,
+    tuple_type: Option<Box<TupleType>>,
     #[serde(rename=\\"array_type\\")]
     array_type: Vec<String>,
     #[serde(rename=\\"additionalProperties\\", skip_serializing_if = \\"Option::is_none\\")]
@@ -149,7 +149,7 @@ pub struct Address {
 
 exports[`RustGenerator Struct & Complete Models Should render complete models 2`] = `
 "// Members represents a union of types: String, f64, bool
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, PartialOrd, Serialize)]
 pub enum Members {
     #[serde(rename=\\"Members0\\")]
     Members0(String),
@@ -164,7 +164,7 @@ pub enum Members {
 
 exports[`RustGenerator Struct & Complete Models Should render complete models 3`] = `
 "// TupleType represents a TupleType model.
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, PartialOrd, Serialize)]
 pub struct TupleType(String, f64);
 
 "
@@ -185,9 +185,9 @@ pub struct Address {
     #[serde(rename=\\"marriage\\", skip_serializing_if = \\"Option::is_none\\")]
     marriage: Option<bool>,
     #[serde(rename=\\"members\\", skip_serializing_if = \\"Option::is_none\\")]
-    members: Option<Box<crate::Members>>,
+    members: Option<Box<Members>>,
     #[serde(rename=\\"tuple_type\\", skip_serializing_if = \\"Option::is_none\\")]
-    tuple_type: Option<Box<crate::TupleType>>,
+    tuple_type: Option<Box<TupleType>>,
     #[serde(rename=\\"array_type\\")]
     array_type: Vec<String>,
     #[serde(rename=\\"additionalProperties\\", skip_serializing_if = \\"Option::is_none\\")]
@@ -198,7 +198,7 @@ pub struct Address {
 
 exports[`RustGenerator Struct & Complete Models should render \`struct\` type  2`] = `
 "// Members represents a union of types: String, f64, bool
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, PartialOrd, Serialize)]
 pub enum Members {
     #[serde(rename=\\"Members0\\")]
     Members0(String),
@@ -213,7 +213,7 @@ pub enum Members {
 
 exports[`RustGenerator Struct & Complete Models should render \`struct\` type  3`] = `
 "// TupleType represents a TupleType model.
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, PartialOrd, Serialize)]
 pub struct TupleType(String, f64);
 
 "

--- a/test/generators/rust/presets/CommonPreset.spec.ts
+++ b/test/generators/rust/presets/CommonPreset.spec.ts
@@ -97,6 +97,37 @@ describe('RUST_COMMON_PRESET', () => {
       expect(models).toHaveLength(1);
       expect(models[0].result).toMatchSnapshot();
     });
+
+    test('should render reserved union for dict array', async () => {
+      const doc = {
+        $id: '_class',
+        type: 'object',
+        definitions: {
+          "student" : {
+            $id: '_student',
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+              birth: { type: 'number' }
+            },
+            required: ['name', 'birth'],
+          }
+        },
+        properties: {
+          students: {
+            type: 'array',
+            items: { $ref: '#/definitions/student' }
+          },
+        },
+        required: ['students'],
+      };
+
+      const models = await generator.generate(doc);
+      expect(models).toHaveLength(3);
+      expect(models[0].result).toMatchSnapshot();
+      expect(models[1].result).toMatchSnapshot();
+      expect(models[2].result).toMatchSnapshot();
+    });
   });
 
   describe('Struct & Complete Models', () => {

--- a/test/generators/rust/presets/__snapshots__/CommonPreset.spec.ts.snap
+++ b/test/generators/rust/presets/__snapshots__/CommonPreset.spec.ts.snap
@@ -5,7 +5,7 @@ exports[`RUST_COMMON_PRESET Enum should render \`enum\` of union type with Defau
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Address {
     #[serde(rename=\\"members\\")]
-    members: crate::Members,
+    members: Box<crate::Members>,
     #[serde(rename=\\"optional_members\\", skip_serializing_if = \\"Option::is_none\\")]
     optional_members: Option<Box<crate::OptionalMembers>>,
     #[serde(rename=\\"additionalProperties\\", skip_serializing_if = \\"Option::is_none\\")]
@@ -15,7 +15,7 @@ pub struct Address {
 impl Address {
     pub fn new(members: crate::Members, optional_members: Option<crate::OptionalMembers>, additional_properties: Option<std::collections::HashMap<String, String>>) -> Address {
         Address {
-        members,
+        Box::new(members),
         optional_members: optional_members.map(Box::new),
         additional_properties,
         }
@@ -59,7 +59,7 @@ exports[`RUST_COMMON_PRESET Enum should render \`enum\` of union type with Defau
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Address {
     #[serde(rename=\\"members\\")]
-    members: crate::Members,
+    members: Box<crate::Members>,
     #[serde(rename=\\"optional_members\\", skip_serializing_if = \\"Option::is_none\\")]
     optional_members: Option<Box<crate::OptionalMembers>>,
     #[serde(rename=\\"additionalProperties\\", skip_serializing_if = \\"Option::is_none\\")]
@@ -69,7 +69,7 @@ pub struct Address {
 impl Address {
     pub fn new(members: crate::Members, optional_members: Option<crate::OptionalMembers>, additional_properties: Option<std::collections::HashMap<String, String>>) -> Address {
         Address {
-        members,
+        Box::new(members),
         optional_members: optional_members.map(Box::new),
         additional_properties,
         }

--- a/test/generators/rust/presets/__snapshots__/CommonPreset.spec.ts.snap
+++ b/test/generators/rust/presets/__snapshots__/CommonPreset.spec.ts.snap
@@ -2,18 +2,18 @@
 
 exports[`RUST_COMMON_PRESET Enum should render \`enum\` of union type with Default implementation of integer type 1`] = `
 "// Address represents a Address model.
-#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Address {
     #[serde(rename=\\"members\\")]
-    members: Box<crate::Members>,
+    members: Members,
     #[serde(rename=\\"optional_members\\", skip_serializing_if = \\"Option::is_none\\")]
-    optional_members: Option<Box<crate::OptionalMembers>>,
+    optional_members: Option<Box<OptionalMembers>>,
     #[serde(rename=\\"additionalProperties\\", skip_serializing_if = \\"Option::is_none\\")]
     additional_properties: Option<std::collections::HashMap<String, String>>,
 }
 
 impl Address {
-    pub fn new(members: Members, optional_members: Option<crate::OptionalMembers>, additional_properties: Option<std::collections::HashMap<String, String>>) -> Address {
+    pub fn new(members: Members, optional_members: Option<OptionalMembers>, additional_properties: Option<std::collections::HashMap<String, String>>) -> Address {
         Address {
         members,
         optional_members: optional_members.map(Box::new),
@@ -26,7 +26,7 @@ impl Address {
 
 exports[`RUST_COMMON_PRESET Enum should render \`enum\` of union type with Default implementation of integer type 2`] = `
 "// Members represents a union of types: String, f64, bool
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, PartialOrd, Serialize)]
 pub enum Members {
     #[serde(rename=\\"Members0\\")]
     Members0(String),
@@ -41,7 +41,7 @@ pub enum Members {
 
 exports[`RUST_COMMON_PRESET Enum should render \`enum\` of union type with Default implementation of integer type 3`] = `
 "// OptionalMembers represents a union of types: String, f64, bool
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, PartialOrd, Serialize)]
 pub enum OptionalMembers {
     #[serde(rename=\\"OptionalMembers0\\")]
     OptionalMembers0(String),
@@ -56,18 +56,18 @@ pub enum OptionalMembers {
 
 exports[`RUST_COMMON_PRESET Enum should render \`enum\` of union type with Default implementation of string type 1`] = `
 "// Address represents a Address model.
-#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Address {
     #[serde(rename=\\"members\\")]
-    members: Box<crate::Members>,
+    members: Members,
     #[serde(rename=\\"optional_members\\", skip_serializing_if = \\"Option::is_none\\")]
-    optional_members: Option<Box<crate::OptionalMembers>>,
+    optional_members: Option<Box<OptionalMembers>>,
     #[serde(rename=\\"additionalProperties\\", skip_serializing_if = \\"Option::is_none\\")]
     additional_properties: Option<std::collections::HashMap<String, String>>,
 }
 
 impl Address {
-    pub fn new(members: Members, optional_members: Option<crate::OptionalMembers>, additional_properties: Option<std::collections::HashMap<String, String>>) -> Address {
+    pub fn new(members: Members, optional_members: Option<OptionalMembers>, additional_properties: Option<std::collections::HashMap<String, String>>) -> Address {
         Address {
         members,
         optional_members: optional_members.map(Box::new),
@@ -80,7 +80,7 @@ impl Address {
 
 exports[`RUST_COMMON_PRESET Enum should render \`enum\` of union type with Default implementation of string type 2`] = `
 "// Members represents a union of types: String, f64, bool
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, PartialOrd, Serialize)]
 pub enum Members {
     #[serde(rename=\\"Members0\\")]
     Members0(String),
@@ -95,7 +95,7 @@ pub enum Members {
 
 exports[`RUST_COMMON_PRESET Enum should render \`enum\` of union type with Default implementation of string type 3`] = `
 "// OptionalMembers represents a union of types: String, f64, bool
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, PartialOrd, Serialize)]
 pub enum OptionalMembers {
     #[serde(rename=\\"OptionalMembers0\\")]
     OptionalMembers0(String),
@@ -203,9 +203,9 @@ pub struct Address {
     #[serde(rename=\\"marriage\\", skip_serializing_if = \\"Option::is_none\\")]
     marriage: Option<bool>,
     #[serde(rename=\\"members\\", skip_serializing_if = \\"Option::is_none\\")]
-    members: Option<Box<crate::Members>>,
+    members: Option<Box<Members>>,
     #[serde(rename=\\"tuple_type\\", skip_serializing_if = \\"Option::is_none\\")]
-    tuple_type: Option<Box<crate::TupleType>>,
+    tuple_type: Option<Box<TupleType>>,
     #[serde(rename=\\"array_type\\")]
     array_type: Vec<String>,
     #[serde(rename=\\"additionalProperties\\", skip_serializing_if = \\"Option::is_none\\")]
@@ -213,7 +213,7 @@ pub struct Address {
 }
 
 impl Address {
-    pub fn new(street_name: String, city: String, state: String, house_number: f64, marriage: Option<bool>, members: Option<crate::Members>, tuple_type: Option<crate::TupleType>, array_type: Vec<String>, additional_properties: Option<std::collections::HashMap<String, String>>) -> Address {
+    pub fn new(street_name: String, city: String, state: String, house_number: f64, marriage: Option<bool>, members: Option<Members>, tuple_type: Option<TupleType>, array_type: Vec<String>, additional_properties: Option<std::collections::HashMap<String, String>>) -> Address {
         Address {
         street_name,
         city,
@@ -232,7 +232,7 @@ impl Address {
 
 exports[`RUST_COMMON_PRESET Struct & Complete Models should render \`struct\` type with all implementations 2`] = `
 "// Members represents a union of types: String, f64, bool
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, PartialOrd, Serialize)]
 pub enum Members {
     #[serde(rename=\\"Members0\\")]
     Members0(String),
@@ -247,7 +247,7 @@ pub enum Members {
 
 exports[`RUST_COMMON_PRESET Struct & Complete Models should render \`struct\` type with all implementations 3`] = `
 "// TupleType represents a TupleType model.
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, PartialOrd, Serialize)]
 pub struct TupleType(String, f64);
 
 impl TupleType {
@@ -274,9 +274,9 @@ pub struct Address {
     #[serde(rename=\\"marriage\\", skip_serializing_if = \\"Option::is_none\\")]
     marriage: Option<bool>,
     #[serde(rename=\\"members\\", skip_serializing_if = \\"Option::is_none\\")]
-    members: Option<Box<crate::Members>>,
+    members: Option<Box<Members>>,
     #[serde(rename=\\"tuple_type\\", skip_serializing_if = \\"Option::is_none\\")]
-    tuple_type: Option<Box<crate::TupleType>>,
+    tuple_type: Option<Box<TupleType>>,
     #[serde(rename=\\"array_type\\")]
     array_type: Vec<String>,
     #[serde(rename=\\"additionalProperties\\", skip_serializing_if = \\"Option::is_none\\")]

--- a/test/generators/rust/presets/__snapshots__/CommonPreset.spec.ts.snap
+++ b/test/generators/rust/presets/__snapshots__/CommonPreset.spec.ts.snap
@@ -5,15 +5,15 @@ exports[`RUST_COMMON_PRESET Enum should render \`enum\` of union type with Defau
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Address {
     #[serde(rename=\\"members\\")]
-    members: Members,
+    members: crate::Members,
     #[serde(rename=\\"optional_members\\", skip_serializing_if = \\"Option::is_none\\")]
-    optional_members: Option<Box<OptionalMembers>>,
+    optional_members: Option<Box<crate::OptionalMembers>>,
     #[serde(rename=\\"additionalProperties\\", skip_serializing_if = \\"Option::is_none\\")]
     additional_properties: Option<std::collections::HashMap<String, String>>,
 }
 
 impl Address {
-    pub fn new(members: Members, optional_members: Option<OptionalMembers>, additional_properties: Option<std::collections::HashMap<String, String>>) -> Address {
+    pub fn new(members: crate::Members, optional_members: Option<crate::OptionalMembers>, additional_properties: Option<std::collections::HashMap<String, String>>) -> Address {
         Address {
         members,
         optional_members: optional_members.map(Box::new),
@@ -59,15 +59,15 @@ exports[`RUST_COMMON_PRESET Enum should render \`enum\` of union type with Defau
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Address {
     #[serde(rename=\\"members\\")]
-    members: Members,
+    members: crate::Members,
     #[serde(rename=\\"optional_members\\", skip_serializing_if = \\"Option::is_none\\")]
-    optional_members: Option<Box<OptionalMembers>>,
+    optional_members: Option<Box<crate::OptionalMembers>>,
     #[serde(rename=\\"additionalProperties\\", skip_serializing_if = \\"Option::is_none\\")]
     additional_properties: Option<std::collections::HashMap<String, String>>,
 }
 
 impl Address {
-    pub fn new(members: Members, optional_members: Option<OptionalMembers>, additional_properties: Option<std::collections::HashMap<String, String>>) -> Address {
+    pub fn new(members: crate::Members, optional_members: Option<crate::OptionalMembers>, additional_properties: Option<std::collections::HashMap<String, String>>) -> Address {
         Address {
         members,
         optional_members: optional_members.map(Box::new),
@@ -203,9 +203,9 @@ pub struct Address {
     #[serde(rename=\\"marriage\\", skip_serializing_if = \\"Option::is_none\\")]
     marriage: Option<bool>,
     #[serde(rename=\\"members\\", skip_serializing_if = \\"Option::is_none\\")]
-    members: Option<Box<Members>>,
+    members: Option<Box<crate::Members>>,
     #[serde(rename=\\"tuple_type\\", skip_serializing_if = \\"Option::is_none\\")]
-    tuple_type: Option<Box<TupleType>>,
+    tuple_type: Option<Box<crate::TupleType>>,
     #[serde(rename=\\"array_type\\")]
     array_type: Vec<String>,
     #[serde(rename=\\"additionalProperties\\", skip_serializing_if = \\"Option::is_none\\")]
@@ -213,7 +213,7 @@ pub struct Address {
 }
 
 impl Address {
-    pub fn new(street_name: String, city: String, state: String, house_number: f64, marriage: Option<bool>, members: Option<Members>, tuple_type: Option<TupleType>, array_type: Vec<String>, additional_properties: Option<std::collections::HashMap<String, String>>) -> Address {
+    pub fn new(street_name: String, city: String, state: String, house_number: f64, marriage: Option<bool>, members: Option<crate::Members>, tuple_type: Option<crate::TupleType>, array_type: Vec<String>, additional_properties: Option<std::collections::HashMap<String, String>>) -> Address {
         Address {
         street_name,
         city,
@@ -274,9 +274,9 @@ pub struct Address {
     #[serde(rename=\\"marriage\\", skip_serializing_if = \\"Option::is_none\\")]
     marriage: Option<bool>,
     #[serde(rename=\\"members\\", skip_serializing_if = \\"Option::is_none\\")]
-    members: Option<Box<Members>>,
+    members: Option<Box<crate::Members>>,
     #[serde(rename=\\"tuple_type\\", skip_serializing_if = \\"Option::is_none\\")]
-    tuple_type: Option<Box<TupleType>>,
+    tuple_type: Option<Box<crate::TupleType>>,
     #[serde(rename=\\"array_type\\")]
     array_type: Vec<String>,
     #[serde(rename=\\"additionalProperties\\", skip_serializing_if = \\"Option::is_none\\")]

--- a/test/generators/rust/presets/__snapshots__/CommonPreset.spec.ts.snap
+++ b/test/generators/rust/presets/__snapshots__/CommonPreset.spec.ts.snap
@@ -188,6 +188,64 @@ impl Default for CustomEnum {
 }"
 `;
 
+exports[`RUST_COMMON_PRESET Enum should render reserved union for dict array 1`] = `
+"// Class represents a Class model.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Class {
+    #[serde(rename=\\"students\\")]
+    students: Vec<crate::ReservedUnion>,
+    #[serde(rename=\\"additionalProperties\\", skip_serializing_if = \\"Option::is_none\\")]
+    additional_properties: Option<std::collections::HashMap<String, serde_json::Value>>,
+}
+
+impl Class {
+    pub fn new(students: Vec<crate::ReservedUnion>, additional_properties: Option<std::collections::HashMap<String, serde_json::Value>>) -> Class {
+        Class {
+        students,
+        additional_properties,
+        }
+    }
+}
+"
+`;
+
+exports[`RUST_COMMON_PRESET Enum should render reserved union for dict array 2`] = `
+"// ReservedUnion represents a union of types: Student0, serde_json::Value
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum ReservedUnion {
+    #[serde(rename=\\"Student0\\")]
+    Student0(crate::Student),
+    #[serde(rename=\\"Undefined1\\")]
+    Undefined1(serde_json::Value),
+}
+
+"
+`;
+
+exports[`RUST_COMMON_PRESET Enum should render reserved union for dict array 3`] = `
+"// Student represents a Student model.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Student {
+    #[serde(rename=\\"name\\")]
+    name: String,
+    #[serde(rename=\\"birth\\")]
+    birth: f64,
+    #[serde(rename=\\"additionalProperties\\", skip_serializing_if = \\"Option::is_none\\")]
+    additional_properties: Option<std::collections::HashMap<String, serde_json::Value>>,
+}
+
+impl Student {
+    pub fn new(name: String, birth: f64, additional_properties: Option<std::collections::HashMap<String, serde_json::Value>>) -> Student {
+        Student {
+        name,
+        birth,
+        additional_properties,
+        }
+    }
+}
+"
+`;
+
 exports[`RUST_COMMON_PRESET Struct & Complete Models should render \`struct\` type with all implementations 1`] = `
 "// Address represents a Address model.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]


### PR DESCRIPTION
**Description**

Locally tried Rust generator with more complicated private examples and got some compile errors in the generate Rust crate.
The PR makes compile pass fixing the following issues:

* Remove warnings in case the model name contains the dash + number (e.g. `Abc_123`)
* Compile errors due to mismatch of some Option field definitions and constructors in struct 
* Fix broken generated file names
* Fix invalid type name included in generated Union types
* Fix the missing qualifer `crate::` in some cases
* Fix undefined error when schemaUid doesn't exist
