### PR TITLE
fix: java dictionary constrainer gives unusable integer type for map value

### DIFF
--- a/src/generators/java/JavaConstrainer.ts
+++ b/src/generators/java/JavaConstrainer.ts
@@ -86,7 +86,7 @@ export const JavaDefaultTypeMapping: TypeMapping<JavaOptions> = {
   Dictionary ({constrainedModel}): string {
     //Limitations to Java is that maps cannot have specific value types...
     if (constrainedModel.value.type === 'int') {
-      constrainedModel.value.type = 'Integer'
+      constrainedModel.value.type = 'Integer';
     }
     return `Map<${constrainedModel.key.type}, ${constrainedModel.value.type}>`;
   }

--- a/src/generators/java/JavaConstrainer.ts
+++ b/src/generators/java/JavaConstrainer.ts
@@ -84,6 +84,10 @@ export const JavaDefaultTypeMapping: TypeMapping<JavaOptions> = {
     return 'Object';
   },
   Dictionary ({constrainedModel}): string {
+    //Limitations to Java is that maps cannot have specific value types...
+    if (constrainedModel.value.type === 'int') {
+      constrainedModel.value.type = 'Integer'
+    }
     return `Map<${constrainedModel.key.type}, ${constrainedModel.value.type}>`;
   }
 };

--- a/test/generators/java/JavaConstrainer.spec.ts
+++ b/test/generators/java/JavaConstrainer.spec.ts
@@ -157,5 +157,12 @@ describe('JavaConstrainer', () => {
       const type = JavaDefaultTypeMapping.Dictionary({constrainedModel: model, options: JavaGenerator.defaultOptions});
       expect(type).toEqual('Map<String, String>');
     });
+    test('should not render simple integer type', () => {
+      const keyModel = new ConstrainedStringModel('test', undefined, 'String');
+      const valueModel = new ConstrainedIntegerModel('test', undefined, 'int');
+      const model = new ConstrainedDictionaryModel('test', undefined, '', keyModel, valueModel);
+      const type = JavaDefaultTypeMapping.Dictionary({constrainedModel: model, options: JavaGenerator.defaultOptions});
+      expect(type).toEqual('Map<String, Integer>');
+    });
   });
 });


### PR DESCRIPTION
**Description**
This PR fixes an issue where the simple `int` type is not allowed for map values.

Fixes https://github.com/asyncapi/modelina/issues/922
Related to #905 