### PR TITLE
fix: undefined error when schemaUid isn't set

### DIFF
--- a/src/processors/AsyncAPIInputProcessor.ts
+++ b/src/processors/AsyncAPIInputProcessor.ts
@@ -63,7 +63,7 @@ export class AsyncAPIInputProcessor extends AbstractInputProcessor {
     
     let schemaUid = schema.uid();
     //Because the constraint functionality of generators cannot handle -, <, >, we remove them from the id if it's an anonymous schema.
-    if (schemaUid.includes('<anonymous-schema')) {
+    if (typeof schemaUid !== 'undefined' && schemaUid.includes('<anonymous-schema')) {
       schemaUid = schemaUid.replace('<', '').replace(/-/g, '_').replace('>', '');
     }
     


### PR DESCRIPTION
**Description**

This will fix type error when type field is omitted in schemas in AsyncAPI spec

**Related issue(s)**

Resolves #875

**Test results**

```javascript
import { JavaScriptGenerator } from '../../src';
import { parse } from 'yaml'

const generator = new JavaScriptGenerator();
const spec = `
asyncapi: 2.0.0
id: "https://github.com/yushiomote/hoge"
info:
  title: "Test"
  version: 2.0.0
defaultContentType: application/json
channels:
  hello:
    publish:
      message:
        name: hello
        payload:
          # type: object <- we omit type field
          properties:
            v1: { type: string }
            v2: { type: string }
            v3: { type: string }
`;

export async function generate() : Promise<void> {
  const models = await generator.generate(parse(spec));
  for (const model of models) {
    console.log(model.result);
  }
}
generate();
```

```sh
npm run start

> start
> ../../node_modules/.bin/ts-node --cwd ../../ ./examples/$npm_package_config_example_name/index.ts

class AnonymousSchema_1 {
  v1;
  v2;
  v3;

  constructor(input) {
    if (input.hasOwnProperty('v1')) {
      this.v1 = input.v1;
    }
    if (input.hasOwnProperty('v2')) {
      this.v2 = input.v2;
    }
    if (input.hasOwnProperty('v3')) {
      this.v3 = input.v3;
    }
  }

  get v1() { return this.v1; }
  set v1(v1) { this.v1 = v1; }

  get v2() { return this.v2; }
  set v2(v2) { this.v2 = v2; }

  get v3() { return this.v3; }
  set v3(v3) { this.v3 = v3; }
}
```
