### PR TITLE
fix: duplicate and self dependencies should not being rendered

### DIFF
--- a/src/helpers/ConstrainHelpers.ts
+++ b/src/helpers/ConstrainHelpers.ts
@@ -215,26 +215,26 @@ export function constrainMetaModel<Options>(typeMapping: TypeMapping<Options>, c
     return constrainArrayModel(typeMapping, constrainRules, {...newContext, metaModel: newContext.metaModel}, alreadySeenModels);
   } else if (newContext.metaModel instanceof UnionModel) {
     return constrainUnionModel(typeMapping, constrainRules, {...newContext, metaModel: newContext.metaModel}, alreadySeenModels);
-  } else {
-    // Simple models are those who does not have properties that contain other MetaModels.
-    let simpleModel: ConstrainedMetaModel | undefined;
-    if (newContext.metaModel instanceof EnumModel) {
-      simpleModel = ConstrainEnumModel(typeMapping, constrainRules, {...newContext, metaModel: newContext.metaModel});
-    }else if (newContext.metaModel instanceof BooleanModel) {
-      simpleModel = constrainBooleanModel(typeMapping, {...newContext, metaModel: newContext.metaModel});
-    } else if (newContext.metaModel instanceof AnyModel) {
-      simpleModel = constrainAnyModel(typeMapping, {...newContext, metaModel: newContext.metaModel});
-    } else if (newContext.metaModel instanceof FloatModel) {
-      simpleModel = constrainFloatModel(typeMapping, {...newContext, metaModel: newContext.metaModel});
-    } else if (newContext.metaModel instanceof IntegerModel) {
-      simpleModel = constrainIntegerModel(typeMapping, {...newContext, metaModel: newContext.metaModel});
-    } else if (newContext.metaModel instanceof StringModel) {
-      simpleModel = constrainStringModel(typeMapping, {...newContext, metaModel: newContext.metaModel});
-    }
-    if (simpleModel !== undefined) {
-      alreadySeenModels.set(context.metaModel, simpleModel); 
-      return simpleModel;
-    }
   }
+  // Simple models are those who does not have properties that contain other MetaModels.
+  let simpleModel: ConstrainedMetaModel | undefined;
+  if (newContext.metaModel instanceof EnumModel) {
+    simpleModel = ConstrainEnumModel(typeMapping, constrainRules, {...newContext, metaModel: newContext.metaModel});
+  } else if (newContext.metaModel instanceof BooleanModel) {
+    simpleModel = constrainBooleanModel(typeMapping, {...newContext, metaModel: newContext.metaModel});
+  } else if (newContext.metaModel instanceof AnyModel) {
+    simpleModel = constrainAnyModel(typeMapping, {...newContext, metaModel: newContext.metaModel});
+  } else if (newContext.metaModel instanceof FloatModel) {
+    simpleModel = constrainFloatModel(typeMapping, {...newContext, metaModel: newContext.metaModel});
+  } else if (newContext.metaModel instanceof IntegerModel) {
+    simpleModel = constrainIntegerModel(typeMapping, {...newContext, metaModel: newContext.metaModel});
+  } else if (newContext.metaModel instanceof StringModel) {
+    simpleModel = constrainStringModel(typeMapping, {...newContext, metaModel: newContext.metaModel});
+  }
+  if (simpleModel !== undefined) {
+    alreadySeenModels.set(context.metaModel, simpleModel); 
+    return simpleModel;
+  }
+
   throw new Error('Could not constrain model');
 }

