### PR TITLE
fix: enable processor options to be passed processors

### DIFF
--- a/src/models/ProcessorOptions.ts
+++ b/src/models/ProcessorOptions.ts
@@ -1,5 +1,5 @@
 import { ParserOptions } from '@asyncapi/parser';
-import { InterpreterOptions } from 'interpreter/Interpreter';
+import { InterpreterOptions } from '../interpreter/Interpreter';
 import { TypeScriptInputProcessorOptions } from '../processors/index';
 
 export interface ProcessorOptions {

--- a/src/models/ProcessorOptions.ts
+++ b/src/models/ProcessorOptions.ts
@@ -1,7 +1,9 @@
 import { ParserOptions } from '@asyncapi/parser';
+import { InterpreterOptions } from 'interpreter/Interpreter';
 import { TypeScriptInputProcessorOptions } from '../processors/index';
 
 export interface ProcessorOptions {
   asyncapi?: ParserOptions,
   typescript?: TypeScriptInputProcessorOptions,
+  interpreter?: InterpreterOptions
 }

--- a/src/processors/AsyncAPIInputProcessor.ts
+++ b/src/processors/AsyncAPIInputProcessor.ts
@@ -32,7 +32,7 @@ export class AsyncAPIInputProcessor extends AbstractInputProcessor {
     // Go over all the message payloads and convert them to models
     for (const [, message] of doc.allMessages()) {
       const schema = AsyncAPIInputProcessor.convertToInternalSchema(message.payload());
-      const newCommonModel = JsonSchemaInputProcessor.convertSchemaToCommonModel(schema);
+      const newCommonModel = JsonSchemaInputProcessor.convertSchemaToCommonModel(schema, options);
       if (newCommonModel.$id !== undefined) {
         if (inputModel.models[newCommonModel.$id] !== undefined) {
           Logger.warn(`Overwriting existing model with $id ${newCommonModel.$id}, are there two models with the same id present?`, newCommonModel);

--- a/src/processors/JsonSchemaInputProcessor.ts
+++ b/src/processors/JsonSchemaInputProcessor.ts
@@ -1,7 +1,7 @@
 import { AbstractInputProcessor } from './AbstractInputProcessor';
 import $RefParser from '@apidevtools/json-schema-ref-parser';
 import path from 'path';
-import { CommonModel, InputMetaModel, Draft4Schema, Draft7Schema, Draft6Schema, SwaggerV2Schema, OpenapiV3Schema, AsyncapiV2Schema } from '../models';
+import { CommonModel, InputMetaModel, Draft4Schema, Draft7Schema, Draft6Schema, SwaggerV2Schema, OpenapiV3Schema, AsyncapiV2Schema, ProcessorOptions } from '../models';
 import { Logger } from '../utils';
 import { Interpreter } from '../interpreter/Interpreter';
 import { convertToMetaModel } from '../helpers';
@@ -310,9 +310,9 @@ export class JsonSchemaInputProcessor extends AbstractInputProcessor {
    * 
    * @param schema to simplify to common model
    */
-  static convertSchemaToCommonModel(schema: Draft4Schema | Draft6Schema | Draft7Schema | SwaggerV2Schema| AsyncapiV2Schema | boolean): CommonModel {
+  static convertSchemaToCommonModel(schema: Draft4Schema | Draft6Schema | Draft7Schema | SwaggerV2Schema| AsyncapiV2Schema | boolean, options?: ProcessorOptions): CommonModel {
     const interpreter = new Interpreter();
-    const model = interpreter.interpret(schema);
+    const model = interpreter.interpret(schema, options?.interpreter);
     if (model === undefined) {
       throw new Error('Could not interpret schema to internal model');
     }

--- a/src/processors/OpenAPIInputProcessor.ts
+++ b/src/processors/OpenAPIInputProcessor.ts
@@ -1,6 +1,6 @@
 import { AbstractInputProcessor } from './AbstractInputProcessor';
 import { JsonSchemaInputProcessor } from './JsonSchemaInputProcessor';
-import { InputMetaModel, OpenapiV3Schema } from '../models';
+import { InputMetaModel, OpenapiV3Schema, ProcessorOptions } from '../models';
 import { Logger } from '../utils';
 import SwaggerParser from '@apidevtools/swagger-parser';
 import { OpenAPIV3 } from 'openapi-types';
@@ -17,7 +17,7 @@ export class OpenAPIInputProcessor extends AbstractInputProcessor {
    * 
    * @param input 
    */
-  async process(input: Record<string, any>): Promise<InputMetaModel> {
+  async process(input: Record<string, any>, options?: ProcessorOptions): Promise<InputMetaModel> {
     if (!this.shouldProcess(input)) {throw new Error('Input is not a OpenAPI document so it cannot be processed.');}
 
     Logger.debug('Processing input as an OpenAPI document');
@@ -26,12 +26,12 @@ export class OpenAPIInputProcessor extends AbstractInputProcessor {
     const api = (await SwaggerParser.dereference(input as any) as unknown) as OpenAPIV3.Document;
 
     for (const [path, pathObject] of Object.entries(api.paths)) {
-      this.processPath(pathObject, path, inputModel);
+      this.processPath(pathObject, path, inputModel, options);
     }
     return inputModel;
   }
 
-  private processPath(pathObject: OpenAPIV3.PathItemObject | undefined, path: string, inputModel: InputMetaModel) {
+  private processPath(pathObject: OpenAPIV3.PathItemObject | undefined, path: string, inputModel: InputMetaModel, options?: ProcessorOptions) {
     if (pathObject) {
       //Remove all special chars from path
       let formattedPathName = path.replace(/[^\w\s*]+/g, '');
@@ -39,58 +39,58 @@ export class OpenAPIInputProcessor extends AbstractInputProcessor {
       formattedPathName = formattedPathName.replace(/\//, '');
       //Replace all segment separators '/'
       formattedPathName = formattedPathName.replace(/\//gm, '_');
-      this.processOperation(pathObject.get, `${formattedPathName}_get`, inputModel);
-      this.processOperation(pathObject.put, `${formattedPathName}_put`, inputModel);
-      this.processOperation(pathObject.post, `${formattedPathName}_post`, inputModel);
-      this.processOperation(pathObject.delete, `${formattedPathName}_delete`, inputModel);
-      this.processOperation(pathObject.options, `${formattedPathName}_options`, inputModel);
-      this.processOperation(pathObject.head, `${formattedPathName}_head`, inputModel);
-      this.processOperation(pathObject.patch, `${formattedPathName}_patch`, inputModel);
-      this.processOperation(pathObject.trace, `${formattedPathName}_trace`, inputModel);
+      this.processOperation(pathObject.get, `${formattedPathName}_get`, inputModel, options);
+      this.processOperation(pathObject.put, `${formattedPathName}_put`, inputModel, options);
+      this.processOperation(pathObject.post, `${formattedPathName}_post`, inputModel, options);
+      this.processOperation(pathObject.delete, `${formattedPathName}_delete`, inputModel, options);
+      this.processOperation(pathObject.options, `${formattedPathName}_options`, inputModel, options);
+      this.processOperation(pathObject.head, `${formattedPathName}_head`, inputModel, options);
+      this.processOperation(pathObject.patch, `${formattedPathName}_patch`, inputModel, options);
+      this.processOperation(pathObject.trace, `${formattedPathName}_trace`, inputModel, options);
     } 
   }
 
-  private processOperation(operation: OpenAPIV3.OperationObject | undefined, path: string, inputModel: InputMetaModel) {
+  private processOperation(operation: OpenAPIV3.OperationObject | undefined, path: string, inputModel: InputMetaModel, options?: ProcessorOptions) {
     if (operation) {
-      this.iterateResponses(operation.responses, path, inputModel);
+      this.iterateResponses(operation.responses, path, inputModel, options);
 
       if (operation.requestBody) {
-        this.iterateMediaType((operation.requestBody as OpenAPIV3.RequestBodyObject).content || {}, path, inputModel);
+        this.iterateMediaType((operation.requestBody as OpenAPIV3.RequestBodyObject).content || {}, path, inputModel, options);
       }
       
       if (operation.callbacks) {
         for (const [callbackName, callback] of Object.entries(operation.callbacks)) {
           const callbackObject = callback as OpenAPIV3.CallbackObject;
           for (const [callbackPath, callbackPathObject] of Object.entries(callbackObject)) {
-            this.processPath(callbackPathObject, `${path}_callback_${callbackName}_${callbackPath}`, inputModel);
+            this.processPath(callbackPathObject, `${path}_callback_${callbackName}_${callbackPath}`, inputModel, options);
           }
         }
       }
     }
   }
 
-  private iterateResponses(responses: OpenAPIV3.ResponsesObject, path: string, inputModel: InputMetaModel) {
+  private iterateResponses(responses: OpenAPIV3.ResponsesObject, path: string, inputModel: InputMetaModel, options?: ProcessorOptions) {
     for (const [responseName, response] of Object.entries(responses)) {
       //Replace any '/' with '_'
       const formattedResponseName = responseName.replace(/\//, '_');
-      this.iterateMediaType((response as OpenAPIV3.ResponseObject).content || {}, `${path}_${formattedResponseName}`, inputModel);
+      this.iterateMediaType((response as OpenAPIV3.ResponseObject).content || {}, `${path}_${formattedResponseName}`, inputModel, options);
     }
   }
 
-  private iterateMediaType(mediaTypes: {[media: string]: OpenAPIV3.MediaTypeObject}, path: string, inputModel: InputMetaModel) {
+  private iterateMediaType(mediaTypes: {[media: string]: OpenAPIV3.MediaTypeObject}, path: string, inputModel: InputMetaModel, options?: ProcessorOptions) {
     for (const [mediaContent, mediaTypeObject] of Object.entries(mediaTypes)) {
       const mediaType = mediaTypeObject;
       if (mediaType.schema === undefined) { continue; }
       const mediaTypeSchema = (mediaType.schema as unknown) as OpenAPIV3.SchemaObject;
       //Replace any '/' with '_'
       const formattedMediaContent = mediaContent.replace(/\//, '_');
-      this.includeSchema(mediaTypeSchema, `${path}_${formattedMediaContent}`, inputModel);
+      this.includeSchema(mediaTypeSchema, `${path}_${formattedMediaContent}`, inputModel, options);
     }
   }
 
-  private includeSchema(schema: OpenAPIV3.SchemaObject, name: string, inputModel: InputMetaModel) {
+  private includeSchema(schema: OpenAPIV3.SchemaObject, name: string, inputModel: InputMetaModel, options?: ProcessorOptions) {
     const internalSchema = OpenAPIInputProcessor.convertToInternalSchema(schema, name);
-    const newCommonModel = JsonSchemaInputProcessor.convertSchemaToCommonModel(internalSchema);
+    const newCommonModel = JsonSchemaInputProcessor.convertSchemaToCommonModel(internalSchema, options);
     if (newCommonModel.$id !== undefined) {
       if (inputModel.models[newCommonModel.$id] !== undefined) {
         Logger.warn(`Overwriting existing model with $id ${newCommonModel.$id}, are there two models with the same id present?`, newCommonModel);

--- a/src/processors/SwaggerInputProcessor.ts
+++ b/src/processors/SwaggerInputProcessor.ts
@@ -1,6 +1,6 @@
 import { AbstractInputProcessor } from './AbstractInputProcessor';
 import { JsonSchemaInputProcessor } from './JsonSchemaInputProcessor';
-import { InputMetaModel, SwaggerV2Schema } from '../models';
+import { InputMetaModel, SwaggerV2Schema, ProcessorOptions } from '../models';
 import { Logger } from '../utils';
 import SwaggerParser from '@apidevtools/swagger-parser';
 import { OpenAPIV2 } from 'openapi-types';
@@ -17,7 +17,7 @@ export class SwaggerInputProcessor extends AbstractInputProcessor {
    * 
    * @param input 
    */
-  async process(input: Record<string, any>): Promise<InputMetaModel> {
+  async process(input: Record<string, any>, options?: ProcessorOptions): Promise<InputMetaModel> {
     if (!this.shouldProcess(input)) {throw new Error('Input is not a Swagger document so it cannot be processed.');}
 
     Logger.debug('Processing input as a Swagger document');
@@ -33,47 +33,47 @@ export class SwaggerInputProcessor extends AbstractInputProcessor {
       formattedPathName = formattedPathName.replace(/\//, '');
       //Replace all segment separators '/'
       formattedPathName = formattedPathName.replace(/\//gm, '_');
-      this.processOperation(pathObject.get, `${formattedPathName}_get`, common);
-      this.processOperation(pathObject.put, `${formattedPathName}_put`, common);
-      this.processOperation(pathObject.post, `${formattedPathName}_post`, common);
-      this.processOperation(pathObject.options, `${formattedPathName}_options`, common);
-      this.processOperation(pathObject.head, `${formattedPathName}_head`, common);
-      this.processOperation(pathObject.patch, `${formattedPathName}_patch`, common);
+      this.processOperation(pathObject.get, `${formattedPathName}_get`, common, options);
+      this.processOperation(pathObject.put, `${formattedPathName}_put`, common, options);
+      this.processOperation(pathObject.post, `${formattedPathName}_post`, common, options);
+      this.processOperation(pathObject.options, `${formattedPathName}_options`, common, options);
+      this.processOperation(pathObject.head, `${formattedPathName}_head`, common, options);
+      this.processOperation(pathObject.patch, `${formattedPathName}_patch`, common, options);
     }
     return common;
   }
 
-  private processOperation(operation: OpenAPIV2.OperationObject | undefined, path: string, inputModel: InputMetaModel) {
+  private processOperation(operation: OpenAPIV2.OperationObject | undefined, path: string, inputModel: InputMetaModel, options?: ProcessorOptions) {
     if (operation) {
-      this.includeResponses(operation.responses, path, inputModel);
-      this.includeParameters(operation.parameters, path, inputModel);
+      this.includeResponses(operation.responses, path, inputModel, options);
+      this.includeParameters(operation.parameters, path, inputModel, options);
     }
   }
 
-  private includeResponses(responses: OpenAPIV2.ResponsesObject, path: string, inputModel: InputMetaModel) {
+  private includeResponses(responses: OpenAPIV2.ResponsesObject, path: string, inputModel: InputMetaModel, options?: ProcessorOptions) {
     for (const [responseName, response] of Object.entries(responses)) {
       if (response !== undefined) {
         const getOperationResponseSchema = (response as OpenAPIV2.ResponseObject).schema;
         if (getOperationResponseSchema !== undefined) { 
-          this.includeSchema(getOperationResponseSchema, `${path}_${responseName}`, inputModel);
+          this.includeSchema(getOperationResponseSchema, `${path}_${responseName}`, inputModel, options);
         }
       }
     }
   }
 
-  private includeParameters(parameters: OpenAPIV2.Parameters | undefined, path: string, inputModel: InputMetaModel) {
+  private includeParameters(parameters: OpenAPIV2.Parameters | undefined, path: string, inputModel: InputMetaModel, options?: ProcessorOptions) {
     for (const parameterObject of parameters || []) {
       const parameter = parameterObject as OpenAPIV2.Parameter;
       if (parameter.in === 'body') {
         const bodyParameterSchema = parameter.schema;
-        this.includeSchema(bodyParameterSchema, `${path}_body`, inputModel);
+        this.includeSchema(bodyParameterSchema, `${path}_body`, inputModel, options);
       }
     }
   }
 
-  private includeSchema(schema: OpenAPIV2.SchemaObject, name: string, inputModel: InputMetaModel) {
+  private includeSchema(schema: OpenAPIV2.SchemaObject, name: string, inputModel: InputMetaModel, options?: ProcessorOptions) {
     const internalSchema = SwaggerInputProcessor.convertToInternalSchema(schema, name);
-    const newCommonModel = JsonSchemaInputProcessor.convertSchemaToCommonModel(internalSchema);
+    const newCommonModel = JsonSchemaInputProcessor.convertSchemaToCommonModel(internalSchema, options);
     if (newCommonModel.$id !== undefined) {
       if (inputModel.models[newCommonModel.$id] !== undefined) {
         Logger.warn(`Overwriting existing model with $id ${newCommonModel.$id}, are there two models with the same id present?`, newCommonModel);

--- a/src/processors/TypeScriptInputProcessor.ts
+++ b/src/processors/TypeScriptInputProcessor.ts
@@ -82,7 +82,7 @@ export class TypeScriptInputProcessor extends AbstractInputProcessor {
     const generatedSchemas = this.generateJSONSchema(baseFile, '*', options?.typescript);
     if (generatedSchemas) {
       for (const schema of generatedSchemas) {
-        const newCommonModel = JsonSchemaInputProcessor.convertSchemaToCommonModel(schema as Record<string, any>);
+        const newCommonModel = JsonSchemaInputProcessor.convertSchemaToCommonModel(schema as Record<string, any>, options);
         if (newCommonModel.$id !== undefined) {
           if (inputModel.models[newCommonModel.$id] !== undefined) {
             Logger.warn(`Overwriting existing model with $id ${newCommonModel.$id}, are there two models with the same id present?`, newCommonModel);


### PR DESCRIPTION
**Description**
This is a small refactoring PR to ensure that all the `processors` have access to `processorOptions` which is passed via `process(...)` method.

Also it adds `interpreterOptions` to `processorOptions` under `interpreter` and it ensures that `interpreter.interpret(...)` receives `interpreterOptions` that is referenced from `processorOptions`.

**Related issue(s)**
https://github.com/asyncapi/modelina/issues/916