### PR TITLE
docs: add contribution guidelines for processors

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,3 +5,5 @@ output
 src/generators/template
 test/generators/template
 examples/integrate-with-react
+src/processors/TemplateInputProcessor.ts
+test/processors/TemplateInputProcessor.spec.ts

--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ To see the complete feature list for each language, please click the individual 
     <td>We support the following OpenAPI versions: <em><a href="./docs/usage.md#generate-models-from-swagger-20-documents">Swagger 2.0</a> and <a href="./docs/usage.md#generate-models-from-openapi-documents">OpenAPI 3.0</a></em>, which generates models for all the defined request and response payloads.</td>
   </tr>
   <tr>
-    <td><a href="./docs/usage.md#generate-model-from-typescript-type-files">TypeScript file</a></td>
-    <td>We currently support TypeScript type file as input for model generation</td>
+    <td><a href="./docs/usage.md#generate-model-from-typescript-type-files">TypeScript</a></td>
+    <td>We currently support TypeScript types as file input for model generation</td>
   </tr>
   <tr>
     <td><a href="./docs/usage.md#generate-models-from-meta-models">Meta model</a></td>
@@ -153,7 +153,7 @@ Read our [contributor](./docs/contributing.md) guide.
 
 ## Contributors ✨
 
-Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+Thanks go out to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore-start -->

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -37,6 +37,26 @@ Adding examples is quite straight forward, so don't feel shy! Here's how to do i
 
 Aaaand you are done! :tada: 
 