--- a/src/helpers/ConstrainHelpers.ts
+++ b/src/helpers/ConstrainHelpers.ts
@@ -207,26 +207,34 @@ export function constrainMetaModel<Options>(typeMapping: TypeMapping<Options>, c
     return constrainObjectModel(typeMapping, constrainRules, {...newContext, metaModel: newContext.metaModel}, alreadySeenModels);
   } else if (newContext.metaModel instanceof ReferenceModel) {
     return constrainReferenceModel(typeMapping, constrainRules, {...newContext, metaModel: newContext.metaModel}, alreadySeenModels);
-  } else if (newContext.metaModel instanceof AnyModel) {
-    return constrainAnyModel(typeMapping, {...newContext, metaModel: newContext.metaModel});
-  } else if (newContext.metaModel instanceof FloatModel) {
-    return constrainFloatModel(typeMapping, {...newContext, metaModel: newContext.metaModel});
-  } else if (newContext.metaModel instanceof IntegerModel) {
-    return constrainIntegerModel(typeMapping, {...newContext, metaModel: newContext.metaModel});
-  } else if (newContext.metaModel instanceof StringModel) {
-    return constrainStringModel(typeMapping, {...newContext, metaModel: newContext.metaModel});
-  } else if (newContext.metaModel instanceof BooleanModel) {
-    return constrainBooleanModel(typeMapping, {...newContext, metaModel: newContext.metaModel});
+  } else if (newContext.metaModel instanceof DictionaryModel) {
+    return constrainDictionaryModel(typeMapping, constrainRules, {...newContext, metaModel: newContext.metaModel}, alreadySeenModels);
   } else if (newContext.metaModel instanceof TupleModel) {
     return constrainTupleModel(typeMapping, constrainRules, {...newContext, metaModel: newContext.metaModel}, alreadySeenModels);
   } else if (newContext.metaModel instanceof ArrayModel) {
     return constrainArrayModel(typeMapping, constrainRules, {...newContext, metaModel: newContext.metaModel}, alreadySeenModels);
   } else if (newContext.metaModel instanceof UnionModel) {
     return constrainUnionModel(typeMapping, constrainRules, {...newContext, metaModel: newContext.metaModel}, alreadySeenModels);
-  } else if (newContext.metaModel instanceof EnumModel) {
-    return ConstrainEnumModel(typeMapping, constrainRules, {...newContext, metaModel: newContext.metaModel});
-  } else if (newContext.metaModel instanceof DictionaryModel) {
-    return constrainDictionaryModel(typeMapping, constrainRules, {...newContext, metaModel: newContext.metaModel}, alreadySeenModels);
+  } else {
+    // Simple models are those who does not have properties that contain other MetaModels.
+    let simpleModel: ConstrainedMetaModel | undefined;
+    if (newContext.metaModel instanceof EnumModel) {
+      simpleModel = ConstrainEnumModel(typeMapping, constrainRules, {...newContext, metaModel: newContext.metaModel});
+    }else if (newContext.metaModel instanceof BooleanModel) {
+      simpleModel = constrainBooleanModel(typeMapping, {...newContext, metaModel: newContext.metaModel});
+    } else if (newContext.metaModel instanceof AnyModel) {
+      simpleModel = constrainAnyModel(typeMapping, {...newContext, metaModel: newContext.metaModel});
+    } else if (newContext.metaModel instanceof FloatModel) {
+      simpleModel = constrainFloatModel(typeMapping, {...newContext, metaModel: newContext.metaModel});
+    } else if (newContext.metaModel instanceof IntegerModel) {
+      simpleModel = constrainIntegerModel(typeMapping, {...newContext, metaModel: newContext.metaModel});
+    } else if (newContext.metaModel instanceof StringModel) {
+      simpleModel = constrainStringModel(typeMapping, {...newContext, metaModel: newContext.metaModel});
+    }
+    if (simpleModel !== undefined) {
+      alreadySeenModels.set(context.metaModel, simpleModel); 
+      return simpleModel;
+    }
   }
   throw new Error('Could not constrain model');
 }

--- a/src/models/ConstrainedMetaModel.ts
+++ b/src/models/ConstrainedMetaModel.ts
@@ -1,4 +1,3 @@
-import { makeUnique } from '../utils/DependencyHelper';
 import { MetaModel } from './MetaModel';
 
 export abstract class ConstrainedMetaModel extends MetaModel {
@@ -60,7 +59,7 @@ export class ConstrainedTupleModel extends ConstrainedMetaModel {
     }
     
     //Ensure no duplicate references
-    dependencyModels = makeUnique(dependencyModels);
+    dependencyModels = [...new Set(dependencyModels)];
     
     return dependencyModels;
   }
@@ -113,7 +112,7 @@ export class ConstrainedUnionModel extends ConstrainedMetaModel {
     }
     
     //Ensure no duplicate references
-    dependencyModels = makeUnique(dependencyModels);
+    dependencyModels = [...new Set(dependencyModels)];
 
     return dependencyModels;
   }
@@ -157,7 +156,7 @@ export class ConstrainedDictionaryModel extends ConstrainedMetaModel {
     }
    
     //Ensure no duplicate references
