### PR TITLE
fix: javascript should not split out enums

### DIFF
--- a/src/generators/javascript/JavaScriptGenerator.ts
+++ b/src/generators/javascript/JavaScriptGenerator.ts
@@ -77,7 +77,6 @@ ${modelCode}`;
   splitMetaModel(model: MetaModel): MetaModel[] {
     //These are the models that we have separate renderers for
     const metaModelsToSplit = {
-      splitEnum: true, 
       splitObject: true
     };
     return split(model, metaModelsToSplit);

--- a/test/generators/javascript/JavaScriptGenerator.spec.ts
+++ b/test/generators/javascript/JavaScriptGenerator.spec.ts
@@ -23,6 +23,22 @@ describe('JavaScriptGenerator', () => {
     expect(models[0].result).toMatchSnapshot();
     expect(models[0].dependencies).toEqual([]);
   });
+
+  test('should not render enums type', async () => {
+    const doc = {
+      $id: 'Address',
+      type: 'object',
+      properties: {
+        enum: { type: 'string', enum: ['test', 'test2'] },
+      },
+    };
+    
+    const models = await generator.generate(doc);
+    expect(models).toHaveLength(1);
+    expect(models[0].result).toMatchSnapshot();
+    expect(models[0].dependencies).toEqual([]);
+  });
+
   test('should render `class` type', async () => {
     const doc = {
       $id: 'Address',

--- a/test/generators/javascript/__snapshots__/JavaScriptGenerator.spec.ts.snap
+++ b/test/generators/javascript/__snapshots__/JavaScriptGenerator.spec.ts.snap
@@ -18,6 +18,28 @@ exports[`JavaScriptGenerator should not render \`class\` with reserved keyword 1
 }"
 `;
 
+exports[`JavaScriptGenerator should not render enums type 1`] = `
+"class Address {
+  reservedEnum;
+  additionalProperties;
+
+  constructor(input) {
+    if (input.hasOwnProperty('reservedEnum')) {
+      this.reservedEnum = input.reservedEnum;
+    }
+    if (input.hasOwnProperty('additionalProperties')) {
+      this.additionalProperties = input.additionalProperties;
+    }
+  }
+
+  get reservedEnum() { return this.reservedEnum; }
+  set reservedEnum(reservedEnum) { this.reservedEnum = reservedEnum; }
+
+  get additionalProperties() { return this.additionalProperties; }
+  set additionalProperties(additionalProperties) { this.additionalProperties = additionalProperties; }
+}"
+`;
+
 exports[`JavaScriptGenerator should render \`class\` type 1`] = `
 "class Address {
   streetName;


### PR DESCRIPTION
**Description**
In the current JavaScript generator the enums are split out but never rendered because we don't have a way to render them.

The reason why this change is necessary, is because classes still try to import/require the enums, when they simply don't exist. Which means something like the black-box tests fails.

Part of https://github.com/asyncapi/modelina/pull/905