### PR TITLE
fix: rust compile errors on enum members containing digits

### DIFF
--- a/examples/rust-generate-crate/__snapshots__/index.spec.ts.snap
+++ b/examples/rust-generate-crate/__snapshots__/index.spec.ts.snap
@@ -52,12 +52,12 @@ Array [
   "// Members represents a union of types: String, f64, bool
 #[derive(Clone, Debug, Deserialize, PartialEq, PartialOrd, Serialize)]
 pub enum Members {
-    #[serde(rename=\\"MembersOneOf_00\\")]
-    MembersOneOf_00(String),
-    #[serde(rename=\\"MembersOneOf_11\\")]
-    MembersOneOf_11(f64),
-    #[serde(rename=\\"MembersOneOf_22\\")]
-    MembersOneOf_22(bool),
+    #[serde(rename=\\"MembersOneOf00\\")]
+    MembersOneOf00(String),
+    #[serde(rename=\\"MembersOneOf11\\")]
+    MembersOneOf11(f64),
+    #[serde(rename=\\"MembersOneOf22\\")]
+    MembersOneOf22(bool),
 }
 
 ",

--- a/examples/rust-generate-crate/__snapshots__/index.spec.ts.snap
+++ b/examples/rust-generate-crate/__snapshots__/index.spec.ts.snap
@@ -50,7 +50,7 @@ impl Address {
 exports[`Should be able to render Rust Models and should log expected output to console 2`] = `
 Array [
   "// Members represents a union of types: String, f64, bool
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, PartialOrd, Serialize)]
 pub enum Members {
     #[serde(rename=\\"MembersOneOf_00\\")]
     MembersOneOf_00(String),
@@ -67,7 +67,7 @@ pub enum Members {
 exports[`Should be able to render Rust Models and should log expected output to console 3`] = `
 Array [
   "// TupleType represents a TupleType model.
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, PartialOrd, Serialize)]
 pub struct TupleType(String, f64);
 
 impl TupleType {

--- a/src/generators/rust/RustConstrainer.ts
+++ b/src/generators/rust/RustConstrainer.ts
@@ -57,7 +57,7 @@ export function derivePartialEq(model: ConstrainedMetaModel): boolean {
 }
 
 export function deriveEq(model: ConstrainedMetaModel): boolean {
-  if (!derivePartialEq(model)) { return false };
+  if (!derivePartialEq(model)) { return false; }
 
   if (model instanceof ConstrainedFloatModel || model instanceof ConstrainedAnyModel) { return false; } else if (
     // all contents implement Eq trait
@@ -87,7 +87,7 @@ export function derivePartialOrd(model: ConstrainedMetaModel): boolean {
 }
 
 export function deriveOrd(model: ConstrainedMetaModel): boolean {
-  if (!derivePartialOrd(model)) { return false };
+  if (!derivePartialOrd(model)) { return false; }
 
   if (
     model instanceof ConstrainedFloatModel ||

--- a/src/generators/rust/RustConstrainer.ts
+++ b/src/generators/rust/RustConstrainer.ts
@@ -41,16 +41,84 @@ export function deriveCopy(model: ConstrainedMetaModel): boolean {
   return true;
 }
 
+export function derivePartialEq(model: ConstrainedMetaModel): boolean {
+  if (model instanceof ConstrainedAnyModel) { return false; }
+
+  if (
+    // all contents implement PartialEq trait
+    model instanceof ConstrainedArrayModel ||
+    model instanceof ConstrainedEnumModel ||
+    model instanceof ConstrainedObjectModel ||
+    model instanceof ConstrainedTupleModel ||
+    model instanceof ConstrainedUnionModel ||
+    model instanceof ConstrainedDictionaryModel
+  ) { return allPartialEq(model); }
+  return true;
+}
+
 export function deriveEq(model: ConstrainedMetaModel): boolean {
+  if (!derivePartialEq(model)) { return false };
+
   if (model instanceof ConstrainedFloatModel || model instanceof ConstrainedAnyModel) { return false; } else if (
     // all contents implement Eq trait
     model instanceof ConstrainedArrayModel ||
     model instanceof ConstrainedEnumModel ||
     model instanceof ConstrainedObjectModel ||
     model instanceof ConstrainedTupleModel ||
-    model instanceof ConstrainedUnionModel
+    model instanceof ConstrainedUnionModel ||
+    model instanceof ConstrainedDictionaryModel
   ) { return allEq(model); }
   return true;
+}
+
+export function derivePartialOrd(model: ConstrainedMetaModel): boolean {
+  if (
+    model instanceof ConstrainedAnyModel ||
+    model instanceof ConstrainedDictionaryModel
+  ) { return false; } else if (
+    // all contents implement PartialOrd trait
+    model instanceof ConstrainedArrayModel ||
+    model instanceof ConstrainedEnumModel ||
+    model instanceof ConstrainedObjectModel ||
+    model instanceof ConstrainedTupleModel ||
+    model instanceof ConstrainedUnionModel
+  ) { return allPartialOrd(model); }
+  return true;
+}
+
+export function deriveOrd(model: ConstrainedMetaModel): boolean {
+  if (!derivePartialOrd(model)) { return false };
+
+  if (
+    model instanceof ConstrainedFloatModel ||
+    model instanceof ConstrainedAnyModel ||
+    model instanceof ConstrainedDictionaryModel
+  ) { return false; } else if (
+    // all contents implement Ord trait
+    model instanceof ConstrainedArrayModel ||
+    model instanceof ConstrainedEnumModel ||
+    model instanceof ConstrainedObjectModel ||
+    model instanceof ConstrainedTupleModel ||
+    model instanceof ConstrainedUnionModel
+  ) { return allOrd(model); }
+  return true;
+}
+
+export function allPartialEq(model: ConstrainedMetaModel): boolean {
+  if (model instanceof ConstrainedUnionModel) {
+    return model.union.map(derivePartialEq).every(v => v === true);
+  } else if (model instanceof ConstrainedTupleModel) {
+    return model.tuple.map(v => derivePartialEq(v.value)).every(v => v === true);
+  } else if (model instanceof ConstrainedObjectModel) {
+    return Object.values(model.properties).map(p => derivePartialEq(p.property)).every(v => v === true);
+  } else if (model instanceof ConstrainedArrayModel) {
+    return derivePartialEq(model.valueModel);
+  } else if (model instanceof ConstrainedEnumModel) {
+    return model.values.map(v => derivePartialEq(v.value)).every(v => v === true);
+  } else if (model instanceof ConstrainedDictionaryModel) {
+    return derivePartialEq(model.value);
+  }
+  return false;
 }
 
 export function allEq(model: ConstrainedMetaModel): boolean {
@@ -64,6 +132,38 @@ export function allEq(model: ConstrainedMetaModel): boolean {
     return deriveEq(model.valueModel);
   } else if (model instanceof ConstrainedEnumModel) {
     return model.values.map(v => deriveEq(v.value)).every(v => v === true);
+  } else if (model instanceof ConstrainedDictionaryModel) {
+    return deriveEq(model.value);
+  }
+  return false;
+}
+
+export function allPartialOrd(model: ConstrainedMetaModel): boolean {
+  if (model instanceof ConstrainedUnionModel) {
+    return model.union.map(derivePartialOrd).every(v => v === true);
+  } else if (model instanceof ConstrainedTupleModel) {
+    return model.tuple.map(v => derivePartialOrd(v.value)).every(v => v === true);
+  } else if (model instanceof ConstrainedObjectModel) {
+    return Object.values(model.properties).map(p => derivePartialOrd(p.property)).every(v => v === true);
+  } else if (model instanceof ConstrainedArrayModel) {
+    return derivePartialOrd(model.valueModel);
+  } else if (model instanceof ConstrainedEnumModel) {
+    return model.values.map(v => derivePartialOrd(v.value)).every(v => v === true);
+  }
+  return false;
+}
+
+export function allOrd(model: ConstrainedMetaModel): boolean {
+  if (model instanceof ConstrainedUnionModel) {
+    return model.union.map(deriveOrd).every(v => v === true);
+  } else if (model instanceof ConstrainedTupleModel) {
+    return model.tuple.map(v => deriveOrd(v.value)).every(v => v === true);
+  } else if (model instanceof ConstrainedObjectModel) {
+    return Object.values(model.properties).map(p => deriveOrd(p.property)).every(v => v === true);
+  } else if (model instanceof ConstrainedArrayModel) {
+    return deriveOrd(model.valueModel);
+  } else if (model instanceof ConstrainedEnumModel) {
+    return model.values.map(v => deriveOrd(v.value)).every(v => v === true);
   }
   return false;
 }
@@ -153,7 +253,8 @@ export const RustDefaultTypeMapping: TypeMapping<RustOptions> = {
     return `${constrainedModel.name}`;
   },
   Array({ constrainedModel }): string {
-    return `Vec<${FormatHelpers.upperFirst(constrainedModel.valueModel.type)}>`;
+    const prefix = (constrainedModel.valueModel instanceof ConstrainedReferenceModel) ? 'crate::' : '';
+    return `Vec<${prefix}${FormatHelpers.upperFirst(constrainedModel.valueModel.type)}>`;
   },
   Enum({ constrainedModel }): string {
     return constrainedModel.name;
@@ -162,7 +263,9 @@ export const RustDefaultTypeMapping: TypeMapping<RustOptions> = {
     return constrainedModel.name;
   },
   Dictionary({ constrainedModel }): string {
-    return `std::collections::HashMap<${constrainedModel.key.type}, ${constrainedModel.value.type}>`;
+    const key_prefix = (constrainedModel.key instanceof ConstrainedReferenceModel) ? 'crate::' : '';
+    const value_prefix = (constrainedModel.value instanceof ConstrainedReferenceModel) ? 'crate::' : '';
+    return `std::collections::HashMap<${key_prefix}${constrainedModel.key.type}, ${value_prefix}${constrainedModel.value.type}>`;
   }
 };
 

--- a/src/generators/rust/RustFileGenerator.ts
+++ b/src/generators/rust/RustFileGenerator.ts
@@ -40,7 +40,7 @@ export class RustFileGenerator extends RustGenerator implements AbstractFileGene
       const supportOutput = await this.generateCompleteSupport(input, options);
       generatedModels = generatedModels.concat(supportOutput);
       for (const outputModel of supportOutput) {
-        const filePath = path.resolve(outputDirectory, outputModel.modelName);
+        const filePath = path.resolve(outputDirectory, outputModel.model.name);
         await FileHelpers.writerToFileSystem(outputModel.result, filePath);
       }
     }

--- a/src/generators/rust/RustRenderer.ts
+++ b/src/generators/rust/RustRenderer.ts
@@ -2,7 +2,7 @@ import { AbstractRenderer } from '../AbstractRenderer';
 import { RustGenerator, RustOptions } from './RustGenerator';
 import { InputMetaModel, Preset, ConstrainedMetaModel } from '../../models';
 import { FormatHelpers } from '../../helpers/FormatHelpers';
-import { deriveCopy, deriveHash, deriveEq } from './RustConstrainer';
+import { deriveCopy, deriveHash, derivePartialEq, deriveEq, derivePartialOrd, deriveOrd } from './RustConstrainer';
 /**
  * Common renderer for Rust types
  * 
@@ -25,17 +25,24 @@ export abstract class RustRenderer<RendererModelType extends ConstrainedMetaMode
   }
 
   renderMacro(model: ConstrainedMetaModel): string {
-    const derive: string[] = ['Serialize', 'Deserialize', 'PartialEq', 'Clone', 'Debug'];
+    const derive: string[] = ['Serialize', 'Deserialize', 'Clone', 'Debug'];
     if (deriveHash(model)) {
       derive.push('Hash');
     }
     if (deriveCopy(model)) {
       derive.push('Copy');
     }
+    if (derivePartialEq(model)) {
+      derive.push('PartialEq');
+    }
     if (deriveEq(model)) {
       derive.push('Eq');
-      derive.push('Ord');
+    }
+    if (derivePartialOrd(model)) {
       derive.push('PartialOrd');
+    }
+    if (deriveOrd(model)) {
+      derive.push('Ord');
     }
     derive.sort();
     return `#[derive(${derive.join(', ')})]`;

--- a/src/generators/rust/constrainer/ModelNameConstrainer.ts
+++ b/src/generators/rust/constrainer/ModelNameConstrainer.ts
@@ -19,7 +19,7 @@ export const DefaultModelNameConstraints: ModelNameConstraints = {
   NO_NUMBER_START_CHAR,
   NO_EMPTY_VALUE,
   NAMING_FORMATTER: (value: string) => {
-    return FormatHelpers.toPascalCase(value);
+    return FormatHelpers.toPascalCaseMergingNumbers(value);
   },
   NO_RESERVED_KEYWORDS: (value: string) => {
     return NO_RESERVED_KEYWORDS(value, isReservedRustKeyword);

--- a/src/generators/rust/presets/CommonPreset.ts
+++ b/src/generators/rust/presets/CommonPreset.ts
@@ -1,7 +1,8 @@
-import { ConstrainedEnumModel, ConstrainedReferenceModel, ConstrainedUnionModel, ConstrainedEnumValueModel } from '../../../models';
+import { ConstrainedEnumModel, ConstrainedObjectModel, ConstrainedReferenceModel, ConstrainedUnionModel, ConstrainedEnumValueModel } from '../../../models';
 import { EnumRenderer } from '../renderers/EnumRenderer';
 import { RustPreset } from '../RustPreset';
 import { Logger } from '../../../utils';
+import { StructRenderer } from '../renderers/StructRenderer';
 
 export interface RustCommonPresetOptions {
   implementDefault: boolean;
@@ -49,6 +50,46 @@ function renderImplementDefault({ model }: {
 }`;
 }
 
+/**
+* Render `new` constructor function in struct impl
+*/
+function renderImplementNew({ model, renderer }: {
+  renderer: StructRenderer
+  model: ConstrainedObjectModel
+}) {
+  const args: string[] = [];
+  const fields: string[] = [];
+  const properties = model.properties || {};
+  for (const v of Object.values(properties)) {
+    const prefix = (v.property instanceof ConstrainedReferenceModel) ? 'crate::' : '';
+    const fieldType = prefix + v.property.type;
+
+    if (v.required) {
+      args.push(`${v.propertyName}: ${fieldType}`);
+      if (v.property instanceof ConstrainedReferenceModel) {
+        fields.push(`Box::new(${v.propertyName}),`);
+      } else {
+        fields.push(`${v.propertyName},`);
+      }
+      // use map to box reference if field is optional
+    } else if (!v.required && (v.property instanceof ConstrainedReferenceModel || v.property instanceof ConstrainedUnionModel)) {
+      args.push(`${v.propertyName}: Option<crate::${v.property.type}>`);
+      fields.push(`${v.propertyName}: ${v.propertyName}.map(Box::new),`);
+    } else {
+      args.push(`${v.propertyName}: Option<${fieldType}>`);
+      fields.push(`${v.propertyName},`);
+    }
+  }
+  const fieldsBlock = renderer.renderBlock(fields);
+  return `
+    pub fn new(${args.join(', ')}) -> ${model.name} {
+        ${model.name} {
+${renderer.indent(fieldsBlock, 8)}
+        }
+    }
+`;
+}
+
 export const RUST_COMMON_PRESET: RustPreset<RustCommonPresetOptions> = {
   enum: {
     additionalContent({ renderer, model, content, options }) {
@@ -63,42 +104,18 @@ export const RUST_COMMON_PRESET: RustPreset<RustCommonPresetOptions> = {
   struct: {
     additionalContent({ renderer, model, content, options }) {
       options = options || defaultRustCommonPresetOptions;
-      const properties = model.properties || {};
+      const fnBlocks = [];
       if (options.implementNew) {
-        const args: string[] = [];
-        const fields: string[] = [];
-        for (const v of Object.values(properties)) {
-          const prefix = (v.property instanceof ConstrainedReferenceModel) ? 'crate::' : '';
-          const fieldType = prefix + v.property.type;
+        fnBlocks.push(renderImplementNew({ model, renderer }));
+      }
 
-          if (v.required) {
-            args.push(`${v.propertyName}: ${fieldType}`);
-            if (v.property instanceof ConstrainedReferenceModel) {
-              fields.push(`Box::new(${v.propertyName}),`);
-            } else {
-              fields.push(`${v.propertyName},`);
-            }
-            // use map to box reference if field is optional
-          } else if (!v.required && (v.property instanceof ConstrainedReferenceModel || v.property instanceof ConstrainedUnionModel)) {
-            args.push(`${v.propertyName}: Option<crate::${v.property.type}>`);
-            fields.push(`${v.propertyName}: ${v.propertyName}.map(Box::new),`);
-          } else {
-            args.push(`${v.propertyName}: Option<${fieldType}>`);
-            fields.push(`${v.propertyName},`);
-          }
-        }
-        const fieldsBlock = renderer.renderBlock(fields);
-        const contentBlock = `
+      const fnBlock = renderer.renderBlock(fnBlocks);
+      const contentBlock = `
 impl ${model.name} {
-    pub fn new(${args.join(', ')}) -> ${model.name} {
-        ${model.name} {
-${renderer.indent(fieldsBlock, 8)}
-        }
-    }
+  ${renderer.indent(fnBlock, 4)}
 }
 `;
-        content = renderer.renderBlock([content, contentBlock]);
-      }
+      content = renderer.renderBlock([content, contentBlock]);
       return content;
     }
   },

--- a/src/generators/rust/presets/CommonPreset.ts
+++ b/src/generators/rust/presets/CommonPreset.ts
@@ -68,15 +68,22 @@ export const RUST_COMMON_PRESET: RustPreset<RustCommonPresetOptions> = {
         const args: string[] = [];
         const fields: string[] = [];
         for (const v of Object.values(properties)) {
+          const prefix = (v.property instanceof ConstrainedReferenceModel) ? 'crate::' : '';
+          const fieldType = prefix + v.property.type;
+
           if (v.required) {
-            args.push(`${v.propertyName}: ${v.property.type}`);
-            fields.push(`${v.propertyName},`);
+            args.push(`${v.propertyName}: ${fieldType}`);
+            if (v.property instanceof ConstrainedReferenceModel) {
+              fields.push(`Box::new(${v.propertyName}),`);
+            } else {
+              fields.push(`${v.propertyName},`);
+            }
             // use map to box reference if field is optional
           } else if (!v.required && (v.property instanceof ConstrainedReferenceModel || v.property instanceof ConstrainedUnionModel)) {
             args.push(`${v.propertyName}: Option<crate::${v.property.type}>`);
             fields.push(`${v.propertyName}: ${v.propertyName}.map(Box::new),`);
           } else {
-            args.push(`${v.propertyName}: Option<${v.property.type}>`);
+            args.push(`${v.propertyName}: Option<${fieldType}>`);
             fields.push(`${v.propertyName},`);
           }
         }

--- a/src/generators/rust/presets/CommonPreset.ts
+++ b/src/generators/rust/presets/CommonPreset.ts
@@ -81,13 +81,11 @@ function renderImplementNew({ model, renderer }: {
     }
   }
   const fieldsBlock = renderer.renderBlock(fields);
-  return `
-    pub fn new(${args.join(', ')}) -> ${model.name} {
-        ${model.name} {
-${renderer.indent(fieldsBlock, 8)}
-        }
+  return `pub fn new(${args.join(', ')}) -> ${model.name} {
+    ${model.name} {
+${renderer.indent(fieldsBlock, 4)}
     }
-`;
+}`;
 }
 
 export const RUST_COMMON_PRESET: RustPreset<RustCommonPresetOptions> = {
@@ -112,7 +110,7 @@ export const RUST_COMMON_PRESET: RustPreset<RustCommonPresetOptions> = {
       const fnBlock = renderer.renderBlock(fnBlocks);
       const contentBlock = `
 impl ${model.name} {
-  ${renderer.indent(fnBlock, 4)}
+${renderer.indent(fnBlock, 4)}
 }
 `;
       content = renderer.renderBlock([content, contentBlock]);

--- a/src/generators/rust/renderers/UnionRenderer.ts
+++ b/src/generators/rust/renderers/UnionRenderer.ts
@@ -1,5 +1,5 @@
 import { RustRenderer } from '../RustRenderer';
-import { ConstrainedUnionModel, ConstrainedMetaModel } from '../../../models';
+import { ConstrainedUnionModel, ConstrainedMetaModel, ConstrainedReferenceModel } from '../../../models';
 import { UnionPresetType } from '../RustPreset';
 import { RustOptions } from '../RustGenerator';
 
@@ -54,6 +54,9 @@ export const RUST_DEFAULT_UNION_PRESET: UnionPresetType<RustOptions> = {
     return `#[serde(${serdeArgs.join(', ')})]`;
   },
   item({ item }) {
+    if (item instanceof ConstrainedReferenceModel) {
+      return `${item.name}(crate::${item.ref.type})`;
+    }
     return `${item.name}(${item.type})`;
   }
 };

--- a/src/helpers/FormatHelpers.ts
+++ b/src/helpers/FormatHelpers.ts
@@ -3,7 +3,8 @@ import {
   pascalCase,
   paramCase,
   constantCase,
-  snakeCase
+  snakeCase,
+  pascalCaseTransformMerge,
 } from 'change-case';
 
 export enum IndentationTypes {
@@ -81,6 +82,16 @@ export class FormatHelpers {
    * @returns {string}
    */
   static toPascalCase = pascalCase;
+
+  /**
+   * Transform into a string of capitalized words without separators
+   * merging numbers.
+   * @param {string} value to transform
+   * @returns {string}
+   */
+  static toPascalCaseMergingNumbers(value: string): string {
+    return pascalCase(value, { transform: pascalCaseTransformMerge });
+  }
 
   /**
    * Transform into a lower cased string with dashes between words.

--- a/src/processors/AsyncAPIInputProcessor.ts
+++ b/src/processors/AsyncAPIInputProcessor.ts
@@ -79,7 +79,7 @@ export class AsyncAPIInputProcessor extends AbstractInputProcessor {
     
     let schemaUid = schema.id();
     //Because the constraint functionality of generators cannot handle -, <, >, we remove them from the id if it's an anonymous schema.
-    if (schemaUid.includes('<anonymous-schema')) {
+    if (typeof schemaUid !== 'undefined' && schemaUid.includes('<anonymous-schema')) {
       schemaUid = schemaUid.replace('<', '').replace(/-/g, '_').replace('>', '');
     }
     

--- a/test/generators/rust/RustGenerator.spec.ts
+++ b/test/generators/rust/RustGenerator.spec.ts
@@ -36,7 +36,7 @@ describe('RustGenerator', () => {
 
     test('should render `enum` with mixed types (union type)', async () => {
       const doc = {
-        $id: 'Things',
+        $id: 'Things_123',
         enum: ['Texas', 1, '1', false, { test: 'test' }],
       };
       const models = await generator.generate(doc);

--- a/test/generators/rust/RustRenderer.spec.ts
+++ b/test/generators/rust/RustRenderer.spec.ts
@@ -22,7 +22,8 @@ describe('RustRenderer', () => {
     const stringModel = new ConstrainedStringModel('test', undefined, 'String');
     const f64Model = new ConstrainedFloatModel('test', undefined, '');
     const f32Model = new ConstrainedFloatModel('test', { format: 'float32' }, '');
-    const dictModel = new ConstrainedDictionaryModel('test', undefined, '', f32Model, f64Model);
+    const dictModel = new ConstrainedDictionaryModel('test', undefined, '', i32Model, i64Model);
+    const floatDictModel = new ConstrainedDictionaryModel('test', undefined, '', f32Model, f64Model);
     const anyModel = new ConstrainedAnyModel('test', undefined, '');
 
     test('Should derive all traits', () => {
@@ -80,7 +81,8 @@ describe('RustRenderer', () => {
       expect(renderer.renderMacro(enumModel)).toEqual('#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]');
       expect(renderer.renderMacro(objectModel)).toEqual('#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]');
     });
-    test('Should not derive Hash, Eq, Ord, PartialEq traits', () => {
+    test('Should not derive Hash, Eq, Ord traits', () => {
+      // float does not implement Hash, Eq, Ord
       const tupleModel = new ConstrainedTupleModel('test', undefined, '', [new ConstrainedTupleValueModel(0, f32Model), new ConstrainedTupleValueModel(1, f64Model)]);
       const arrayModel = new ConstrainedArrayModel('test', undefined, '', f64Model);
       const enumModel = new ConstrainedEnumModel('test', undefined, '', [new ConstrainedEnumValueModel('one', f64Model,), new ConstrainedEnumValueModel('two', f32Model)]);
@@ -102,9 +104,90 @@ describe('RustRenderer', () => {
 
       });
 
-      expect(renderer.renderMacro(arrayModel)).toEqual('#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]');
-      expect(renderer.renderMacro(enumModel)).toEqual('#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]');
-      expect(renderer.renderMacro(objectModel)).toEqual('#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]');
+      expect(renderer.renderMacro(arrayModel)).toEqual('#[derive(Clone, Copy, Debug, Deserialize, PartialEq, PartialOrd, Serialize)]');
+      expect(renderer.renderMacro(enumModel)).toEqual('#[derive(Clone, Copy, Debug, Deserialize, PartialEq, PartialOrd, Serialize)]');
+      expect(renderer.renderMacro(objectModel)).toEqual('#[derive(Clone, Copy, Debug, Deserialize, PartialEq, PartialOrd, Serialize)]');
+    });
+    test('Should not derive Hash, Copy, PartialOrd, Ord traits', () => {
+      // dict (HashMap) does not implement Copy, PartialOrd, Ord
+      const tupleModel = new ConstrainedTupleModel('test', undefined, '', [new ConstrainedTupleValueModel(0, boolModel), new ConstrainedTupleValueModel(1, boolModel)]);
+      const arrayModel = new ConstrainedArrayModel('test', undefined, '', dictModel);
+      const enumModel = new ConstrainedEnumModel('test', undefined, '', [new ConstrainedEnumValueModel('one', i32Model,), new ConstrainedEnumValueModel('two', dictModel)]);
+      const unionModel = new ConstrainedUnionModel('test', undefined, '', [
+        i32Model,
+        i64Model,
+        boolModel,
+        tupleModel,
+        arrayModel,
+        enumModel
+      ]);
+      const objectModel = new ConstrainedObjectModel('test', undefined, '', {
+        i32Model: new ConstrainedObjectPropertyModel('test', 'test', true, i32Model),
+        i64Model: new ConstrainedObjectPropertyModel('test', 'test', true, i64Model),
+        boolProp: new ConstrainedObjectPropertyModel('test', 'test', true, boolModel),
+        tupleModel: new ConstrainedObjectPropertyModel('test', 'test', true, tupleModel),
+        unionModel: new ConstrainedObjectPropertyModel('test', 'test', true, unionModel),
+        enumModel: new ConstrainedObjectPropertyModel('test', 'test', true, enumModel),
+
+      });
+
+      expect(renderer.renderMacro(arrayModel)).toEqual('#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]');
+      expect(renderer.renderMacro(enumModel)).toEqual('#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]');
+      expect(renderer.renderMacro(objectModel)).toEqual('#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]');
+    });
+    test('Should not derive Hash, Copy, PartialOrd, Ord, PartialEq, traits', () => {
+      // dict (HashMap) + float does not implement Copy, PartialOrd, Ord, Eq
+      const tupleModel = new ConstrainedTupleModel('test', undefined, '', [new ConstrainedTupleValueModel(0, boolModel), new ConstrainedTupleValueModel(1, f32Model)]);
+      const arrayModel = new ConstrainedArrayModel('test', undefined, '', floatDictModel);
+      const enumModel = new ConstrainedEnumModel('test', undefined, '', [new ConstrainedEnumValueModel('one', f32Model,), new ConstrainedEnumValueModel('two', dictModel)]);
+      const unionModel = new ConstrainedUnionModel('test', undefined, '', [
+        i32Model,
+        i64Model,
+        boolModel,
+        tupleModel,
+        arrayModel,
+        enumModel
+      ]);
+      const objectModel = new ConstrainedObjectModel('test', undefined, '', {
+        i32Model: new ConstrainedObjectPropertyModel('test', 'test', true, i32Model),
+        i64Model: new ConstrainedObjectPropertyModel('test', 'test', true, i64Model),
+        boolProp: new ConstrainedObjectPropertyModel('test', 'test', true, boolModel),
+        tupleModel: new ConstrainedObjectPropertyModel('test', 'test', true, tupleModel),
+        unionModel: new ConstrainedObjectPropertyModel('test', 'test', true, unionModel),
+        enumModel: new ConstrainedObjectPropertyModel('test', 'test', true, enumModel),
+
+      });
+
+      expect(renderer.renderMacro(arrayModel)).toEqual('#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]');
+      expect(renderer.renderMacro(enumModel)).toEqual('#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]');
+      expect(renderer.renderMacro(objectModel)).toEqual('#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]');
+    });
+    test('Should not derive Hash, Copy, PartialOrd, Ord, PartialEq, Eq', () => {
+      // any prevents those traits
+      const tupleModel = new ConstrainedTupleModel('test', undefined, '', [new ConstrainedTupleValueModel(0, boolModel), new ConstrainedTupleValueModel(1, anyModel)]);
+      const arrayModel = new ConstrainedArrayModel('test', undefined, '', anyModel);
+      const enumModel = new ConstrainedEnumModel('test', undefined, '', [new ConstrainedEnumValueModel('one', i32Model,), new ConstrainedEnumValueModel('two', anyModel)]);
+      const unionModel = new ConstrainedUnionModel('test', undefined, '', [
+        i32Model,
+        i64Model,
+        boolModel,
+        tupleModel,
+        arrayModel,
+        enumModel
+      ]);
+      const objectModel = new ConstrainedObjectModel('test', undefined, '', {
+        i32Model: new ConstrainedObjectPropertyModel('test', 'test', true, i32Model),
+        i64Model: new ConstrainedObjectPropertyModel('test', 'test', true, i64Model),
+        boolProp: new ConstrainedObjectPropertyModel('test', 'test', true, boolModel),
+        tupleModel: new ConstrainedObjectPropertyModel('test', 'test', true, tupleModel),
+        unionModel: new ConstrainedObjectPropertyModel('test', 'test', true, unionModel),
+        enumModel: new ConstrainedObjectPropertyModel('test', 'test', true, enumModel),
+
+      });
+
+      expect(renderer.renderMacro(arrayModel)).toEqual('#[derive(Clone, Debug, Deserialize, Serialize)]');
+      expect(renderer.renderMacro(enumModel)).toEqual('#[derive(Clone, Debug, Deserialize, Serialize)]');
+      expect(renderer.renderMacro(objectModel)).toEqual('#[derive(Clone, Debug, Deserialize, Serialize)]');
     });
   });
 });

--- a/test/generators/rust/__snapshots__/RustGenerator.spec.ts.snap
+++ b/test/generators/rust/__snapshots__/RustGenerator.spec.ts.snap
@@ -27,9 +27,9 @@ pub enum Numbers {
 `;
 
 exports[`RustGenerator Enum should render \`enum\` with mixed types (union type) 1`] = `
-"// Things represents a Things model.
+"// Things123 represents a Things123 model.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum Things {
+pub enum Things123 {
     #[serde(rename=\\"Texas\\")]
     Texas,
     #[serde(rename=\\"1\\")]
@@ -149,7 +149,7 @@ pub struct Address {
 
 exports[`RustGenerator Struct & Complete Models Should render complete models 2`] = `
 "// Members represents a union of types: String, f64, bool
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, PartialOrd, Serialize)]
 pub enum Members {
     #[serde(rename=\\"MembersOneOf_00\\")]
     MembersOneOf_00(String),
@@ -164,7 +164,7 @@ pub enum Members {
 
 exports[`RustGenerator Struct & Complete Models Should render complete models 3`] = `
 "// TupleType represents a TupleType model.
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, PartialOrd, Serialize)]
 pub struct TupleType(String, f64);
 
 "
@@ -198,7 +198,7 @@ pub struct Address {
 
 exports[`RustGenerator Struct & Complete Models should render \`struct\` type  2`] = `
 "// Members represents a union of types: String, f64, bool
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, PartialOrd, Serialize)]
 pub enum Members {
     #[serde(rename=\\"MembersOneOf_00\\")]
     MembersOneOf_00(String),
@@ -213,7 +213,7 @@ pub enum Members {
 
 exports[`RustGenerator Struct & Complete Models should render \`struct\` type  3`] = `
 "// TupleType represents a TupleType model.
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, PartialOrd, Serialize)]
 pub struct TupleType(String, f64);
 
 "

--- a/test/generators/rust/__snapshots__/RustGenerator.spec.ts.snap
+++ b/test/generators/rust/__snapshots__/RustGenerator.spec.ts.snap
@@ -151,12 +151,12 @@ exports[`RustGenerator Struct & Complete Models Should render complete models 2`
 "// Members represents a union of types: String, f64, bool
 #[derive(Clone, Debug, Deserialize, PartialEq, PartialOrd, Serialize)]
 pub enum Members {
-    #[serde(rename=\\"MembersOneOf_00\\")]
-    MembersOneOf_00(String),
-    #[serde(rename=\\"MembersOneOf_11\\")]
-    MembersOneOf_11(f64),
-    #[serde(rename=\\"MembersOneOf_22\\")]
-    MembersOneOf_22(bool),
+    #[serde(rename=\\"MembersOneOf00\\")]
+    MembersOneOf00(String),
+    #[serde(rename=\\"MembersOneOf11\\")]
+    MembersOneOf11(f64),
+    #[serde(rename=\\"MembersOneOf22\\")]
+    MembersOneOf22(bool),
 }
 
 "
@@ -200,12 +200,12 @@ exports[`RustGenerator Struct & Complete Models should render \`struct\` type  2
 "// Members represents a union of types: String, f64, bool
 #[derive(Clone, Debug, Deserialize, PartialEq, PartialOrd, Serialize)]
 pub enum Members {
-    #[serde(rename=\\"MembersOneOf_00\\")]
-    MembersOneOf_00(String),
-    #[serde(rename=\\"MembersOneOf_11\\")]
-    MembersOneOf_11(f64),
-    #[serde(rename=\\"MembersOneOf_22\\")]
-    MembersOneOf_22(bool),
+    #[serde(rename=\\"MembersOneOf00\\")]
+    MembersOneOf00(String),
+    #[serde(rename=\\"MembersOneOf11\\")]
+    MembersOneOf11(f64),
+    #[serde(rename=\\"MembersOneOf22\\")]
+    MembersOneOf22(bool),
 }
 
 "

--- a/test/generators/rust/presets/CommonPreset.spec.ts
+++ b/test/generators/rust/presets/CommonPreset.spec.ts
@@ -103,7 +103,7 @@ describe('RUST_COMMON_PRESET', () => {
         $id: '_class',
         type: 'object',
         definitions: {
-          "student" : {
+          student: {
             $id: '_student',
             type: 'object',
             properties: {

--- a/test/generators/rust/presets/CommonPreset.spec.ts
+++ b/test/generators/rust/presets/CommonPreset.spec.ts
@@ -97,6 +97,37 @@ describe('RUST_COMMON_PRESET', () => {
       expect(models).toHaveLength(1);
       expect(models[0].result).toMatchSnapshot();
     });
+
+    test('should render reserved union for dict array', async () => {
+      const doc = {
+        $id: '_class',
+        type: 'object',
+        definitions: {
+          "student" : {
+            $id: '_student',
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+              birth: { type: 'number' }
+            },
+            required: ['name', 'birth'],
+          }
+        },
+        properties: {
+          students: {
+            type: 'array',
+            items: { $ref: '#/definitions/student' }
+          },
+        },
+        required: ['students'],
+      };
+
+      const models = await generator.generate(doc);
+      expect(models).toHaveLength(3);
+      expect(models[0].result).toMatchSnapshot();
+      expect(models[1].result).toMatchSnapshot();
+      expect(models[2].result).toMatchSnapshot();
+    });
   });
 
   describe('Struct & Complete Models', () => {

--- a/test/generators/rust/presets/__snapshots__/CommonPreset.spec.ts.snap
+++ b/test/generators/rust/presets/__snapshots__/CommonPreset.spec.ts.snap
@@ -340,5 +340,9 @@ pub struct Address {
     #[serde(rename=\\"additionalProperties\\", skip_serializing_if = \\"Option::is_none\\")]
     additional_properties: Option<std::collections::HashMap<String, String>>,
 }
+
+impl Address {
+    
+}
 "
 `;

--- a/test/generators/rust/presets/__snapshots__/CommonPreset.spec.ts.snap
+++ b/test/generators/rust/presets/__snapshots__/CommonPreset.spec.ts.snap
@@ -28,12 +28,12 @@ exports[`RUST_COMMON_PRESET Enum should render \`enum\` of union type with Defau
 "// Members represents a union of types: String, f64, bool
 #[derive(Clone, Debug, Deserialize, PartialEq, PartialOrd, Serialize)]
 pub enum Members {
-    #[serde(rename=\\"MembersOneOf_00\\")]
-    MembersOneOf_00(String),
-    #[serde(rename=\\"MembersOneOf_11\\")]
-    MembersOneOf_11(f64),
-    #[serde(rename=\\"MembersOneOf_22\\")]
-    MembersOneOf_22(bool),
+    #[serde(rename=\\"MembersOneOf00\\")]
+    MembersOneOf00(String),
+    #[serde(rename=\\"MembersOneOf11\\")]
+    MembersOneOf11(f64),
+    #[serde(rename=\\"MembersOneOf22\\")]
+    MembersOneOf22(bool),
 }
 
 "
@@ -43,12 +43,12 @@ exports[`RUST_COMMON_PRESET Enum should render \`enum\` of union type with Defau
 "// OptionalMembers represents a union of types: String, f64, bool
 #[derive(Clone, Debug, Deserialize, PartialEq, PartialOrd, Serialize)]
 pub enum OptionalMembers {
-    #[serde(rename=\\"OptionalMembersOneOf_00\\")]
-    OptionalMembersOneOf_00(String),
-    #[serde(rename=\\"OptionalMembersOneOf_11\\")]
-    OptionalMembersOneOf_11(f64),
-    #[serde(rename=\\"OptionalMembersOneOf_22\\")]
-    OptionalMembersOneOf_22(bool),
+    #[serde(rename=\\"OptionalMembersOneOf00\\")]
+    OptionalMembersOneOf00(String),
+    #[serde(rename=\\"OptionalMembersOneOf11\\")]
+    OptionalMembersOneOf11(f64),
+    #[serde(rename=\\"OptionalMembersOneOf22\\")]
+    OptionalMembersOneOf22(bool),
 }
 
 "
@@ -82,12 +82,12 @@ exports[`RUST_COMMON_PRESET Enum should render \`enum\` of union type with Defau
 "// Members represents a union of types: String, f64, bool
 #[derive(Clone, Debug, Deserialize, PartialEq, PartialOrd, Serialize)]
 pub enum Members {
-    #[serde(rename=\\"MembersOneOf_00\\")]
-    MembersOneOf_00(String),
-    #[serde(rename=\\"MembersOneOf_11\\")]
-    MembersOneOf_11(f64),
-    #[serde(rename=\\"MembersOneOf_22\\")]
-    MembersOneOf_22(bool),
+    #[serde(rename=\\"MembersOneOf00\\")]
+    MembersOneOf00(String),
+    #[serde(rename=\\"MembersOneOf11\\")]
+    MembersOneOf11(f64),
+    #[serde(rename=\\"MembersOneOf22\\")]
+    MembersOneOf22(bool),
 }
 
 "
@@ -97,12 +97,12 @@ exports[`RUST_COMMON_PRESET Enum should render \`enum\` of union type with Defau
 "// OptionalMembers represents a union of types: String, f64, bool
 #[derive(Clone, Debug, Deserialize, PartialEq, PartialOrd, Serialize)]
 pub enum OptionalMembers {
-    #[serde(rename=\\"OptionalMembersOneOf_00\\")]
-    OptionalMembersOneOf_00(String),
-    #[serde(rename=\\"OptionalMembersOneOf_11\\")]
-    OptionalMembersOneOf_11(f64),
-    #[serde(rename=\\"OptionalMembersOneOf_22\\")]
-    OptionalMembersOneOf_22(bool),
+    #[serde(rename=\\"OptionalMembersOneOf00\\")]
+    OptionalMembersOneOf00(String),
+    #[serde(rename=\\"OptionalMembersOneOf11\\")]
+    OptionalMembersOneOf11(f64),
+    #[serde(rename=\\"OptionalMembersOneOf22\\")]
+    OptionalMembersOneOf22(bool),
 }
 
 "
@@ -292,12 +292,12 @@ exports[`RUST_COMMON_PRESET Struct & Complete Models should render \`struct\` ty
 "// Members represents a union of types: String, f64, bool
 #[derive(Clone, Debug, Deserialize, PartialEq, PartialOrd, Serialize)]
 pub enum Members {
-    #[serde(rename=\\"MembersOneOf_00\\")]
-    MembersOneOf_00(String),
-    #[serde(rename=\\"MembersOneOf_11\\")]
-    MembersOneOf_11(f64),
-    #[serde(rename=\\"MembersOneOf_22\\")]
-    MembersOneOf_22(bool),
+    #[serde(rename=\\"MembersOneOf00\\")]
+    MembersOneOf00(String),
+    #[serde(rename=\\"MembersOneOf11\\")]
+    MembersOneOf11(f64),
+    #[serde(rename=\\"MembersOneOf22\\")]
+    MembersOneOf22(bool),
 }
 
 "

--- a/test/generators/rust/presets/__snapshots__/CommonPreset.spec.ts.snap
+++ b/test/generators/rust/presets/__snapshots__/CommonPreset.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`RUST_COMMON_PRESET Enum should render \`enum\` of union type with Default implementation of integer type 1`] = `
 "// Address represents a Address model.
-#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Address {
     #[serde(rename=\\"members\\")]
     members: Box<crate::Members>,
@@ -13,9 +13,9 @@ pub struct Address {
 }
 
 impl Address {
-    pub fn new(members: Members, optional_members: Option<crate::OptionalMembers>, additional_properties: Option<std::collections::HashMap<String, String>>) -> Address {
+    pub fn new(members: crate::Members, optional_members: Option<crate::OptionalMembers>, additional_properties: Option<std::collections::HashMap<String, String>>) -> Address {
         Address {
-        members,
+        Box::new(members),
         optional_members: optional_members.map(Box::new),
         additional_properties,
         }
@@ -26,7 +26,7 @@ impl Address {
 
 exports[`RUST_COMMON_PRESET Enum should render \`enum\` of union type with Default implementation of integer type 2`] = `
 "// Members represents a union of types: String, f64, bool
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, PartialOrd, Serialize)]
 pub enum Members {
     #[serde(rename=\\"MembersOneOf_00\\")]
     MembersOneOf_00(String),
@@ -41,7 +41,7 @@ pub enum Members {
 
 exports[`RUST_COMMON_PRESET Enum should render \`enum\` of union type with Default implementation of integer type 3`] = `
 "// OptionalMembers represents a union of types: String, f64, bool
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, PartialOrd, Serialize)]
 pub enum OptionalMembers {
     #[serde(rename=\\"OptionalMembersOneOf_00\\")]
     OptionalMembersOneOf_00(String),
@@ -56,7 +56,7 @@ pub enum OptionalMembers {
 
 exports[`RUST_COMMON_PRESET Enum should render \`enum\` of union type with Default implementation of string type 1`] = `
 "// Address represents a Address model.
-#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Address {
     #[serde(rename=\\"members\\")]
     members: Box<crate::Members>,
@@ -67,9 +67,9 @@ pub struct Address {
 }
 
 impl Address {
-    pub fn new(members: Members, optional_members: Option<crate::OptionalMembers>, additional_properties: Option<std::collections::HashMap<String, String>>) -> Address {
+    pub fn new(members: crate::Members, optional_members: Option<crate::OptionalMembers>, additional_properties: Option<std::collections::HashMap<String, String>>) -> Address {
         Address {
-        members,
+        Box::new(members),
         optional_members: optional_members.map(Box::new),
         additional_properties,
         }
@@ -80,7 +80,7 @@ impl Address {
 
 exports[`RUST_COMMON_PRESET Enum should render \`enum\` of union type with Default implementation of string type 2`] = `
 "// Members represents a union of types: String, f64, bool
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, PartialOrd, Serialize)]
 pub enum Members {
     #[serde(rename=\\"MembersOneOf_00\\")]
     MembersOneOf_00(String),
@@ -95,7 +95,7 @@ pub enum Members {
 
 exports[`RUST_COMMON_PRESET Enum should render \`enum\` of union type with Default implementation of string type 3`] = `
 "// OptionalMembers represents a union of types: String, f64, bool
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, PartialOrd, Serialize)]
 pub enum OptionalMembers {
     #[serde(rename=\\"OptionalMembersOneOf_00\\")]
     OptionalMembersOneOf_00(String),
@@ -188,6 +188,64 @@ impl Default for CustomEnum {
 }"
 `;
 
+exports[`RUST_COMMON_PRESET Enum should render reserved union for dict array 1`] = `
+"// Class represents a Class model.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Class {
+    #[serde(rename=\\"students\\")]
+    students: Vec<crate::ReservedUnion>,
+    #[serde(rename=\\"additionalProperties\\", skip_serializing_if = \\"Option::is_none\\")]
+    additional_properties: Option<std::collections::HashMap<String, serde_json::Value>>,
+}
+
+impl Class {
+    pub fn new(students: Vec<crate::ReservedUnion>, additional_properties: Option<std::collections::HashMap<String, serde_json::Value>>) -> Class {
+        Class {
+        students,
+        additional_properties,
+        }
+    }
+}
+"
+`;
+
+exports[`RUST_COMMON_PRESET Enum should render reserved union for dict array 2`] = `
+"// ReservedUnion represents a union of types: Student0, serde_json::Value
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum ReservedUnion {
+    #[serde(rename=\\"Student0\\")]
+    Student0(crate::Student),
+    #[serde(rename=\\"Undefined1\\")]
+    Undefined1(serde_json::Value),
+}
+
+"
+`;
+
+exports[`RUST_COMMON_PRESET Enum should render reserved union for dict array 3`] = `
+"// Student represents a Student model.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Student {
+    #[serde(rename=\\"name\\")]
+    name: String,
+    #[serde(rename=\\"birth\\")]
+    birth: f64,
+    #[serde(rename=\\"additionalProperties\\", skip_serializing_if = \\"Option::is_none\\")]
+    additional_properties: Option<std::collections::HashMap<String, serde_json::Value>>,
+}
+
+impl Student {
+    pub fn new(name: String, birth: f64, additional_properties: Option<std::collections::HashMap<String, serde_json::Value>>) -> Student {
+        Student {
+        name,
+        birth,
+        additional_properties,
+        }
+    }
+}
+"
+`;
+
 exports[`RUST_COMMON_PRESET Struct & Complete Models should render \`struct\` type with all implementations 1`] = `
 "// Address represents a Address model.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
@@ -232,7 +290,7 @@ impl Address {
 
 exports[`RUST_COMMON_PRESET Struct & Complete Models should render \`struct\` type with all implementations 2`] = `
 "// Members represents a union of types: String, f64, bool
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, PartialOrd, Serialize)]
 pub enum Members {
     #[serde(rename=\\"MembersOneOf_00\\")]
     MembersOneOf_00(String),
@@ -247,7 +305,7 @@ pub enum Members {
 
 exports[`RUST_COMMON_PRESET Struct & Complete Models should render \`struct\` type with all implementations 3`] = `
 "// TupleType represents a TupleType model.
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, PartialOrd, Serialize)]
 pub struct TupleType(String, f64);
 
 impl TupleType {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
Continuation of: https://github.com/asyncapi/modelina/pull/869

Figured I should get this PR cleaned up and merged before rolling up my sleeves to fix Rust black-box tests.

**Original PR Description**

Locally tried Rust generator with more complicated private examples and got some compile errors in the generate Rust crate.
The PR makes compile pass fixing the following issues:

* Remove warnings in case the model name contains the dash + number (e.g. `Abc_123`)
* Compile errors due to mismatch of some Option field definitions and constructors in struct 
* Fix broken generated file names
* Fix invalid type name included in generated Union types
* Fix the missing qualifer `crate::` in some cases
* Fix undefined error when schemaUid doesn't exist
