### PR TITLE
fix: references are getting incorrect model name

### DIFF
--- a/src/processors/JsonSchemaInputProcessor.ts
+++ b/src/processors/JsonSchemaInputProcessor.ts
@@ -147,7 +147,6 @@ export class JsonSchemaInputProcessor extends AbstractInputProcessor {
     input = this.handleRootReference(input);
     Logger.debug('Dereferencing all $ref instances');
     const refParser = new $RefParser;
-    // eslint-disable-next-line no-undef
     const localPath = `${process.cwd()}${path.sep}`;
     const deRefOption: $RefParser.Options = {
       continueOnError: true,
@@ -191,7 +190,7 @@ export class JsonSchemaInputProcessor extends AbstractInputProcessor {
       namesStack[String(name)] = 0;
       (schema as any)[this.MODELGEN_INFFERED_NAME] = name;
       name = '';
-    } else if (name && !(schema as any)[this.MODELGEN_INFFERED_NAME]) {
+    } else if (name && !(schema as any)[this.MODELGEN_INFFERED_NAME] && schema.$ref === undefined) {
       let occurrence = namesStack[String(name)];
       if (occurrence === undefined) {
         namesStack[String(name)] = 0;

--- a/test/processors/JsonSchemaInputProcessor.spec.ts
+++ b/test/processors/JsonSchemaInputProcessor.spec.ts
@@ -82,6 +82,7 @@ describe('JsonSchemaInputProcessor', () => {
       expect(JsonSchemaInputProcessor.convertSchemaToCommonModel).toHaveBeenCalledTimes(1);
       expect(functionArgConvertSchemaToCommonModel).toMatchObject(expectedResolvedInput);
     });
+    
     test('should be able to use $ref when circular', async () => {
       const inputSchemaPath = './JsonSchemaInputProcessor/references_circular.json';
       const {inputMetaModel, inputSchema} = await getCommonInput(inputSchemaPath);
@@ -91,6 +92,7 @@ describe('JsonSchemaInputProcessor', () => {
       expect(JsonSchemaInputProcessor.convertSchemaToCommonModel).toHaveBeenCalledTimes(1);
       expect(functionArgConvertSchemaToCommonModel).toMatchObject(expectedResolvedInput);
     });
+
     test('should fail correctly when reference cannot be resolved', async () => {
       const inputSchemaPath = './JsonSchemaInputProcessor/wrong_references.json';
       const inputSchemaString = fs.readFileSync(path.resolve(__dirname, inputSchemaPath), 'utf8');
@@ -183,6 +185,9 @@ describe('JsonSchemaInputProcessor', () => {
     test('should work', () => {
       const schema = {
         properties: {
+          reference: {
+            $ref: '#/definitions/def'
+          },
           prop: {
             type: 'string',
           },
@@ -258,6 +263,7 @@ describe('JsonSchemaInputProcessor', () => {
       expect(expected['x-modelgen-inferred-name']).toEqual('root');
 
       // properties
+      expect(expected.properties.reference['x-modelgen-inferred-name']).toBeUndefined();
       expect(expected.properties.prop['x-modelgen-inferred-name']).toEqual('prop');
       expect(expected.properties.allOfCase.allOf[0]['x-modelgen-inferred-name']).toEqual('allOfCase_allOf_0');
       expect(expected.properties.allOfCase.allOf[1]['x-modelgen-inferred-name']).toEqual('allOfCase_allOf_1');


### PR DESCRIPTION
**Description**

This PR fixes that schemas that reference others are getting incorrectly assigned model names. This PR fixes that by not giving any schemas with a reference name.

Fixes https://github.com/asyncapi/modelina/issues/232
Partly fixes https://github.com/asyncapi/modelina/issues/823