-    dependencyModels = makeUnique(dependencyModels);
+    dependencyModels = [...new Set(dependencyModels)];
 
     return dependencyModels;
   }
@@ -189,7 +188,7 @@ export class ConstrainedObjectModel extends ConstrainedMetaModel {
     });
 
     //Ensure no duplicate references
-    dependencyModels = makeUnique(dependencyModels);
+    dependencyModels = [...new Set(dependencyModels)];
 
     return dependencyModels;
   }

--- a/src/models/ConstrainedMetaModel.ts
+++ b/src/models/ConstrainedMetaModel.ts
@@ -1,3 +1,4 @@
+import { makeUnique } from '../utils/DependencyHelper';
 import { MetaModel } from './MetaModel';
 
 export abstract class ConstrainedMetaModel extends MetaModel {
@@ -59,7 +60,7 @@ export class ConstrainedTupleModel extends ConstrainedMetaModel {
     }
     
     //Ensure no duplicate references
-    dependencyModels = [...new Set(dependencyModels)];
+    dependencyModels = makeUnique(dependencyModels);
     
     return dependencyModels;
   }
@@ -112,7 +113,7 @@ export class ConstrainedUnionModel extends ConstrainedMetaModel {
     }
     
     //Ensure no duplicate references
-    dependencyModels = [...new Set(dependencyModels)];
+    dependencyModels = makeUnique(dependencyModels);
 
     return dependencyModels;
   }
@@ -156,7 +157,7 @@ export class ConstrainedDictionaryModel extends ConstrainedMetaModel {
     }
    
     //Ensure no duplicate references
-    dependencyModels = [...new Set(dependencyModels)];
+    dependencyModels = makeUnique(dependencyModels);
 
     return dependencyModels;
   }
@@ -188,7 +189,7 @@ export class ConstrainedObjectModel extends ConstrainedMetaModel {
     });
 
     //Ensure no duplicate references
-    dependencyModels = [...new Set(dependencyModels)];
+    dependencyModels = makeUnique(dependencyModels);
 
     return dependencyModels;
   }

--- a/src/models/ConstrainedMetaModel.ts
+++ b/src/models/ConstrainedMetaModel.ts
@@ -1,3 +1,4 @@
+import { makeUnique } from '../utils/DependencyHelper';
 import { MetaModel } from './MetaModel';
 
 export abstract class ConstrainedMetaModel extends MetaModel {
@@ -59,7 +60,7 @@ export class ConstrainedTupleModel extends ConstrainedMetaModel {
     }
     
     //Ensure no duplicate references
-    dependencyModels = [...new Set(dependencyModels)];
+    dependencyModels = makeUnique(dependencyModels);
     
     return dependencyModels;
   }
@@ -112,7 +113,7 @@ export class ConstrainedUnionModel extends ConstrainedMetaModel {
     }
     
     //Ensure no duplicate references
-    dependencyModels = [...new Set(dependencyModels)];
+    dependencyModels = makeUnique(dependencyModels);
 
     return dependencyModels;
   }
@@ -130,20 +131,6 @@ export class ConstrainedEnumModel extends ConstrainedMetaModel {
     type: string, 
     public values: ConstrainedEnumValueModel[]) {
     super(name, originalInput, type);
-  }
-
-  getNearestDependencies(): ConstrainedMetaModel[] {
-    let dependencyModels = Object.values(this.values).filter(
-      (enumModel) => {
-        return enumModel.value instanceof ConstrainedReferenceModel;
-      }
-    ).map((enumModel) => {
-      return enumModel.value as ConstrainedReferenceModel;
-    });
-
-    //Ensure no duplicate references
-    dependencyModels = [...new Set(dependencyModels)];
-    return dependencyModels;
   }
 }
 export class ConstrainedDictionaryModel extends ConstrainedMetaModel {
@@ -170,7 +157,7 @@ export class ConstrainedDictionaryModel extends ConstrainedMetaModel {
     }
    
     //Ensure no duplicate references
-    dependencyModels = [...new Set(dependencyModels)];
+    dependencyModels = makeUnique(dependencyModels);
 
     return dependencyModels;
   }
@@ -196,8 +183,13 @@ export class ConstrainedObjectModel extends ConstrainedMetaModel {
       }
     }
 
