### PR TITLE
fix: wrong typescript number type used for integers

### DIFF
--- a/src/generators/typescript/TypeScriptConstrainer.ts
+++ b/src/generators/typescript/TypeScriptConstrainer.ts
@@ -20,7 +20,7 @@ export const TypeScriptDefaultTypeMapping: TypeMapping<TypeScriptOptions> = {
     return 'number';
   },
   Integer (): string {
-    return 'integer'; 
+    return 'number'; 
   },
   String (): string {
     return 'string';

--- a/test/generators/typescript/TypeScriptConstrainer.spec.ts
+++ b/test/generators/typescript/TypeScriptConstrainer.spec.ts
@@ -34,7 +34,7 @@ describe('TypeScriptConstrainer', () => {
     test('should render type', () => {
       const model = new ConstrainedIntegerModel('test', undefined, '');
       const type = TypeScriptDefaultTypeMapping.Integer({constrainedModel: model, options: TypeScriptGenerator.defaultOptions});
-      expect(type).toEqual('integer');
+      expect(type).toEqual('number');
     });
   });
   describe('String', () => { 


### PR DESCRIPTION
**Description**
There does not exist a type called `interger` for typescript numbers.

This change is part of fixing the black-box tests.