### PR TITLE
fix: enum generator for Java should use strict types for it's values

### DIFF
--- a/src/generators/java/JavaConstrainer.ts
+++ b/src/generators/java/JavaConstrainer.ts
@@ -1,12 +1,13 @@
 import { ConstrainedEnumValueModel } from 'models';
+import { createSemanticDiagnosticsBuilderProgram } from 'typescript';
 import { TypeMapping } from '../../helpers';
 import { defaultEnumKeyConstraints, defaultEnumValueConstraints } from './constrainer/EnumConstrainer';
 import { defaultModelNameConstraints } from './constrainer/ModelNameConstrainer';
 import { defaultPropertyKeyConstraints } from './constrainer/PropertyKeyConstrainer';
 import { JavaOptions } from './JavaGenerator';
 
-function enumFormatToNumberType(format: string): string {
-  switch(format){
+function enumFormatToNumberType(enumValueModel: ConstrainedEnumValueModel, format: string): string {
+  switch (format) {
     case 'integer':
     case 'int32':
       return 'int';
@@ -16,88 +17,114 @@ function enumFormatToNumberType(format: string): string {
     case 'float':
       return 'float';
     case 'double':
-      return 'double'
-    case 'number':
-    default: 
-      return 'int';
+      return 'double';
+    default:
+      if (Number.isInteger(enumValueModel.value)) {
+        return 'int';
+      } else {
+        return 'double';
+      }
   }
 }
 
-const fromEnumValuetoType = (enumValueModel: ConstrainedEnumValueModel, format: string): string => {
-  switch(typeof enumValueModel.value) {
-  case 'boolean':
-    return 'boolean';
-  case 'number':
-  case 'bigint':
-    return enumFormatToNumberType(format);
-  case 'object':
-    return 'Object';
-  case 'string':
-    return 'String';
-  default: 
-    return 'Object';
+const fromEnumValueToType = (enumValueModel: ConstrainedEnumValueModel, format: string): string => {
+  switch (typeof enumValueModel.value) {
+    case 'boolean':
+      return 'boolean';
+    case 'number':
+    case 'bigint':
+      return enumFormatToNumberType(enumValueModel, format);
+    case 'object':
+      return 'Object';
+    case 'string':
+      return 'String';
+    default:
+      return 'Object';
   }
 };
 
+/**
+ * Converts union of different number types to the most strict type it can be.
+ * 
+ * int + double = double (long + double, float + double can never happen, otherwise this would be converted to double)
+ * int + float = float (long + float can never happen, otherwise this would be the case as well)
+ * int + long = long
+ */
+const interpretUnionValueType = (types: string[]): string => {
+  if(types.includes('double')) {
+    return 'double';
+  }
+
+  if(types.includes('float')) {
+    return 'float';
+  }
+
+  if(types.includes('long')) {
+    return 'long';
+  }
+
+  return 'Object';
+}
+
 export const JavaDefaultTypeMapping: TypeMapping<JavaOptions> = {
-  Object ({constrainedModel}): string {
+  Object({ constrainedModel }): string {
     return constrainedModel.name;
   },
-  Reference ({constrainedModel}): string {
+  Reference({ constrainedModel }): string {
     return constrainedModel.name;
   },
-  Any (): string {
+  Any(): string {
     return 'Object';
   },
-  Float ({constrainedModel}): string {
+  Float({ constrainedModel }): string {
     let type = 'Double';
     const format = constrainedModel.originalInput && constrainedModel.originalInput['format'];
     switch (format) {
-    case 'float':
-      type = 'float';
-      break;
+      case 'float':
+        type = 'float';
+        break;
     }
     return type;
   },
-  Integer ({constrainedModel}): string {
+  Integer({ constrainedModel }): string {
     let type = 'Integer';
     const format = constrainedModel.originalInput && constrainedModel.originalInput['format'];
     switch (format) {
-    case 'integer':
-    case 'int32':
-      type = 'int';
-      break;
-    case 'long':
-    case 'int64':
-      type = 'long';
-      break;
+      case 'integer':
+      case 'int32':
+        type = 'int';
+        break;
+      case 'long':
+      case 'int64':
+        type = 'long';
+        break;
     }
     return type;
   },
-  String ({constrainedModel}): string {
+  String({ constrainedModel }): string {
     let type = 'String';
     const format = constrainedModel.originalInput && constrainedModel.originalInput['format'];
     switch (format) {
-    case 'date':
-      type = 'java.time.LocalDate';
-      break;
-    case 'time':
-      type = 'java.time.OffsetTime';
-      break;
-    case 'dateTime':
-    case 'date-time':
-      type = 'java.time.OffsetDateTime';
-      break;
-    case 'binary':
-      type = 'byte[]';
-      break;
+      case 'date':
+        type = 'java.time.LocalDate';
+        break;
+      case 'time':
+        type = 'java.time.OffsetTime';
+        break;
+      case 'dateTime':
+      case 'date-time':
+        type = 'java.time.OffsetDateTime';
+        break;
+      case 'binary':
+        type = 'byte[]';
+        break;
     }
     return type;
   },
-  Boolean (): string {
+  Boolean(): string {
     return 'Boolean';
   },
-  Tuple ({options}): string {
+  Tuple({ options }): string {
     //Because Java have no notion of tuples (and no custom implementation), we have to render it as a list of any value.
     const tupleType = 'Object';
     if (options.collectionType && options.collectionType === 'List') {
@@ -105,30 +132,30 @@ export const JavaDefaultTypeMapping: TypeMapping<JavaOptions> = {
     }
     return `${tupleType}[]`;
   },
-  Array ({constrainedModel, options}): string {
+  Array({ constrainedModel, options }): string {
     if (options.collectionType && options.collectionType === 'List') {
       return `List<${constrainedModel.valueModel.type}>`;
     }
     return `${constrainedModel.valueModel.type}[]`;
   },
-  Enum ({constrainedModel}): string {
+  Enum({ constrainedModel }): string {
     const format = constrainedModel.originalInput && constrainedModel.originalInput['format'];
-    const valueTypes = constrainedModel.values.map((enumValue) => fromEnumValuetoType(enumValue, format));
-    const uniqueTypes = valueTypes.filter(function(item, pos) {
+    const valueTypes = constrainedModel.values.map((enumValue) => fromEnumValueToType(enumValue, format));
+    const uniqueTypes = valueTypes.filter(function (item, pos) {
       return valueTypes.indexOf(item) == pos;
     });
 
     //Enums cannot handle union types, default to a loose type
-    if(uniqueTypes.length > 1) {
-      return 'Object';
+    if (uniqueTypes.length > 1) {
+      return interpretUnionValueType(uniqueTypes);
     }
     return uniqueTypes[0];
   },
-  Union (): string {
+  Union(): string {
     //Because Java have no notion of unions (and no custom implementation), we have to render it as any value.
     return 'Object';
   },
-  Dictionary ({constrainedModel}): string {
+  Dictionary({ constrainedModel }): string {
     //Limitations to Java is that maps cannot have specific value types...
     if (constrainedModel.value.type === 'int') {
       constrainedModel.value.type = 'Integer';

--- a/src/generators/java/renderers/EnumRenderer.ts
+++ b/src/generators/java/renderers/EnumRenderer.ts
@@ -42,10 +42,12 @@ export const JAVA_DEFAULT_ENUM_PRESET: EnumPresetType<JavaOptions> = {
     renderer.addDependency('import com.fasterxml.jackson.annotation.*;');
     return renderer.defaultSelf();
   },
-  item({ item }) {
-    return `${item.key}(${item.value})`;
+  item({ item, model }) {
+    //Cast the enum type just to be sure, as some cases can be `int` type with floating value. 
+    return `${item.key}((${model.type})${item.value})`;
   },
   additionalContent({ model }) {
+    const valueComparitor = model.type.charAt(0) == model.type.charAt(0).toUpperCase() ? 'e.value.equals(value)' : 'e.value == value';
     return `private ${model.type} value;
 
 ${model.name}(${model.type} value) {
@@ -65,7 +67,7 @@ public String toString() {
 @JsonCreator
 public static ${model.name} fromValue(${model.type} value) {
   for (${model.name} e : ${model.name}.values()) {
-    if (e.value.equals(value)) {
+    if (${valueComparitor}) {
       return e;
     }
   }

--- a/src/generators/java/renderers/EnumRenderer.ts
+++ b/src/generators/java/renderers/EnumRenderer.ts
@@ -46,16 +46,14 @@ export const JAVA_DEFAULT_ENUM_PRESET: EnumPresetType<JavaOptions> = {
     return `${item.key}(${item.value})`;
   },
   additionalContent({ model }) {
-    const enumValueType = 'Object';
+    return `private ${model.type} value;
 
-    return `private ${enumValueType} value;
-
-${model.type}(${enumValueType} value) {
+${model.name}(${model.type} value) {
   this.value = value;
 }
 
 @JsonValue
-public ${enumValueType} getValue() {
+public ${model.type} getValue() {
   return value;
 }
 
@@ -65,8 +63,8 @@ public String toString() {
 }
 
 @JsonCreator
-public static ${model.type} fromValue(${enumValueType} value) {
-  for (${model.type} e : ${model.type}.values()) {
+public static ${model.name} fromValue(${model.type} value) {
+  for (${model.name} e : ${model.name}.values()) {
     if (e.value.equals(value)) {
       return e;
     }

--- a/test/generators/java/JavaConstrainer.spec.ts
+++ b/test/generators/java/JavaConstrainer.spec.ts
@@ -177,6 +177,20 @@ describe('JavaConstrainer', () => {
       const type = JavaDefaultTypeMapping.Enum({constrainedModel: model, options: JavaGenerator.defaultOptions});
       expect(type).toEqual('Object');
     });
+    test('should render double and integer as double type', () => {
+      const enumValue2 = new ConstrainedEnumValueModel('test', 123);
+      const enumValue1 = new ConstrainedEnumValueModel('test', 123.12);
+      const model = new ConstrainedEnumModel('test', undefined, '', [enumValue1, enumValue2]);
+      const type = JavaDefaultTypeMapping.Enum({constrainedModel: model, options: JavaGenerator.defaultOptions});
+      expect(type).toEqual('double');
+    });
+    test('should render int and long as long type', () => {
+      const enumValue2 = new ConstrainedEnumValueModel('test', 123);
+      const enumValue1 = new ConstrainedEnumValueModel('test', 123);
+      const model = new ConstrainedEnumModel('test', {format: 'long'}, '', [enumValue1, enumValue2]);
+      const type = JavaDefaultTypeMapping.Enum({constrainedModel: model, options: JavaGenerator.defaultOptions});
+      expect(type).toEqual('long');
+    });
   });
 
   describe('Union', () => { 

--- a/test/generators/java/JavaConstrainer.spec.ts
+++ b/test/generators/java/JavaConstrainer.spec.ts
@@ -1,5 +1,5 @@
 import {JavaDefaultTypeMapping } from '../../../src/generators/java/JavaConstrainer';
-import { ConstrainedAnyModel, ConstrainedArrayModel, ConstrainedBooleanModel, ConstrainedDictionaryModel, ConstrainedEnumModel, ConstrainedFloatModel, ConstrainedIntegerModel, ConstrainedObjectModel, ConstrainedReferenceModel, ConstrainedStringModel, ConstrainedTupleModel, ConstrainedUnionModel, JavaGenerator, JavaOptions } from '../../../src';
+import { ConstrainedAnyModel, ConstrainedArrayModel, ConstrainedBooleanModel, ConstrainedDictionaryModel, ConstrainedEnumModel, ConstrainedEnumValueModel, ConstrainedFloatModel, ConstrainedIntegerModel, ConstrainedObjectModel, ConstrainedReferenceModel, ConstrainedStringModel, ConstrainedTupleModel, ConstrainedUnionModel, JavaGenerator, JavaOptions } from '../../../src';
 describe('JavaConstrainer', () => {
   describe('ObjectModel', () => { 
     test('should render the constrained name as type', () => {
@@ -134,10 +134,48 @@ describe('JavaConstrainer', () => {
   });
 
   describe('Enum', () => { 
-    test('should render the constrained name as type', () => {
-      const model = new ConstrainedEnumModel('test', undefined, '', []);
+    test('should render string enum values as String type', () => {
+      const enumValue = new ConstrainedEnumValueModel('test', 'string type');
+      const model = new ConstrainedEnumModel('test', undefined, '', [enumValue]);
       const type = JavaDefaultTypeMapping.Enum({constrainedModel: model, options: JavaGenerator.defaultOptions});
-      expect(type).toEqual(model.name);
+      expect(type).toEqual('String');
+    });
+    test('should render boolean enum values as boolean type', () => {
+      const enumValue = new ConstrainedEnumValueModel('test', true);
+      const model = new ConstrainedEnumModel('test', undefined, '', [enumValue]);
+      const type = JavaDefaultTypeMapping.Enum({constrainedModel: model, options: JavaGenerator.defaultOptions});
+      expect(type).toEqual('boolean');
+    });
+    test('should render generic number enum value with format  ', () => {
+      const enumValue = new ConstrainedEnumValueModel('test', 123);
+      const model = new ConstrainedEnumModel('test', undefined, '', [enumValue]);
+      const type = JavaDefaultTypeMapping.Enum({constrainedModel: model, options: JavaGenerator.defaultOptions});
+      expect(type).toEqual('int');
+    });
+    test('should render generic number enum value with float format as float type', () => {
+      const enumValue = new ConstrainedEnumValueModel('test', 12.0);
+      const model = new ConstrainedEnumModel('test', {format: 'float'}, '', [enumValue]);
+      const type = JavaDefaultTypeMapping.Enum({constrainedModel: model, options: JavaGenerator.defaultOptions});
+      expect(type).toEqual('float');
+    });
+    test('should render generic number enum value with double format as double type', () => {
+      const enumValue = new ConstrainedEnumValueModel('test', 12.0);
+      const model = new ConstrainedEnumModel('test', {format: 'double'}, '', [enumValue]);
+      const type = JavaDefaultTypeMapping.Enum({constrainedModel: model, options: JavaGenerator.defaultOptions});
+      expect(type).toEqual('double');
+    });
+    test('should render object enum value as generic Object', () => {
+      const enumValue = new ConstrainedEnumValueModel('test', {});
+      const model = new ConstrainedEnumModel('test', undefined, '', [enumValue]);
+      const type = JavaDefaultTypeMapping.Enum({constrainedModel: model, options: JavaGenerator.defaultOptions});
+      expect(type).toEqual('Object');
+    });
+    test('should render multiple value types as generic Object', () => {
+      const enumValue2 = new ConstrainedEnumValueModel('test', true);
+      const enumValue1 = new ConstrainedEnumValueModel('test', 'string type');
+      const model = new ConstrainedEnumModel('test', undefined, '', [enumValue1, enumValue2]);
+      const type = JavaDefaultTypeMapping.Enum({constrainedModel: model, options: JavaGenerator.defaultOptions});
+      expect(type).toEqual('Object');
     });
   });
 

--- a/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
+++ b/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
@@ -54,14 +54,14 @@ exports[`JavaGenerator should render \`enum\` type (integer type) 1`] = `
 "public enum Numbers {
   NUMBER_0(0), NUMBER_1(1), NUMBER_2(2), NUMBER_3(3);
 
-  private Object value;
+  private int value;
 
-  Numbers(Object value) {
+  Numbers(int value) {
     this.value = value;
   }
 
   @JsonValue
-  public Object getValue() {
+  public int getValue() {
     return value;
   }
 
@@ -71,7 +71,7 @@ exports[`JavaGenerator should render \`enum\` type (integer type) 1`] = `
   }
 
   @JsonCreator
-  public static Numbers fromValue(Object value) {
+  public static Numbers fromValue(int value) {
     for (Numbers e : Numbers.values()) {
       if (e.value.equals(value)) {
         return e;
@@ -86,14 +86,14 @@ exports[`JavaGenerator should render \`enum\` type (string type) 1`] = `
 "public enum States {
   TEXAS(\\"Texas\\"), ALABAMA(\\"Alabama\\"), CALIFORNIA(\\"California\\"), NEW_YORK(\\"New York\\");
 
-  private Object value;
+  private String value;
 
-  States(Object value) {
+  States(String value) {
     this.value = value;
   }
 
   @JsonValue
-  public Object getValue() {
+  public String getValue() {
     return value;
   }
 
@@ -103,7 +103,7 @@ exports[`JavaGenerator should render \`enum\` type (string type) 1`] = `
   }
 
   @JsonCreator
-  public static States fromValue(Object value) {
+  public static States fromValue(String value) {
     for (States e : States.values()) {
       if (e.value.equals(value)) {
         return e;
@@ -160,14 +160,14 @@ exports[`JavaGenerator should render custom preset for \`enum\` type 1`] = `
 public enum CustomEnum {
   TEXAS(\\"Texas\\"), ALABAMA(\\"Alabama\\"), CALIFORNIA(\\"California\\");
 
-  private Object value;
+  private String value;
 
-  CustomEnum(Object value) {
+  CustomEnum(String value) {
     this.value = value;
   }
 
   @JsonValue
-  public Object getValue() {
+  public String getValue() {
     return value;
   }
 
@@ -177,7 +177,7 @@ public enum CustomEnum {
   }
 
   @JsonCreator
-  public static CustomEnum fromValue(Object value) {
+  public static CustomEnum fromValue(String value) {
     for (CustomEnum e : CustomEnum.values()) {
       if (e.value.equals(value)) {
         return e;
@@ -192,14 +192,14 @@ exports[`JavaGenerator should render enums with translated special characters 1`
 "public enum States {
   TEST_PLUS(\\"test+\\"), TEST(\\"test\\"), TEST_MINUS(\\"test-\\"), TEST_QUESTION_EXCLAMATION(\\"test?!\\"), ASTERISK_TEST(\\"*test\\");
 
-  private Object value;
+  private String value;
 
-  States(Object value) {
+  States(String value) {
     this.value = value;
   }
 
   @JsonValue
-  public Object getValue() {
+  public String getValue() {
     return value;
   }
 
@@ -209,7 +209,7 @@ exports[`JavaGenerator should render enums with translated special characters 1`
   }
 
   @JsonCreator
-  public static States fromValue(Object value) {
+  public static States fromValue(String value) {
     for (States e : States.values()) {
       if (e.value.equals(value)) {
         return e;

--- a/test/generators/java/presets/__snapshots__/DescriptionPreset.spec.ts.snap
+++ b/test/generators/java/presets/__snapshots__/DescriptionPreset.spec.ts.snap
@@ -29,14 +29,14 @@ exports[`JAVA_DESCRIPTION_PRESET should render description and examples for enum
 public enum ReservedEnum {
   ON(\\"on\\"), OFF(\\"off\\");
 
-  private Object value;
+  private String value;
 
-  ReservedEnum(Object value) {
+  ReservedEnum(String value) {
     this.value = value;
   }
 
   @JsonValue
-  public Object getValue() {
+  public String getValue() {
     return value;
   }
 
@@ -46,7 +46,7 @@ public enum ReservedEnum {
   }
 
   @JsonCreator
-  public static ReservedEnum fromValue(Object value) {
+  public static ReservedEnum fromValue(String value) {
     for (ReservedEnum e : ReservedEnum.values()) {
       if (e.value.equals(value)) {
         return e;


### PR DESCRIPTION
**Description**
This PR ensures that enums have accurate value types based on different parameters.

I also double-checked with the black-box tests that they no longer had any issues.

Fixes https://github.com/asyncapi/modelina/issues/390