### PR TITLE
fix: add `exec` as reserved keyword for Python

### DIFF
--- a/src/generators/python/Constants.ts
+++ b/src/generators/python/Constants.ts
@@ -33,7 +33,8 @@ export const RESERVED_PYTHON_KEYWORDS = [
   'or',
   'continue',
   'global',
-  'pass'
+  'pass',
+  'exec'
 ];
 
 export function isReservedPythonKeyword(word: string, forceLowerCase = true): boolean {

--- a/test/generators/python/Constants.spec.ts
+++ b/test/generators/python/Constants.spec.ts
@@ -35,6 +35,7 @@ describe('Reserved keywords', () => {
     expect(isReservedPythonKeyword('continue')).toBe(true);
     expect(isReservedPythonKeyword('global')).toBe(true);
     expect(isReservedPythonKeyword('pass')).toBe(true);
+    expect(isReservedPythonKeyword('exec')).toBe(true);
   });
 
   it('should return false if the word is not a reserved keyword', () => {


### PR DESCRIPTION
**Description**
This PR adds the missing reserved keyword `exec` for python that failed black-box tests.
