### PR TITLE
ci: fix `next` branch is not getting released

### DIFF
--- a/.github/workflows/if-nodejs-release.yml
+++ b/.github/workflows/if-nodejs-release.yml
@@ -10,6 +10,7 @@ on:
       - master
       # below lines are not enough to have release supported for these branches
       # make sure configuration of `semantic-release` package mentions these branches
+      - next
       - next-spec
       - next-major
       - next-major-spec


### PR DESCRIPTION
**Description**
This PR fixes that the `next` branch is not getting released