### PR TITLE
fix: merging CommonModel properties should not carry over properties to other models

### DIFF
--- a/src/models/CommonModel.ts
+++ b/src/models/CommonModel.ts
@@ -353,20 +353,25 @@ export class CommonModel {
    * @param alreadyIteratedModels
    */
   private static mergeProperties(mergeTo: CommonModel, mergeFrom: CommonModel, originalInput: any, alreadyIteratedModels: Map<CommonModel, CommonModel> = new Map()) {
-    const mergeToProperties = mergeTo.properties;
-    const mergeFromProperties = mergeFrom.properties;
-    if (mergeFromProperties !== undefined) {
-      if (mergeToProperties === undefined) {
-        mergeTo.properties = mergeFromProperties;
+    if (!mergeTo.properties) {
+      mergeTo.properties = mergeFrom.properties;
+      return;
+    }
+
+    if (!mergeFrom.properties) {
+      return;
+    }
+
+    mergeTo.properties = {
+      ...mergeTo.properties,
+    };
+
+    for (const [propName, propValue] of Object.entries(mergeFrom.properties)) {
+      if (!mergeTo.properties[String(propName)]) {
+        mergeTo.properties[String(propName)] = propValue;
       } else {
-        for (const [propName, prop] of Object.entries(mergeFromProperties)) {
-          if (mergeToProperties[String(propName)] !== undefined) {
-            Logger.warn(`Found duplicate properties ${propName} for model. Model property from ${mergeFrom.$id || 'unknown'} merged into ${mergeTo.$id || 'unknown'}`, mergeTo, mergeFrom, originalInput);
-            mergeToProperties[String(propName)] = CommonModel.mergeCommonModels(mergeToProperties[String(propName)], prop, originalInput, alreadyIteratedModels);
-          } else {
-            mergeToProperties[String(propName)] = prop;
-          }
-        }
+        Logger.warn(`Found duplicate properties ${propName} for model. Model property from ${mergeFrom.$id || 'unknown'} merged into ${mergeTo.$id || 'unknown'}`, mergeTo, mergeFrom, originalInput);
+        mergeTo.properties[String(propName)] = CommonModel.mergeCommonModels(mergeTo.properties[String(propName)], propValue, originalInput, alreadyIteratedModels);
       }
     }
   }

--- a/test/generators/typescript/TypeScriptGenerator.spec.ts
+++ b/test/generators/typescript/TypeScriptGenerator.spec.ts
@@ -467,6 +467,14 @@ ${content}`;
       const models = await generator.generate(asyncapiDoc);
       expect(models).toHaveLength(6);
       expect(models.map((model) => model.result)).toMatchSnapshot();
+
+      const cat = models.find((model) => model.modelName === 'Cat');
+      expect(cat).not.toBeUndefined();
+      expect(cat?.result).toContain('petType');
+      expect(cat?.result).toContain('reservedName');
+      expect(cat?.result).toContain('huntingSkill');
+      expect(cat?.result).not.toContain('packSize');
+      expect(cat?.result).not.toContain('color');
     });
 
     test('should render enum with discriminator', async () => {

--- a/test/generators/typescript/__snapshots__/TypeScriptGenerator.spec.ts.snap
+++ b/test/generators/typescript/__snapshots__/TypeScriptGenerator.spec.ts.snap
@@ -7,21 +7,15 @@ Array [
   private _petType: PetType;
   private _reservedName: string;
   private _huntingSkill: AnonymousSchema_5;
-  private _packSize?: number;
-  private _color?: string;
 
   constructor(input: {
     petType: PetType,
     reservedName: string,
     huntingSkill: AnonymousSchema_5,
-    packSize?: number,
-    color?: string,
   }) {
     this._petType = input.petType;
     this._reservedName = input.reservedName;
     this._huntingSkill = input.huntingSkill;
-    this._packSize = input.packSize;
-    this._color = input.color;
   }
 
   get petType(): PetType { return this._petType; }
@@ -32,12 +26,6 @@ Array [
 
   get huntingSkill(): AnonymousSchema_5 { return this._huntingSkill; }
   set huntingSkill(huntingSkill: AnonymousSchema_5) { this._huntingSkill = huntingSkill; }
-
-  get packSize(): number | undefined { return this._packSize; }
-  set packSize(packSize: number | undefined) { this._packSize = packSize; }
-
-  get color(): string | undefined { return this._color; }
-  set color(color: string | undefined) { this._color = color; }
 }",
   "enum PetType {
   CAT = \\"Cat\\",
@@ -53,22 +41,16 @@ Array [
   "class Dog {
   private _petType: PetType;
   private _reservedName: string;
-  private _huntingSkill?: AnonymousSchema_5;
   private _packSize: number;
-  private _color?: string;
 
   constructor(input: {
     petType: PetType,
     reservedName: string,
-    huntingSkill?: AnonymousSchema_5,
     packSize: number,
-    color?: string,
   }) {
     this._petType = input.petType;
     this._reservedName = input.reservedName;
-    this._huntingSkill = input.huntingSkill;
     this._packSize = input.packSize;
-    this._color = input.color;
   }
 
   get petType(): PetType { return this._petType; }
@@ -77,33 +59,21 @@ Array [
   get reservedName(): string { return this._reservedName; }
   set reservedName(reservedName: string) { this._reservedName = reservedName; }
 
-  get huntingSkill(): AnonymousSchema_5 | undefined { return this._huntingSkill; }
-  set huntingSkill(huntingSkill: AnonymousSchema_5 | undefined) { this._huntingSkill = huntingSkill; }
-
   get packSize(): number { return this._packSize; }
   set packSize(packSize: number) { this._packSize = packSize; }
-
-  get color(): string | undefined { return this._color; }
-  set color(color: string | undefined) { this._color = color; }
 }",
   "class StickInsect {
   private _petType: PetType;
   private _reservedName: string;
-  private _huntingSkill?: AnonymousSchema_5;
-  private _packSize?: number;
   private _color: string;
 
   constructor(input: {
     petType: PetType,
     reservedName: string,
-    huntingSkill?: AnonymousSchema_5,
-    packSize?: number,
     color: string,
   }) {
     this._petType = input.petType;
     this._reservedName = input.reservedName;
-    this._huntingSkill = input.huntingSkill;
-    this._packSize = input.packSize;
     this._color = input.color;
   }
 
@@ -112,12 +82,6 @@ Array [
 
   get reservedName(): string { return this._reservedName; }
   set reservedName(reservedName: string) { this._reservedName = reservedName; }
-
-  get huntingSkill(): AnonymousSchema_5 | undefined { return this._huntingSkill; }
-  set huntingSkill(huntingSkill: AnonymousSchema_5 | undefined) { this._huntingSkill = huntingSkill; }
-
-  get packSize(): number | undefined { return this._packSize; }
-  set packSize(packSize: number | undefined) { this._packSize = packSize; }
 
   get color(): string { return this._color; }
   set color(color: string) { this._color = color; }

--- a/test/models/CommonModel.spec.ts
+++ b/test/models/CommonModel.spec.ts
@@ -529,7 +529,7 @@ describe('CommonModel', () => {
         expect(catModel.properties?.petType.$id).toBe('PetType');
         expect(catModel.properties).toHaveProperty('name');
         expect(catModel.properties).toHaveProperty('huntingSkill');
-        expect(catModel.properties?.packSize).toBeUndefined();
+        expect(catModel.properties).not.toHaveProperty('packSize');
 
         expect(dogModel.properties).toHaveProperty('petType');
         expect(dogModel.properties?.petType.$id).toBe('PetType');

--- a/test/models/CommonModel.spec.ts
+++ b/test/models/CommonModel.spec.ts
@@ -479,6 +479,64 @@ describe('CommonModel', () => {
         doc1 = CommonModel.mergeCommonModels(doc1, doc2, doc);
         expect(doc1.properties).toBeUndefined();
       });
+      test('should not carry over properties to other models', () => {
+        const petModel = CommonModel.toCommonModel({
+          title: 'Pet',
+          type: 'object',
+          discriminator: 'petType',
+          properties: {
+            petType: {
+              $id: 'PetType',
+              type: 'string'
+            },
+            name: {
+              type: 'string'
+            },
+          },
+        });
+
+        const cat = {};
+        const catModel = CommonModel.toCommonModel(cat);
+        CommonModel.mergeCommonModels(catModel, petModel, cat);
+        CommonModel.mergeCommonModels(catModel, CommonModel.toCommonModel({
+          title: 'Cat',
+          properties: {
+            petType: {
+              const: 'Cat',
+            },
+            huntingSkill: {
+              type: 'string',
+            }
+          },
+        }), cat);
+
+        const dog = {};
+        const dogModel = CommonModel.toCommonModel(dog);
+        CommonModel.mergeCommonModels(dogModel, petModel, dog);
+        CommonModel.mergeCommonModels(dogModel, CommonModel.toCommonModel({
+          title: 'Dog',
+          properties: {
+            petType: {
+              const: 'Dog',
+            },
+            packSize: {
+              type: 'integer',
+            }
+          },
+        }), dog);
+
+        expect(catModel.properties).toHaveProperty('petType');
+        expect(catModel.properties?.petType.$id).toBe('PetType');
+        expect(catModel.properties).toHaveProperty('name');
+        expect(catModel.properties).toHaveProperty('huntingSkill');
+        expect(catModel.properties?.packSize).toBeUndefined();
+
+        expect(dogModel.properties).toHaveProperty('petType');
+        expect(dogModel.properties?.petType.$id).toBe('PetType');
+        expect(dogModel.properties).toHaveProperty('name');
+        expect(dogModel.properties).toHaveProperty('packSize');
+        expect(dogModel.properties).not.toHaveProperty('huntingSkill');
+      });
     });
     describe('additionalProperties', () => {
       test('should be merged when only right side is defined', () => {


### PR DESCRIPTION
**Description**

- Please check the Pet test in the MR. This fix makes sure that `CommonModel.mergeProperties` doesn't carry over any properties to other models when trying to merge Pet into multiple schemas.