### PR TITLE
fix: typescript marshalling preset not caring about external models  

### DIFF
--- a/src/generators/typescript/presets/CommonPreset.ts
+++ b/src/generators/typescript/presets/CommonPreset.ts
@@ -110,7 +110,7 @@ function renderUnmarshalProperties(model: ConstrainedObjectModel) {
   const unmarshalDictionaryProperties = [];
   for (const [prop, propModel] of unwrapDictionaryProperties) {
     const modelInstanceVariable = 'value as any';
-    const unmarshalCode = renderUnmarshalProperty(modelInstanceVariable, propModel.property);
+    const unmarshalCode = renderUnmarshalProperty(modelInstanceVariable, (propModel.property as ConstrainedDictionaryModel).value);
     setDictionaryProperties.push(`if (instance.${prop} === undefined) {instance.${prop} = new Map();}`);
     unmarshalDictionaryProperties.push(`instance.${prop}.set(key, ${unmarshalCode});`);
   }

--- a/src/generators/typescript/presets/CommonPreset.ts
+++ b/src/generators/typescript/presets/CommonPreset.ts
@@ -15,7 +15,7 @@ function realizePropertyFactory(prop: string) {
 
 function renderMarshalProperty(modelInstanceVariable: string, model: ConstrainedMetaModel) {
   if (model instanceof ConstrainedReferenceModel && !(model.ref instanceof ConstrainedEnumModel)) {
-    return `$\{${model.type}.marshal()}`;
+    return `$\{${modelInstanceVariable}.marshal()}`;
   }
   return realizePropertyFactory(modelInstanceVariable);
 }
@@ -45,7 +45,7 @@ function renderMarshalProperties(model: ConstrainedObjectModel) {
 
   const marshalUnwrapDictionaryProperties = unwrapDictionaryProperties.map(([prop, propModel]) => {
     const modelInstanceVariable = 'value';
-    const patternPropertyMarshalCode = renderMarshalProperty(modelInstanceVariable, propModel.property);
+    const patternPropertyMarshalCode = renderMarshalProperty(modelInstanceVariable, (propModel.property as ConstrainedDictionaryModel).value);
     const marshalCode = `json += \`"$\{key}": ${patternPropertyMarshalCode},\`;`;
     return `if(this.${prop} !== undefined) { 
 for (const [key, value] of this.${prop}.entries()) {
@@ -79,7 +79,7 @@ ${renderer.indent(renderMarshalProperties(model))}
 
 function renderUnmarshalProperty(modelInstanceVariable: string, model: ConstrainedMetaModel) {
   if (model instanceof ConstrainedReferenceModel && !(model.ref instanceof ConstrainedEnumModel)) {
-    return `$\{${model.type}.marshal()}`;
+    return `$\{${model.type}.unmarshal(${modelInstanceVariable})}`;
   }
   return `${modelInstanceVariable}`;
 }

--- a/test/generators/typescript/preset/MarshallingPreset.spec.ts
+++ b/test/generators/typescript/preset/MarshallingPreset.spec.ts
@@ -1,7 +1,6 @@
 /* eslint-disable */
 
 import { TypeScriptGenerator, TS_COMMON_PRESET } from '../../../../src/generators'; 
-import Ajv from 'ajv';
 const doc = {
   definitions: {
     'NestedTest': {
@@ -15,7 +14,8 @@ const doc = {
   properties: {
     'string prop': { type: 'string' },
     enumProp: { $id: 'EnumTest', enum: ['Some enum String', true, {test: 'test'}, 2]},
-    numberProp: { type: 'number' }
+    numberProp: { type: 'number' },
+    nestedObject: {$ref: '#/definitions/NestedTest'}
   }
 };
 describe('Marshalling preset', () => {

--- a/test/generators/typescript/preset/__snapshots__/MarshallingPreset.spec.ts.snap
+++ b/test/generators/typescript/preset/__snapshots__/MarshallingPreset.spec.ts.snap
@@ -82,7 +82,7 @@ exports[`Marshalling preset should render un/marshal code 1`] = `
 
     if (instance.additionalProperties === undefined) {instance.additionalProperties = new Map();}
       for (const [key, value] of Object.entries(obj).filter((([key,]) => {return ![\\"stringProp\\",\\"enumProp\\",\\"numberProp\\",\\"nestedObject\\",\\"additionalProperties\\"].includes(key);}))) {
-        instance.additionalProperties.set(key, value as any);
+        instance.additionalProperties.set(key, \${NestedTest.unmarshal(value as any)});
       }
 
     return instance;

--- a/test/generators/typescript/preset/__snapshots__/MarshallingPreset.spec.ts.snap
+++ b/test/generators/typescript/preset/__snapshots__/MarshallingPreset.spec.ts.snap
@@ -5,17 +5,20 @@ exports[`Marshalling preset should render un/marshal code 1`] = `
   private _stringProp: string;
   private _enumProp?: EnumTest;
   private _numberProp?: number;
+  private _nestedObject?: NestedTest;
   private _additionalProperties?: Map<string, NestedTest>;
 
   constructor(input: {
     stringProp: string,
     enumProp?: EnumTest,
     numberProp?: number,
+    nestedObject?: NestedTest,
     additionalProperties?: Map<string, NestedTest>,
   }) {
     this._stringProp = input.stringProp;
     this._enumProp = input.enumProp;
     this._numberProp = input.numberProp;
+    this._nestedObject = input.nestedObject;
     this._additionalProperties = input.additionalProperties;
   }
 
@@ -27,6 +30,9 @@ exports[`Marshalling preset should render un/marshal code 1`] = `
 
   get numberProp(): number | undefined { return this._numberProp; }
   set numberProp(numberProp: number | undefined) { this._numberProp = numberProp; }
+
+  get nestedObject(): NestedTest | undefined { return this._nestedObject; }
+  set nestedObject(nestedObject: NestedTest | undefined) { this._nestedObject = nestedObject; }
 
   get additionalProperties(): Map<string, NestedTest> | undefined { return this._additionalProperties; }
   set additionalProperties(additionalProperties: Map<string, NestedTest> | undefined) { this._additionalProperties = additionalProperties; }
@@ -42,11 +48,14 @@ exports[`Marshalling preset should render un/marshal code 1`] = `
     if(this.numberProp !== undefined) {
       json += \`\\"numberProp\\": \${typeof this.numberProp === 'number' || typeof this.numberProp === 'boolean' ? this.numberProp : JSON.stringify(this.numberProp)},\`; 
     }
+    if(this.nestedObject !== undefined) {
+      json += \`\\"nestedObject\\": \${this.nestedObject.marshal()},\`; 
+    }
     if(this.additionalProperties !== undefined) { 
     for (const [key, value] of this.additionalProperties.entries()) {
       //Only unwrap those who are not already a property in the JSON object
       if(Object.keys(this).includes(String(key))) continue;
-        json += \`\\"\${key}\\": \${typeof value === 'number' || typeof value === 'boolean' ? value : JSON.stringify(value)},\`;
+        json += \`\\"\${key}\\": \${value.marshal()},\`;
       }
     }
 
@@ -67,9 +76,12 @@ exports[`Marshalling preset should render un/marshal code 1`] = `
     if (obj[\\"numberProp\\"] !== undefined) {
       instance.numberProp = obj[\\"numberProp\\"];
     }
+    if (obj[\\"nestedObject\\"] !== undefined) {
+      instance.nestedObject = \${NestedTest.unmarshal(obj[\\"nestedObject\\"])};
+    }
 
     if (instance.additionalProperties === undefined) {instance.additionalProperties = new Map();}
-      for (const [key, value] of Object.entries(obj).filter((([key,]) => {return ![\\"stringProp\\",\\"enumProp\\",\\"numberProp\\",\\"additionalProperties\\"].includes(key);}))) {
+      for (const [key, value] of Object.entries(obj).filter((([key,]) => {return ![\\"stringProp\\",\\"enumProp\\",\\"numberProp\\",\\"nestedObject\\",\\"additionalProperties\\"].includes(key);}))) {
         instance.additionalProperties.set(key, value as any);
       }
 


### PR DESCRIPTION
**Description**
This PR fixes two issues with the preset. 

1. The unmarshal code does not handle external models correctly
2. The unmarshal code does not handle dictionary properties correctly
3. The marshal code does not handle external models correctly

Fixes https://github.com/asyncapi/modelina/issues/909