### PR TITLE
refactor: generate enums of fixed types

### DIFF
--- a/test/generators/go/GoGenerator.spec.ts
+++ b/test/generators/go/GoGenerator.spec.ts
@@ -66,7 +66,7 @@ describe('GoGenerator', () => {
   test('should render `enum` with mixed types', async () => {
     const doc = {
       $id: 'Things',
-      enum: ['Texas', 1, '1', false, { test: 'test' }],
+      enum: ['Texas', 1, '1', false, { objectTest: 'test' }, ["one", 2, "three"]],
     };
     const models = await generator.generate(doc);
     expect(models).toHaveLength(1);

--- a/test/generators/go/constrainer/EnumConstrainer.spec.ts
+++ b/test/generators/go/constrainer/EnumConstrainer.spec.ts
@@ -48,8 +48,23 @@ describe('EnumConstrainer', () => {
       expect(constrainedValue).toEqual(123);
     });
     test('should render object', () => {
-      const constrainedValue = GoDefaultConstraints.enumValue({enumModel, constrainedEnumModel, enumValue: {test: 'test'}});
-      expect(constrainedValue).toEqual('{"test":"test"}');
+      const value = {
+        test: 'test', 
+        aNumber: 123, 
+        multipleObjects: {
+          anotherObject: {
+            test: 'test',
+          }
+        },
+        anArray: [
+          "elementOne",
+          2,
+          {test: "test"},
+          [{test: "test"}]
+        ]
+      };
+      const constrainedValue = GoDefaultConstraints.enumValue({enumModel, constrainedEnumModel, enumValue: value});
+      expect(constrainedValue).toEqual('map[string]any{"test":"test,"aNumber":123,"multipleObjects":map[string]any{"anotherObject":map[string]any{"test":"test}}}');
     });
     test('should render unknown value', () => {
       const constrainedValue = GoDefaultConstraints.enumValue({enumModel, constrainedEnumModel, enumValue: undefined});


### PR DESCRIPTION
**Description**

This Draft PR is my best effort on generating Go enums of mixed types. This is not finished, as there are some issues that I didn't fix yet (a matter of time and priority), but hopefully is useful to inspire someone to take where I left.

The idea is that the generated code should look like: 

<details>

```go
package main

import (
	"reflect"
)

// Test represents a Test model.
type Test struct {
	EnumProp *EnumTest `json:"enumProp,omitempty"`
}

type EnumTest uint

const (
	EnumTestSomeSpaceEnumSpaceString EnumTest = iota
	EnumTestTrue
	EnumTestCurlyleftQuotationTestQuotationColonQuotationTestQuotationCurlyright
	EnumTestSquareleftQuotationOneQuotationComma2CommaQuotationThreeQuotationSquareright
	EnumTestNumber_2
)

// UnmarshalJSON implements json.Unmarshaler interface.
func (op *EnumTest) UnmarshalJSON(raw []byte) error {
	var v any
	if err := json.Unmarshal(raw, &v); err != nil {
		return err
	}
	*op = ValuesToEnumFunc(v)
	return nil
}

// Value returns the value of the enum.
func (op EnumTest) Value() any {
	if op >= EnumTest(len(ScalarEnumTestValues)) {
		return nil
	}
	return ScalarEnumTestValues[op]
}

var ScalarEnumTestValues = []any{
	"Some enum String",
	true,
	map[string]any{"test": "test", "anotherObject": map[string]any{"foo": "bar"}},
	2,
}

var ScalarValuesToEnumTest = map[any]EnumTest{
	ScalarEnumTestValues[EnumTestSomeSpaceEnumSpaceString]: EnumTestSomeSpaceEnumSpaceString,
	ScalarEnumTestValues[EnumTestTrue]:                     EnumTestTrue,
	ScalarEnumTestValues[EnumTestNumber_2]:                 EnumTestNumber_2,
}
var EnumTestToObjectValues = map[EnumTest]map[string]any{
	EnumTestCurlyleftQuotationTestQuotationColonQuotationTestQuotationCurlyright: {"objectTest": "test", "anotherObject": map[string]any{"foo": "bar"}},
}

var EnumTestToSliceValues = map[EnumTest][]any{
	EnumTestSquareleftQuotationOneQuotationComma2CommaQuotationThreeQuotationSquareright: {"hello"},
}

func ValuesToEnumFunc(v any) EnumTest {
	switch v.(type) {
	case map[string]any:
		// One if for each JSON object detected. Not nice in terms of performance.
		if reflect.DeepEqual(v, EnumTestToObjectValues[EnumTestCurlyleftQuotationTestQuotationColonQuotationTestQuotationCurlyright]) {
			return EnumTestCurlyleftQuotationTestQuotationColonQuotationTestQuotationCurlyright
		}
	case []any:
		// One if for each JSON array detected. Not nice in terms of performance.
		if reflect.DeepEqual(v, EnumTestToSliceValues[EnumTestSquareleftQuotationOneQuotationComma2CommaQuotationThreeQuotationSquareright]) {
			return EnumTestSquareleftQuotationOneQuotationComma2CommaQuotationThreeQuotationSquareright
		}
	}
	return ScalarValuesToEnumTest[v]
}

```

</details>

cc @jonaslagoni @magicmatatjahu 

**Related issue(s)**
Relates to https://github.com/asyncapi/modelina/pull/867/files#r978599788