### PR TITLE
fix: remove unintended characters for typescript marshalling preset

### DIFF
--- a/src/generators/typescript/presets/CommonPreset.ts
+++ b/src/generators/typescript/presets/CommonPreset.ts
@@ -79,7 +79,7 @@ ${renderer.indent(renderMarshalProperties(model))}
 
 function renderUnmarshalProperty(modelInstanceVariable: string, model: ConstrainedMetaModel) {
   if (model instanceof ConstrainedReferenceModel && !(model.ref instanceof ConstrainedEnumModel)) {
-    return `$\{${model.type}.unmarshal(${modelInstanceVariable})}`;
+    return `${model.type}.unmarshal(${modelInstanceVariable})`;
   }
   return `${modelInstanceVariable}`;
 }

--- a/test/generators/typescript/preset/__snapshots__/MarshallingPreset.spec.ts.snap
+++ b/test/generators/typescript/preset/__snapshots__/MarshallingPreset.spec.ts.snap
@@ -77,12 +77,12 @@ exports[`Marshalling preset should render un/marshal code 1`] = `
       instance.numberProp = obj[\\"numberProp\\"];
     }
     if (obj[\\"nestedObject\\"] !== undefined) {
-      instance.nestedObject = \${NestedTest.unmarshal(obj[\\"nestedObject\\"])};
+      instance.nestedObject = NestedTest.unmarshal(obj[\\"nestedObject\\"]);
     }
 
     if (instance.additionalProperties === undefined) {instance.additionalProperties = new Map();}
       for (const [key, value] of Object.entries(obj).filter((([key,]) => {return ![\\"stringProp\\",\\"enumProp\\",\\"numberProp\\",\\"nestedObject\\",\\"additionalProperties\\"].includes(key);}))) {
-        instance.additionalProperties.set(key, \${NestedTest.unmarshal(value as any)});
+        instance.additionalProperties.set(key, NestedTest.unmarshal(value as any));
       }
 
     return instance;


### PR DESCRIPTION
**Description**

- fixes renderUnmarshalProperty for typescript