+### New input processor
+Input processors are the translators from inputs to MetaModel (read more about [the input processing here](./input-processing.md)). 
+
+Here is how you can add a new input processor:
+1. Duplicate the [template input processor](../src/processors/TemplateInputProcessor.ts) and rename it to the input you are adding a processor for.
+2. Adapt the `shouldProcess` function which is used to detect whether an input processor should process the provided input.
+3. Adapt the `process` function which is used to convert the input into meta models.
+4. Duplicate the [template input processor tests](../test/processors/TemplateInputProcessor.spec.ts) and rename it to the input you are adding a processor for.
+5. Adapt the testing code based on your input and the expected MetaModel conversion.
+6. [Export your input processor](../src/processors/index.ts)
+7. Add your input processor as part of the [main input processor](../src/processors/InputProcessor.ts)
+8. Add a [test for the main input processor](../test/processors/InputProcessor.spec.ts) to ensure that your input processor are accessed accordingly.
+
+Thats it for the code and tests, now all that remains is docs and examples! :fire:
+1. [Add a new example](#adding-examples) showcasing the new supported input.
+2. Add the [usage example to the usage document](./usage.md).
+3. Add the new supported input to the [main readme file](../README.md#features).
+
+Aaaand you are done! :tada: 
+
 ### New Generators
 Generators sits as the core of Modelina, which frames the core concepts of what you can generate. Therefore it's also no small task to create a new one, so dont get discourage, we are here to help you! 
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -22,12 +22,17 @@ module.exports = {
   collectCoverageFrom: [
     'src/**'
   ],
+  coveragePathIgnorePatterns: [
+    "<rootDir>/src/processors/TemplateInputProcessor.ts",
+    "<rootDir>/src/generators/template",
+  ],
   moduleNameMapper: {
     '^nimma/legacy$': '<rootDir>/node_modules/nimma/dist/legacy/cjs/index.js',
     '^nimma/(.*)': '<rootDir>/node_modules/nimma/dist/cjs/$1',
   },
   modulePathIgnorePatterns: [
     '<rootDir>/examples/TEMPLATE',
-    '<rootDir>/test/generators/template'
+    '<rootDir>/test/generators/template',
+    '<rootDir>/test/processors/TemplateInputProcessor.spec.ts'
   ]
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -23,8 +23,8 @@ module.exports = {
     'src/**'
   ],
   coveragePathIgnorePatterns: [
-    "<rootDir>/src/processors/TemplateInputProcessor.ts",
-    "<rootDir>/src/generators/template",
+    '<rootDir>/src/processors/TemplateInputProcessor.ts',
+    '<rootDir>/src/generators/template',
   ],
   moduleNameMapper: {
     '^nimma/legacy$': '<rootDir>/node_modules/nimma/dist/legacy/cjs/index.js',

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "docker:test:blackbox": "npm run docker:build && docker run asyncapi/modelina npm run test:blackbox",
     "test": "npm run test:library && npm run test:examples",
     "test:library": "cross-env CI=true jest --coverage --testPathIgnorePatterns ./test/blackbox --testPathIgnorePatterns ./examples",
-    "test:examples": "cross-env CI=true jest  ./examples --testPathIgnorePatterns ./examples/integrate-with-react --testPathIgnorePatterns ./examples/TEMPLATE && npm run test:examples:websites",
+    "test:examples": "cross-env CI=true jest ./examples --testPathIgnorePatterns ./examples/integrate-with-react && npm run test:examples:websites",
     "test:examples:websites": "cd ./examples/integrate-with-react && npm i && npm run test",
     "test:blackbox": "cross-env CI=true jest ./test/blackbox",
     "test:watch": "jest --watch",

--- a/src/generators/AbstractGenerator.ts
+++ b/src/generators/AbstractGenerator.ts
@@ -47,7 +47,7 @@ export abstract class AbstractGenerator<
    * @param input 
    * @param options to use for rendering full output
    */
-  public async generateCompleteModels(input: Record<string, unknown> | InputMetaModel, options: RenderCompleteModelOptions): Promise<OutputModel[]> {
+  public async generateCompleteModels(input: any | InputMetaModel, options: RenderCompleteModelOptions): Promise<OutputModel[]> {
     const inputModel = await this.processInput(input);
     const renders = Object.values(inputModel.models).map(async (model) => {
       const constrainedModel = this.constrainToMetaModel(model);
@@ -68,7 +68,7 @@ export abstract class AbstractGenerator<
    * 
    * @param input 
    */
-  public async generate(input: Record<string, unknown> | InputMetaModel): Promise<OutputModel[]> {
+  public async generate(input: any | InputMetaModel): Promise<OutputModel[]> {
     const inputModel = await this.processInput(input);
     const renders = Object.values(inputModel.models).map(async (model) => {
       const constrainedModel = this.constrainToMetaModel(model);
@@ -90,7 +90,7 @@ export abstract class AbstractGenerator<
    * 
    * @param input 
    */
-  protected async processInput(input: Record<string, unknown> | InputMetaModel): Promise<InputMetaModel> {
+  protected async processInput(input: any | InputMetaModel): Promise<InputMetaModel> {
     const rawInputModel = input instanceof InputMetaModel ? input : await this.process(input);
 
     //Split out the models based on the language specific requirements of which models is rendered separately

--- a/src/generators/java/JavaConstrainer.ts
+++ b/src/generators/java/JavaConstrainer.ts
@@ -1,5 +1,4 @@
 import { ConstrainedEnumValueModel } from 'models';
-import { createSemanticDiagnosticsBuilderProgram } from 'typescript';
 import { TypeMapping } from '../../helpers';
 import { defaultEnumKeyConstraints, defaultEnumValueConstraints } from './constrainer/EnumConstrainer';
 import { defaultModelNameConstraints } from './constrainer/ModelNameConstrainer';
@@ -141,7 +140,7 @@ export const JavaDefaultTypeMapping: TypeMapping<JavaOptions> = {
     const format = constrainedModel.originalInput && constrainedModel.originalInput['format'];
     const valueTypes = constrainedModel.values.map((enumValue) => fromEnumValueToType(enumValue, format));
     const uniqueTypes = valueTypes.filter((item, pos) => {
-      return valueTypes.indexOf(item) == pos;
+      return valueTypes.indexOf(item) === pos;
     });
 
     //Enums cannot handle union types, default to a loose type

--- a/src/generators/java/JavaConstrainer.ts
+++ b/src/generators/java/JavaConstrainer.ts
@@ -8,38 +8,37 @@ import { JavaOptions } from './JavaGenerator';
 
 function enumFormatToNumberType(enumValueModel: ConstrainedEnumValueModel, format: string): string {
   switch (format) {
-    case 'integer':
-    case 'int32':
+  case 'integer':
+  case 'int32':
+    return 'int';
+  case 'long':
+  case 'int64':
+    return 'long';
+  case 'float':
+    return 'float';
+  case 'double':
+    return 'double';
+  default:
+    if (Number.isInteger(enumValueModel.value)) {
       return 'int';
-    case 'long':
-    case 'int64':
-      return 'long';
-    case 'float':
-      return 'float';
-    case 'double':
-      return 'double';
-    default:
-      if (Number.isInteger(enumValueModel.value)) {
-        return 'int';
-      } else {
-        return 'double';
-      }
+    } 
+    return 'double';
   }
 }
 
 const fromEnumValueToType = (enumValueModel: ConstrainedEnumValueModel, format: string): string => {
   switch (typeof enumValueModel.value) {
-    case 'boolean':
-      return 'boolean';
-    case 'number':
-    case 'bigint':
-      return enumFormatToNumberType(enumValueModel, format);
-    case 'object':
-      return 'Object';
-    case 'string':
-      return 'String';
-    default:
-      return 'Object';
+  case 'boolean':
+    return 'boolean';
+  case 'number':
+  case 'bigint':
+    return enumFormatToNumberType(enumValueModel, format);
+  case 'object':
+    return 'Object';
+  case 'string':
+    return 'String';
+  default:
+    return 'Object';
   }
 };
 
@@ -51,20 +50,20 @@ const fromEnumValueToType = (enumValueModel: ConstrainedEnumValueModel, format: 
  * int + long = long
  */
 const interpretUnionValueType = (types: string[]): string => {
-  if(types.includes('double')) {
+  if (types.includes('double')) {
     return 'double';
   }
 
-  if(types.includes('float')) {
+  if (types.includes('float')) {
     return 'float';
   }
 
-  if(types.includes('long')) {
+  if (types.includes('long')) {
     return 'long';
   }
 
   return 'Object';
-}
+};
 
 export const JavaDefaultTypeMapping: TypeMapping<JavaOptions> = {
   Object({ constrainedModel }): string {
@@ -80,9 +79,9 @@ export const JavaDefaultTypeMapping: TypeMapping<JavaOptions> = {
     let type = 'Double';
     const format = constrainedModel.originalInput && constrainedModel.originalInput['format'];
     switch (format) {
-      case 'float':
-        type = 'float';
-        break;
+    case 'float':
+      type = 'float';
+      break;
     }
     return type;
   },
@@ -90,14 +89,14 @@ export const JavaDefaultTypeMapping: TypeMapping<JavaOptions> = {
     let type = 'Integer';
     const format = constrainedModel.originalInput && constrainedModel.originalInput['format'];
     switch (format) {
-      case 'integer':
-      case 'int32':
-        type = 'int';
-        break;
-      case 'long':
-      case 'int64':
-        type = 'long';
-        break;
+    case 'integer':
+    case 'int32':
+      type = 'int';
+      break;
+    case 'long':
+    case 'int64':
+      type = 'long';
+      break;
     }
     return type;
   },
@@ -105,19 +104,19 @@ export const JavaDefaultTypeMapping: TypeMapping<JavaOptions> = {
     let type = 'String';
     const format = constrainedModel.originalInput && constrainedModel.originalInput['format'];
     switch (format) {
-      case 'date':
-        type = 'java.time.LocalDate';
-        break;
-      case 'time':
-        type = 'java.time.OffsetTime';
-        break;
-      case 'dateTime':
-      case 'date-time':
-        type = 'java.time.OffsetDateTime';
-        break;
-      case 'binary':
-        type = 'byte[]';
-        break;
+    case 'date':
+      type = 'java.time.LocalDate';
+      break;
+    case 'time':
+      type = 'java.time.OffsetTime';
+      break;
+    case 'dateTime':
+    case 'date-time':
+      type = 'java.time.OffsetDateTime';
+      break;
+    case 'binary':
+      type = 'byte[]';
+      break;
     }
     return type;
   },
@@ -141,7 +140,7 @@ export const JavaDefaultTypeMapping: TypeMapping<JavaOptions> = {
   Enum({ constrainedModel }): string {
     const format = constrainedModel.originalInput && constrainedModel.originalInput['format'];
     const valueTypes = constrainedModel.values.map((enumValue) => fromEnumValueToType(enumValue, format));
-    const uniqueTypes = valueTypes.filter(function (item, pos) {
+    const uniqueTypes = valueTypes.filter((item, pos) => {
       return valueTypes.indexOf(item) == pos;
     });
 

--- a/src/generators/java/renderers/EnumRenderer.ts
+++ b/src/generators/java/renderers/EnumRenderer.ts
@@ -47,7 +47,7 @@ export const JAVA_DEFAULT_ENUM_PRESET: EnumPresetType<JavaOptions> = {
     return `${item.key}((${model.type})${item.value})`;
   },
   additionalContent({ model }) {
-    const valueComparitor = model.type.charAt(0) == model.type.charAt(0).toUpperCase() ? 'e.value.equals(value)' : 'e.value == value';
+    const valueComparitor = model.type.charAt(0) === model.type.charAt(0).toUpperCase() ? 'e.value.equals(value)' : 'e.value == value';
     return `private ${model.type} value;
 
 ${model.name}(${model.type} value) {

--- a/src/processors/AbstractInputProcessor.ts
+++ b/src/processors/AbstractInputProcessor.ts
@@ -2,6 +2,6 @@ import { ProcessorOptions, InputMetaModel } from '../models';
 
 export abstract class AbstractInputProcessor {
   public static MODELGEN_INFFERED_NAME = 'x-modelgen-inferred-name';
-  abstract process(input: Record<string, any>, options?: ProcessorOptions): Promise<InputMetaModel>;
-  abstract shouldProcess(input: Record<string, any>): boolean;
+  abstract process(input: any, options?: ProcessorOptions): Promise<InputMetaModel>;
+  abstract shouldProcess(input: any): boolean;
 }

--- a/src/processors/AsyncAPIInputProcessor.ts
+++ b/src/processors/AsyncAPIInputProcessor.ts
@@ -5,7 +5,6 @@ import { InputMetaModel, ProcessorOptions } from '../models';
 import { Logger } from '../utils';
 import { AsyncapiV2Schema } from '../models/AsyncapiV2Schema';
 import { convertToMetaModel } from '../helpers';
-
 import type { AsyncAPIDocumentInterface, SchemaInterface as AsyncAPISchema } from '@asyncapi/parser';
 
 /**
@@ -22,7 +21,7 @@ export class AsyncAPIInputProcessor extends AbstractInputProcessor {
    * @param input 
    */
   // eslint-disable-next-line sonarjs/cognitive-complexity
-  async process(input?: Record<string, any>, options?: ProcessorOptions): Promise<InputMetaModel> {
+  async process(input?: any, options?: ProcessorOptions): Promise<InputMetaModel> {
     if (!this.shouldProcess(input)) {throw new Error('Input is not an AsyncAPI document so it cannot be processed.');}
 
     Logger.debug('Processing input as an AsyncAPI document');
@@ -188,7 +187,7 @@ export class AsyncAPIInputProcessor extends AbstractInputProcessor {
 	 * 
 	 * @param input 
 	 */
-  shouldProcess(input?: Record<string, any>) : boolean {
+  shouldProcess(input?: any) : boolean {
     if (!input) {return false;}
     const version = this.tryGetVersionOfDocument(input);
     if (!version) {return false;}
@@ -200,7 +199,7 @@ export class AsyncAPIInputProcessor extends AbstractInputProcessor {
    * 
    * @param input 
    */
-  tryGetVersionOfDocument(input?: Record<string, any>) : string | undefined {
+  tryGetVersionOfDocument(input?: any) : string | undefined {
     if (!input) {return;}
     if (AsyncAPIInputProcessor.isFromParser(input)) {
       return input.version();
@@ -213,7 +212,7 @@ export class AsyncAPIInputProcessor extends AbstractInputProcessor {
    * 
    * @param input 
    */
-  static isFromParser(input?: Record<string, any>): boolean {
+  static isFromParser(input?: any): boolean {
     if (!input) {return false;}
     if (input['_json'] !== undefined && input['_json'].asyncapi !== undefined && 
       typeof input.version === 'function') {

--- a/src/processors/InputProcessor.ts
+++ b/src/processors/InputProcessor.ts
@@ -45,7 +45,7 @@ export class InputProcessor {
    * @param input to process
    * @param options passed to the processors
    */
-  process(input: Record<string, any>, options?: ProcessorOptions): Promise<InputMetaModel> {
+  process(input: any, options?: ProcessorOptions): Promise<InputMetaModel> {
     for (const [type, processor] of this.processors) {
       if (type === 'default') {continue;}
       if (processor.shouldProcess(input)) {

--- a/src/processors/JsonSchemaInputProcessor.ts
+++ b/src/processors/JsonSchemaInputProcessor.ts
@@ -15,7 +15,7 @@ export class JsonSchemaInputProcessor extends AbstractInputProcessor {
    * 
    * @param input 
    */
-  process(input: Record<string, any>): Promise<InputMetaModel> {
+  process(input: any): Promise<InputMetaModel> {
     if (this.shouldProcess(input)) {
       switch (input.$schema) {
       case 'http://json-schema.org/draft-04/schema':
@@ -38,7 +38,7 @@ export class JsonSchemaInputProcessor extends AbstractInputProcessor {
    * 
    * @param input 
    */
-  shouldProcess(input: Record<string, any>): boolean {
+  shouldProcess(input: any): boolean {
     if (input.$schema !== undefined) {
       if (input.$schema === 'http://json-schema.org/draft-04/schema#' ||
       input.$schema === 'http://json-schema.org/draft-04/schema' ||
@@ -58,11 +58,11 @@ export class JsonSchemaInputProcessor extends AbstractInputProcessor {
    * 
    * @param input to process as draft 7
    */
-  private async processDraft7(input: Record<string, any>) : Promise<InputMetaModel> {
+  private async processDraft7(input: any) : Promise<InputMetaModel> {
     Logger.debug('Processing input as a JSON Schema Draft 7 document');
     const inputModel = new InputMetaModel();
     inputModel.originalInput = input;
-    input = JsonSchemaInputProcessor.reflectSchemaNames(input, {}, 'root', true) as Record<string, any>;
+    input = JsonSchemaInputProcessor.reflectSchemaNames(input, {}, 'root', true) as any;
     input = await this.dereferenceInputs(input);
     const parsedSchema = Draft7Schema.toSchema(input);
     const newCommonModel = JsonSchemaInputProcessor.convertSchemaToCommonModel(parsedSchema);
@@ -77,11 +77,11 @@ export class JsonSchemaInputProcessor extends AbstractInputProcessor {
    * 
    * @param input to process as draft 4
    */
-  private async processDraft4(input: Record<string, any>) : Promise<InputMetaModel> {
+  private async processDraft4(input: any) : Promise<InputMetaModel> {
     Logger.debug('Processing input as JSON Schema Draft 4 document');
     const inputModel = new InputMetaModel();
     inputModel.originalInput = input;
-    input = JsonSchemaInputProcessor.reflectSchemaNames(input, {}, 'root', true) as Record<string, any>;
+    input = JsonSchemaInputProcessor.reflectSchemaNames(input, {}, 'root', true) as any;
     input = await this.dereferenceInputs(input);
     const parsedSchema = Draft4Schema.toSchema(input);
     const newCommonModel = JsonSchemaInputProcessor.convertSchemaToCommonModel(parsedSchema);
@@ -96,11 +96,11 @@ export class JsonSchemaInputProcessor extends AbstractInputProcessor {
    * 
    * @param input to process as draft-6
    */
-  private async processDraft6(input: Record<string, any>) : Promise<InputMetaModel> {
+  private async processDraft6(input: any) : Promise<InputMetaModel> {
     Logger.debug('Processing input as a JSON Schema Draft 6 document');
     const inputModel = new InputMetaModel();
     inputModel.originalInput = input;
-    input = JsonSchemaInputProcessor.reflectSchemaNames(input, {}, 'root', true) as Record<string, any>;
+    input = JsonSchemaInputProcessor.reflectSchemaNames(input, {}, 'root', true) as any;
     input = await this.dereferenceInputs(input);
     const parsedSchema = Draft6Schema.toSchema(input);
     const newCommonModel = JsonSchemaInputProcessor.convertSchemaToCommonModel(parsedSchema);
@@ -115,7 +115,7 @@ export class JsonSchemaInputProcessor extends AbstractInputProcessor {
    * 
    * But it's the best we can do until we find or build a better library to handle references.
    */
-  public handleRootReference(input: Record<string, any>): Record<string, any> {
+  public handleRootReference(input: any): any {
     //Because of https://github.com/APIDevTools/json-schema-ref-parser/issues/201 the tool cannot handle root references.
     //This really is a bad patch to fix an underlying problem, but until a full library is available, this is best we can do.
     const hasRootRef = input.$ref !== undefined;
@@ -143,7 +143,7 @@ export class JsonSchemaInputProcessor extends AbstractInputProcessor {
     return input;
   }
 
-  public async dereferenceInputs(input: Record<string, any>): Promise<Record<string, any>> {
+  public async dereferenceInputs(input: any): Promise<any> {
     input = this.handleRootReference(input);
     Logger.debug('Dereferencing all $ref instances');
     const refParser = new $RefParser;

--- a/src/processors/OpenAPIInputProcessor.ts
+++ b/src/processors/OpenAPIInputProcessor.ts
@@ -17,7 +17,7 @@ export class OpenAPIInputProcessor extends AbstractInputProcessor {
    * 
    * @param input 
    */
-  async process(input: Record<string, any>, options?: ProcessorOptions): Promise<InputMetaModel> {
+  async process(input: any, options?: ProcessorOptions): Promise<InputMetaModel> {
     if (!this.shouldProcess(input)) {throw new Error('Input is not a OpenAPI document so it cannot be processed.');}
 
     Logger.debug('Processing input as an OpenAPI document');
@@ -121,7 +121,7 @@ export class OpenAPIInputProcessor extends AbstractInputProcessor {
 	 * 
 	 * @param input 
 	 */
-  shouldProcess(input: Record<string, any>) : boolean {
+  shouldProcess(input: any) : boolean {
     const version = this.tryGetVersionOfDocument(input);
     if (!version) {return false;}
     return OpenAPIInputProcessor.supportedVersions.includes(version);
@@ -132,7 +132,7 @@ export class OpenAPIInputProcessor extends AbstractInputProcessor {
    * 
    * @param input 
    */
-  tryGetVersionOfDocument(input: Record<string, any>) : string | undefined {
+  tryGetVersionOfDocument(input: any) : string | undefined {
     return input && input.openapi;
   }
 }

--- a/src/processors/SwaggerInputProcessor.ts
+++ b/src/processors/SwaggerInputProcessor.ts
@@ -17,7 +17,7 @@ export class SwaggerInputProcessor extends AbstractInputProcessor {
    * 
    * @param input 
    */
-  async process(input: Record<string, any>, options?: ProcessorOptions): Promise<InputMetaModel> {
+  async process(input: any, options?: ProcessorOptions): Promise<InputMetaModel> {
     if (!this.shouldProcess(input)) {throw new Error('Input is not a Swagger document so it cannot be processed.');}
 
     Logger.debug('Processing input as a Swagger document');
@@ -103,7 +103,7 @@ export class SwaggerInputProcessor extends AbstractInputProcessor {
 	 * 
 	 * @param input 
 	 */
-  shouldProcess(input: Record<string, any>) : boolean {
+  shouldProcess(input: any) : boolean {
     const version = this.tryGetVersionOfDocument(input);
     if (!version) { return false; }
     return SwaggerInputProcessor.supportedVersions.includes(version);
@@ -114,7 +114,7 @@ export class SwaggerInputProcessor extends AbstractInputProcessor {
    * 
    * @param input 
    */
-  tryGetVersionOfDocument(input: Record<string, any>) : string | undefined {
+  tryGetVersionOfDocument(input: any) : string | undefined {
     return input && input.swagger;
   }
 }

--- a/src/processors/TemplateInputProcessor.ts
+++ b/src/processors/TemplateInputProcessor.ts
@@ -1,0 +1,24 @@
+import { AbstractInputProcessor } from './AbstractInputProcessor';
+import { InputMetaModel, ProcessorOptions } from '../models';
+
+/**
+ * Class for processing X input
+ */
+export class TemplateInputProcessor extends AbstractInputProcessor {
+
+  shouldProcess(input?: any) : boolean {
+    if (!input) {return false;}
+    
+    return false;
+  }
+
+  async process(input?: any, options?: ProcessorOptions): Promise<InputMetaModel> {
+    if (!this.shouldProcess(input)) {throw new Error('Input is not X and cannot be processed by this input processor.');}
+
+    const inputModel = new InputMetaModel();
+
+    // Add processing code here
+
+    return inputModel;
+  }
+}

--- a/src/processors/TypeScriptInputProcessor.ts
+++ b/src/processors/TypeScriptInputProcessor.ts
@@ -51,7 +51,7 @@ export class TypeScriptInputProcessor extends AbstractInputProcessor {
     return [schema];
   }
 
-  shouldProcess(input: Record<string, any>): boolean {
+  shouldProcess(input: any): boolean {
     // checking if input is null
     if ((input === null || undefined) || (input.baseFile === null || undefined)) {
       return false;
@@ -68,7 +68,7 @@ export class TypeScriptInputProcessor extends AbstractInputProcessor {
     return true;
   }
 
-  process(input: Record<string, any>, options?: ProcessorOptions): Promise<InputMetaModel> {
+  process(input: any, options?: ProcessorOptions): Promise<InputMetaModel> {
     const inputModel = new InputMetaModel();
 
     if (!this.shouldProcess(input)) {
@@ -82,7 +82,7 @@ export class TypeScriptInputProcessor extends AbstractInputProcessor {
     const generatedSchemas = this.generateJSONSchema(baseFile, '*', options?.typescript);
     if (generatedSchemas) {
       for (const schema of generatedSchemas) {
-        const newCommonModel = JsonSchemaInputProcessor.convertSchemaToCommonModel(schema as Record<string, any>, options);
+        const newCommonModel = JsonSchemaInputProcessor.convertSchemaToCommonModel(schema as any, options);
         if (newCommonModel.$id !== undefined) {
           if (inputModel.models[newCommonModel.$id] !== undefined) {
             Logger.warn(`Overwriting existing model with $id ${newCommonModel.$id}, are there two models with the same id present?`, newCommonModel);

--- a/test/processors/InputProcessor.spec.ts
+++ b/test/processors/InputProcessor.spec.ts
@@ -51,15 +51,11 @@ describe('InputProcessor', () => {
       const openAPIInputProcessor = new OpenAPIInputProcessor();
       jest.spyOn(openAPIInputProcessor, 'shouldProcess');
       jest.spyOn(openAPIInputProcessor, 'process');
-      const typeScriptInputProcessor = new TypeScriptInputProcessor();
-      jest.spyOn(typeScriptInputProcessor, 'shouldProcess');
-      jest.spyOn(typeScriptInputProcessor, 'process');
       const processor = new InputProcessor();
       processor.setProcessor('asyncapi', asyncInputProcessor);
       processor.setProcessor('swagger', swaggerInputProcessor);
       processor.setProcessor('openapi', openAPIInputProcessor);
       processor.setProcessor('default', defaultInputProcessor);
-      processor.setProcessor('typescript', typeScriptInputProcessor);
       return {processor, asyncInputProcessor, swaggerInputProcessor, openAPIInputProcessor, defaultInputProcessor};
     };
     test('should throw error when no default processor found', async () => {
@@ -109,17 +105,6 @@ describe('InputProcessor', () => {
       await processor.process(inputSchema);
       expect(openAPIInputProcessor.process).toHaveBeenNthCalledWith(1, inputSchema, undefined);
       expect(openAPIInputProcessor.shouldProcess).toHaveBeenNthCalledWith(1, inputSchema);
-      expect(defaultInputProcessor.process).not.toHaveBeenCalled();
-      expect(defaultInputProcessor.shouldProcess).not.toHaveBeenCalled();
-    });
-
-    test('should be able to process TypeScript input', async () => {
-      const {processor, asyncInputProcessor, defaultInputProcessor} = getProcessors(); 
-      const inputSchemaString = fs.readFileSync(path.resolve(__dirname, './AsyncAPIInputProcessor/basic.json'), 'utf8');
-      const inputSchema = JSON.parse(inputSchemaString);
-      await processor.process(inputSchema);
-      expect(asyncInputProcessor.process).toHaveBeenNthCalledWith(1, inputSchema, undefined);
-      expect(asyncInputProcessor.shouldProcess).toHaveBeenNthCalledWith(1, inputSchema);
       expect(defaultInputProcessor.process).not.toHaveBeenCalled();
       expect(defaultInputProcessor.shouldProcess).not.toHaveBeenCalled();
     });

--- a/test/processors/InputProcessor.spec.ts
+++ b/test/processors/InputProcessor.spec.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { InputMetaModel, ProcessorOptions } from '../../src/models';
-import { AbstractInputProcessor, AsyncAPIInputProcessor, JsonSchemaInputProcessor, InputProcessor, SwaggerInputProcessor } from '../../src/processors';
+import { AbstractInputProcessor, AsyncAPIInputProcessor, JsonSchemaInputProcessor, InputProcessor, SwaggerInputProcessor, TypeScriptInputProcessor } from '../../src/processors';
 import { OpenAPIInputProcessor } from '../../src/processors/OpenAPIInputProcessor';
 
 describe('InputProcessor', () => {
@@ -51,11 +51,15 @@ describe('InputProcessor', () => {
       const openAPIInputProcessor = new OpenAPIInputProcessor();
       jest.spyOn(openAPIInputProcessor, 'shouldProcess');
       jest.spyOn(openAPIInputProcessor, 'process');
+      const typeScriptInputProcessor = new TypeScriptInputProcessor();
+      jest.spyOn(typeScriptInputProcessor, 'shouldProcess');
+      jest.spyOn(typeScriptInputProcessor, 'process');
       const processor = new InputProcessor();
       processor.setProcessor('asyncapi', asyncInputProcessor);
       processor.setProcessor('swagger', swaggerInputProcessor);
       processor.setProcessor('openapi', openAPIInputProcessor);
       processor.setProcessor('default', defaultInputProcessor);
+      processor.setProcessor('typescript', typeScriptInputProcessor);
       return {processor, asyncInputProcessor, swaggerInputProcessor, openAPIInputProcessor, defaultInputProcessor};
     };
     test('should throw error when no default processor found', async () => {
@@ -105,6 +109,17 @@ describe('InputProcessor', () => {
       await processor.process(inputSchema);
       expect(openAPIInputProcessor.process).toHaveBeenNthCalledWith(1, inputSchema, undefined);
       expect(openAPIInputProcessor.shouldProcess).toHaveBeenNthCalledWith(1, inputSchema);
+      expect(defaultInputProcessor.process).not.toHaveBeenCalled();
+      expect(defaultInputProcessor.shouldProcess).not.toHaveBeenCalled();
+    });
+
+    test('should be able to process TypeScript input', async () => {
+      const {processor, asyncInputProcessor, defaultInputProcessor} = getProcessors(); 
+      const inputSchemaString = fs.readFileSync(path.resolve(__dirname, './AsyncAPIInputProcessor/basic.json'), 'utf8');
+      const inputSchema = JSON.parse(inputSchemaString);
+      await processor.process(inputSchema);
+      expect(asyncInputProcessor.process).toHaveBeenNthCalledWith(1, inputSchema, undefined);
+      expect(asyncInputProcessor.shouldProcess).toHaveBeenNthCalledWith(1, inputSchema);
       expect(defaultInputProcessor.process).not.toHaveBeenCalled();
       expect(defaultInputProcessor.shouldProcess).not.toHaveBeenCalled();
     });

--- a/test/processors/TemplateInputProcessor.spec.ts
+++ b/test/processors/TemplateInputProcessor.spec.ts
@@ -1,0 +1,28 @@
+import {TemplateInputProcessor} from '../../src/processors/TemplateInputProcessor';
+
+describe('TemplateInputProcessor', () => {
+  const processor = new TemplateInputProcessor();
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+  describe('shouldProcess()', () => {
+    test('should be able to process X', () => {
+      const input = { };
+      expect(processor.shouldProcess(input)).toEqual(true);
+    });
+  });
+
+  describe('process()', () => {
+    test('should throw error when trying to process wrong schema', async () => {
+      const processor = new TemplateInputProcessor();
+      await expect(processor.process({}))
+        .rejects
+        .toThrow('Input is not X and cannot be processed by this input processor.');
+    });
+    test('should process X accurately', async () => {
+      const input = { };
+      const commonInputModel = await processor.process(input);
+      expect(commonInputModel).toMatchSnapshot();
+    });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,7 @@
   "include": [
     "src/**/*.ts",
   ],
-  "exclude": ["node_modules", "lib", "examples", "src/generator/template"],
+  "exclude": ["node_modules", "lib", "examples", "src/generator/template", "src/processors/TemplateInputProcessor"],
   "ts-node": {
     "compilerOptions": {
       "module": "CommonJS"


### PR DESCRIPTION
**Description**
This PR adds contribution guidelines and a template processor for adding new ones more easily. 

This PR also contains the following changes:
- Changed the old `Record<string, unknown>` input type to `any` because we should be able to process any type of input.
- Fixed an issue where templates are collected for coverage
- Add new contribution guidelines for new processors
- Add new input processor template and test
- Removed unused script ignore command