+    //Ensure no self references
+    dependencyModels = dependencyModels.filter((referenceModel) => {
+      return referenceModel.name !== this.name;
+    });
+
     //Ensure no duplicate references
-    dependencyModels = [...new Set(dependencyModels)];
+    dependencyModels = makeUnique(dependencyModels);
 
     return dependencyModels;
   }

--- a/src/utils/DependencyHelper.ts
+++ b/src/utils/DependencyHelper.ts
@@ -18,12 +18,12 @@ export function renderJavaScriptDependency(toImport: string, fromModule: string,
  * 
  * @param array to make unique
  */
-export function makeUnique(array: ConstrainedMetaModel[]) {
-  let seen: Map<ConstrainedMetaModel, boolean> = new Map();
-  return array.filter(function(item) {
-    if(item instanceof ConstrainedReferenceModel) {
-      return seen.has(item.ref) ? false : seen.set(item.ref, true) && true;
+export function makeUnique(array: ConstrainedMetaModel[]): ConstrainedMetaModel[] {
+  const seen: Map<ConstrainedMetaModel, boolean> = new Map();
+  return array.filter((item: ConstrainedMetaModel) => {
+    if (item instanceof ConstrainedReferenceModel) {
+      return seen.has(item.ref) ? false : seen.set(item.ref, true);
     }
-    return seen.has(item) ? false : (seen.set(item, true));
+    return seen.has(item) ? false : seen.set(item, true);
   });
 }

--- a/src/utils/DependencyHelper.ts
+++ b/src/utils/DependencyHelper.ts
@@ -1,4 +1,4 @@
-import { ConstrainedMetaModel, ConstrainedReferenceModel } from "../models";
+import { ConstrainedMetaModel, ConstrainedReferenceModel } from '../models';
 
 /**
  * Function to make it easier to render JS/TS dependencies based on module system
@@ -20,16 +20,9 @@ export function renderJavaScriptDependency(toImport: string, fromModule: string,
  */
 export function makeUnique(array: ConstrainedMetaModel[]) {
   let seen: Map<ConstrainedMetaModel, boolean> = new Map();
-  let seen2 = [];
   return array.filter(function(item) {
     if(item instanceof ConstrainedReferenceModel) {
-      const hassomething = seen.has(item.ref);
-      if(hassomething) {
-        return false;
-      } else {
-        const addSomething = seen.set(item.ref, true) && true;
-        return addSomething;
-      }
+      return seen.has(item.ref) ? false : seen.set(item.ref, true) && true;
     }
     return seen.has(item) ? false : (seen.set(item, true));
   });

--- a/src/utils/DependencyHelper.ts
+++ b/src/utils/DependencyHelper.ts
@@ -1,3 +1,4 @@
+import { ConstrainedMetaModel, ConstrainedReferenceModel } from "../models";
 
 /**
  * Function to make it easier to render JS/TS dependencies based on module system
@@ -10,4 +11,26 @@ export function renderJavaScriptDependency(toImport: string, fromModule: string,
   return moduleSystem === 'CJS'
     ? `const ${toImport} = require('${fromModule}');`
     : `import ${toImport} from '${fromModule}';`;
+}
+
+/**
+ * Function to make an array only contain unique values (ignores different in memory instances)
+ * 
+ * @param array to make unique
+ */
+export function makeUnique(array: ConstrainedMetaModel[]) {
+  let seen: Map<ConstrainedMetaModel, boolean> = new Map();
+  let seen2 = [];
+  return array.filter(function(item) {
+    if(item instanceof ConstrainedReferenceModel) {
+      const hassomething = seen.has(item.ref);
+      if(hassomething) {
+        return false;
+      } else {
+        const addSomething = seen.set(item.ref, true) && true;
+        return addSomething;
+      }
+    }
+    return seen.has(item) ? false : (seen.set(item, true));
+  });
 }

--- a/src/utils/DependencyHelper.ts
+++ b/src/utils/DependencyHelper.ts
@@ -12,18 +12,3 @@ export function renderJavaScriptDependency(toImport: string, fromModule: string,
     ? `const ${toImport} = require('${fromModule}');`
     : `import ${toImport} from '${fromModule}';`;
 }
-
-/**
- * Function to make an array only contain unique values (ignores different in memory instances)
- * 
- * @param array to make unique
- */
-export function makeUnique(array: ConstrainedMetaModel[]): ConstrainedMetaModel[] {
-  const seen: Map<ConstrainedMetaModel, boolean> = new Map();
-  return array.filter((item: ConstrainedMetaModel) => {
-    if (item instanceof ConstrainedReferenceModel) {
-      return seen.has(item.ref) ? false : seen.set(item.ref, true);
-    }
-    return seen.has(item) ? false : seen.set(item, true);
-  });
-}

--- a/src/utils/DependencyHelper.ts
+++ b/src/utils/DependencyHelper.ts
@@ -12,3 +12,18 @@ export function renderJavaScriptDependency(toImport: string, fromModule: string,
     ? `const ${toImport} = require('${fromModule}');`
     : `import ${toImport} from '${fromModule}';`;
 }
+
+/**
+ * Function to make an array only contain unique values (ignores different in memory instances)
+ * 
+ * @param array to make unique
+ */
+export function makeUnique(array: ConstrainedMetaModel[]): ConstrainedMetaModel[] {
+  const seen: Map<ConstrainedMetaModel, boolean> = new Map();
+  return array.filter((item: ConstrainedMetaModel) => {
+    if (item instanceof ConstrainedReferenceModel) {
+      return seen.has(item.ref) ? false : seen.set(item.ref, true);
+    }
+    return seen.has(item) ? false : seen.set(item, true);
+  });
+}

--- a/src/utils/DependencyHelper.ts
+++ b/src/utils/DependencyHelper.ts
@@ -14,7 +14,7 @@ export function renderJavaScriptDependency(toImport: string, fromModule: string,
 }
 
 /**
- * Function to make an array only contain unique values (ignores different in memory instances)
+ * Function to make an array of ConstrainedMetaModels only contain unique values (ignores different in memory instances)
  * 
  * @param array to make unique
  */

--- a/test/helpers/ConstrainHelpers.spec.ts
+++ b/test/helpers/ConstrainHelpers.spec.ts
@@ -229,7 +229,8 @@ describe('ConstrainHelpers', () => {
   describe('constrain DictionaryModel', () => {
     test('should constrain correctly', () => {
       const stringModel = new StringModel('', undefined);
-      const metaModel = new DictionaryModel('test', undefined, stringModel, stringModel);
+      const stringModel2 = new StringModel('', undefined);
+      const metaModel = new DictionaryModel('test', undefined, stringModel, stringModel2);
       const constrainedModel = constrainMetaModel(mockedTypeMapping, mockedConstraints, {
         metaModel,
         options: {},

--- a/test/models/ConstrainedMetaModel.spec.ts
+++ b/test/models/ConstrainedMetaModel.spec.ts
@@ -131,6 +131,23 @@ describe('ConstrainedMetaModel', () => {
       const dependencies = model.getNearestDependencies();
       expect(dependencies).toHaveLength(1);
     });
+
+    test('should not return duplicate dependencies when different reference instances', () => {
+      const stringModel = new StringModel('', undefined);
+      const referenceModel = new ReferenceModel('', undefined, stringModel);
+      const referenceModel2 = new ReferenceModel('', undefined, stringModel);
+      const referenceTupleModel = new TupleValueModel(0, referenceModel);
+      const reference2TupleModel = new TupleValueModel(1, referenceModel2);
+      const rawModel = new TupleModel('test', undefined, [referenceTupleModel, reference2TupleModel]);
+
+      const model = constrainMetaModel(mockedTypeMapping, mockedConstraints, {
+        metaModel: rawModel,
+        constrainedName: '',
+        options: undefined
+      }) as ConstrainedTupleModel;
+      const dependencies = model.getNearestDependencies();
+      expect(dependencies).toHaveLength(1);
+    });
   });
   describe('ObjectModel', () => {
     test('should return inner reference dependencies', () => {
@@ -171,11 +188,47 @@ describe('ConstrainedMetaModel', () => {
       expect(dependencies[0]).toEqual(model.properties['reference'].property);
     });
 
+    test('should not return self reference', () => {
+      const rawModel = new ObjectModel('ObjectTest', undefined, {});
+      const referenceModel = new ReferenceModel(rawModel.name, undefined, rawModel);
+      const referenceObjectPropertyModel = new ObjectPropertyModel('self', false, referenceModel);
+      rawModel.properties['self'] = referenceObjectPropertyModel;
+      
+      const model = constrainMetaModel(mockedTypeMapping, mockedConstraints, {
+        metaModel: rawModel,
+        constrainedName: '',
+        options: undefined
+      }) as ConstrainedObjectModel;
+      const dependencies = model.getNearestDependencies();
+      expect(dependencies).toHaveLength(0);
+    });
+
     test('should not return duplicate dependencies', () => {
       const stringModel = new StringModel('string', undefined);
       const referenceModel = new ReferenceModel('reference', undefined, stringModel);
       const referenceObjectPropertyModel = new ObjectPropertyModel('reference', false, referenceModel);
       const reference2ObjectPropertyModel = new ObjectPropertyModel('reference2', false, referenceModel);
+      const rawModel = new ObjectModel('test', undefined, {
+        reference: referenceObjectPropertyModel,
+        reference2: reference2ObjectPropertyModel
+      });
+      
+      const model = constrainMetaModel(mockedTypeMapping, mockedConstraints, {
+        metaModel: rawModel,
+        constrainedName: '',
+        options: undefined
+      }) as ConstrainedObjectModel;
+      const dependencies = model.getNearestDependencies();
+      expect(dependencies).toHaveLength(1);
+      expect(dependencies[0]).toEqual(model.properties['reference'].property);
+    });
+
+    test('should not return duplicate dependencies when different reference instances', () => {
+      const stringModel = new StringModel('string', undefined);
+      const referenceModel = new ReferenceModel('reference', undefined, stringModel);
+      const referenceModel2 = new ReferenceModel('reference', undefined, stringModel);
+      const referenceObjectPropertyModel = new ObjectPropertyModel('reference', false, referenceModel);
+      const reference2ObjectPropertyModel = new ObjectPropertyModel('reference2', false, referenceModel2);
       const rawModel = new ObjectModel('test', undefined, {
         reference: referenceObjectPropertyModel,
         reference2: reference2ObjectPropertyModel
@@ -264,6 +317,22 @@ describe('ConstrainedMetaModel', () => {
       expect(dependencies).toHaveLength(1);
       expect(dependencies[0]).toEqual(model.key);
     });
+
+    test('should not return duplicate dependencies when different reference instances', () => {
+      const stringModel = new StringModel('', undefined);
+      const referenceModel = new ReferenceModel('', undefined, stringModel);
+      const referenceModel2 = new ReferenceModel('', undefined, stringModel);
+      const rawModel = new DictionaryModel('test', undefined, referenceModel, referenceModel2);
+      
+      const model = constrainMetaModel(mockedTypeMapping, mockedConstraints, {
+        metaModel: rawModel,
+        constrainedName: '',
+        options: undefined
+      }) as ConstrainedDictionaryModel;
+      const dependencies = model.getNearestDependencies();
+      expect(dependencies).toHaveLength(1);
+      expect(dependencies[0]).toEqual(model.key);
+    });
   });
   describe('ArrayModel', () => {
     test('should return all reference dependencies', () => {
@@ -329,6 +398,22 @@ describe('ConstrainedMetaModel', () => {
       const stringModel = new StringModel('', undefined);
       const referenceModel = new ReferenceModel('', undefined, stringModel);
       const rawModel = new UnionModel('test', undefined, [referenceModel, referenceModel]);
+      
+      const model = constrainMetaModel(mockedTypeMapping, mockedConstraints, {
+        metaModel: rawModel,
+        constrainedName: '',
+        options: undefined
+      }) as ConstrainedUnionModel;
+      const dependencies = model.getNearestDependencies();
+      expect(dependencies).toHaveLength(1);
+      expect(dependencies[0]).toEqual(model.union[0]);
+    });
+
+    test('should not return duplicate dependencies when different reference instances', () => {
+      const stringModel = new StringModel('', undefined);
+      const referenceModel = new ReferenceModel('', undefined, stringModel);
+      const referenceModel2 = new ReferenceModel('', undefined, stringModel);
+      const rawModel = new UnionModel('test', undefined, [referenceModel, referenceModel2]);
       
       const model = constrainMetaModel(mockedTypeMapping, mockedConstraints, {
         metaModel: rawModel,

--- a/test/utils/DependencyHelper.spec.ts
+++ b/test/utils/DependencyHelper.spec.ts
@@ -1,5 +1,4 @@
-import { ConstrainedReferenceModel, ConstrainedStringModel } from '../../src';
-import {renderJavaScriptDependency, makeUnique} from '../../src/utils'; 
+import {renderJavaScriptDependency} from '../../src/utils'; 
 
 describe('DependencyHelper', () => {
   describe('renderJavaScriptDependency', () => {
@@ -10,29 +9,6 @@ describe('DependencyHelper', () => {
     test('should render accurate ESM dependency', () => {
       const renderedDependency = renderJavaScriptDependency('test', 'test2', 'ESM');
       expect(renderedDependency).toEqual('import test from \'test2\';');
-    });
-  });
-  describe('makeUnique', () => {
-    test('should remove duplicate regular instances', () => {
-      const stringModel = new ConstrainedStringModel('', undefined, '');
-      const nonUniqueArray = [stringModel, stringModel];
-      const uniqueArray = makeUnique(nonUniqueArray);
-      expect(uniqueArray).toHaveLength(1);
-    });
-    test('should remove duplicate reference instances', () => {
-      const stringModel = new ConstrainedStringModel('', undefined, '');
-      const ref1 = new ConstrainedReferenceModel('', undefined, '', stringModel);
-      const nonUniqueArray = [ref1, ref1];
-      const uniqueArray = makeUnique(nonUniqueArray);
-      expect(uniqueArray).toHaveLength(1);
-    });
-    test('should remove duplicate reference value instances', () => {
-      const stringModel = new ConstrainedStringModel('', undefined, '');
-      const ref1 = new ConstrainedReferenceModel('', undefined, '', stringModel);
-      const ref2 = new ConstrainedReferenceModel('', undefined, '', stringModel);
-      const nonUniqueArray = [ref1, ref2];
-      const uniqueArray = makeUnique(nonUniqueArray);
-      expect(uniqueArray).toHaveLength(1);
     });
   });
 });

--- a/test/utils/DependencyHelper.spec.ts
+++ b/test/utils/DependencyHelper.spec.ts
@@ -1,4 +1,5 @@
-import {renderJavaScriptDependency} from '../../src/utils'; 
+import { ConstrainedReferenceModel, ConstrainedStringModel } from '../../src';
+import {renderJavaScriptDependency, makeUnique} from '../../src/utils'; 
 
 describe('DependencyHelper', () => {
   describe('renderJavaScriptDependency', () => {
@@ -9,6 +10,29 @@ describe('DependencyHelper', () => {
     test('should render accurate ESM dependency', () => {
       const renderedDependency = renderJavaScriptDependency('test', 'test2', 'ESM');
       expect(renderedDependency).toEqual('import test from \'test2\';');
+    });
+  });
+  describe('makeUnique', () => {
+    test('should remove duplicate regular instances', () => {
+      const stringModel = new ConstrainedStringModel('', undefined, '');
+      const nonUniqueArray = [stringModel, stringModel];
+      const uniqueArray = makeUnique(nonUniqueArray);
+      expect(uniqueArray).toHaveLength(1);
+    });
+    test('should remove duplicate reference instances', () => {
+      const stringModel = new ConstrainedStringModel('', undefined, '');
+      const ref1 = new ConstrainedReferenceModel('', undefined, '', stringModel);
+      const nonUniqueArray = [ref1, ref1];
+      const uniqueArray = makeUnique(nonUniqueArray);
+      expect(uniqueArray).toHaveLength(1);
+    });
+    test('should remove duplicate reference value instances', () => {
+      const stringModel = new ConstrainedStringModel('', undefined, '');
+      const ref1 = new ConstrainedReferenceModel('', undefined, '', stringModel);
+      const ref2 = new ConstrainedReferenceModel('', undefined, '', stringModel);
+      const nonUniqueArray = [ref1, ref2];
+      const uniqueArray = makeUnique(nonUniqueArray);
+      expect(uniqueArray).toHaveLength(1);
     });
   });
 });


### PR DESCRIPTION
**Description**
In the current implementation, we sometimes render duplicate and self-dependencies, which makes some black-box tests fail.  This PR fixes this issue.

This change is part of fixing the black-box tests.