### PR TITLE
fix: python generate unusable class for empty properties

### DIFF
--- a/src/generators/python/renderers/ClassRenderer.ts
+++ b/src/generators/python/renderers/ClassRenderer.ts
@@ -76,13 +76,20 @@ export const PYTHON_DEFAULT_CLASS_PRESET: ClassPresetType<PythonOptions> = {
   },
   ctor({renderer, model}) {
     const properties = model.properties || {};
-    const assigments = Object.values(properties).map((property) => {
-      if (!property.required) {
-        return `if hasattr(input, '${property.propertyName}'):\n\tself._${property.propertyName} = input.${property.propertyName}`;
-      }
-      return `self._${property.propertyName} = input.${property.propertyName}`;
-    });
-    const body = renderer.renderBlock(assigments);
+    let body = '';
+    if(Object.keys(properties).length > 0) {
+      const assigments = Object.values(properties).map((property) => {
+        if (!property.required) {
+          return `if hasattr(input, '${property.propertyName}'):\n\tself._${property.propertyName} = input.${property.propertyName}`;
+        }
+        return `self._${property.propertyName} = input.${property.propertyName}`;
+      });
+      body = renderer.renderBlock(assigments);
+    } else {
+      body = `"""
+No properties
+"""`;
+    }
     return `def __init__(self, input):
 ${renderer.indent(body)}`;
   },

--- a/src/generators/python/renderers/ClassRenderer.ts
+++ b/src/generators/python/renderers/ClassRenderer.ts
@@ -77,7 +77,7 @@ export const PYTHON_DEFAULT_CLASS_PRESET: ClassPresetType<PythonOptions> = {
   ctor({renderer, model}) {
     const properties = model.properties || {};
     let body = '';
-    if(Object.keys(properties).length > 0) {
+    if (Object.keys(properties).length > 0) {
       const assigments = Object.values(properties).map((property) => {
         if (!property.required) {
           return `if hasattr(input, '${property.propertyName}'):\n\tself._${property.propertyName} = input.${property.propertyName}`;

--- a/test/generators/python/PythonGenerator.spec.ts
+++ b/test/generators/python/PythonGenerator.spec.ts
@@ -128,5 +128,19 @@ describe('PythonGenerator', () => {
       expect(models[0].result).toMatchSnapshot();
       expect(models[0].dependencies).toEqual(expectedDependencies);
     });
+    test('should work with empty objects', async () => {
+      const doc = {
+        $id: 'CustomClass',
+        type: 'object',
+        additionalProperties: false
+      };
+      generator = new PythonGenerator();
+      const expectedDependencies: string[] = [];
+  
+      const models = await generator.generate(doc);
+      expect(models).toHaveLength(1);
+      expect(models[0].result).toMatchSnapshot();
+      expect(models[0].dependencies).toEqual(expectedDependencies);
+    });
   });
 });

--- a/test/generators/python/__snapshots__/PythonGenerator.spec.ts.snap
+++ b/test/generators/python/__snapshots__/PythonGenerator.spec.ts.snap
@@ -23,3 +23,12 @@ exports[`PythonGenerator Class should not render reserved keyword 1`] = `
   	self._reservedDel = reservedDel
 "
 `;
+
+exports[`PythonGenerator Class should work with empty objects 1`] = `
+"class CustomClass: 
+  def __init__(self, input):
+    \\"\\"\\"
+    No properties
+    \\"\\"\\"
+"
+`;


### PR DESCRIPTION
**Description**
If the class generator tries to render one with no properties, the class file is unable to compile. 

This change is part of fixing the black-box tests.