### PR TITLE
fix: rust enum renderer only working for JSON Schema inputs

### DIFF
--- a/src/generators/rust/constrainer/EnumConstrainer.ts
+++ b/src/generators/rust/constrainer/EnumConstrainer.ts
@@ -46,22 +46,7 @@ export function defaultEnumKeyConstraints(customConstraints?: Partial<ModelEnumK
 }
 
 export function defaultEnumValueConstraints(): EnumValueConstraint {
-  return ({ enumValue }) => {
-    switch (typeof enumValue) {
-    case 'boolean':
-      return 'bool';
-    case 'bigint':
-      return 'i64';
-    case 'number': {
-      return 'f64';
-    }
-    case 'object': {
-      return 'HashMap<String, serde_json::Value>';
-    }
-    case 'string':
-    default: {
-      return 'String';
-    }
-    }
+  return ({enumValue}) => {
+    return enumValue;
   };
 }

--- a/src/generators/rust/renderers/EnumRenderer.ts
+++ b/src/generators/rust/renderers/EnumRenderer.ts
@@ -43,26 +43,48 @@ ${additionalContent}`;
   runStructMacroPreset(): Promise<string> {
     return this.runPreset('structMacro');
   }
+
+
+  /**
+   * Returns the type for the JSON value
+   */
+  renderEnumValueType(value: any): string {
+    switch (typeof value) {
+      case 'boolean':
+        return 'bool';
+      case 'bigint':
+        return 'i64';
+      case 'number': {
+        return 'f64';
+      }
+      case 'object': {
+        return 'HashMap<String, serde_json::Value>';
+      }
+      case 'string':
+      default: {
+        return 'String';
+      }
+    }
+  }
 }
 
 export const RUST_DEFAULT_ENUM_PRESET: EnumPresetType<RustOptions> = {
   self({ renderer }) {
     return renderer.defaultSelf();
   },
-  item({ item }) {
-    if (item.value === 'HashMap<String, serde_json::Value>') {
-      return `${item.key}(${item.value})`;
+  item({ item, renderer }) {
+    const typeOfEnumValue = renderer.renderEnumValueType(item.value);
+    if (typeOfEnumValue === 'HashMap<String, serde_json::Value>') {
+      return `${item.key}(${typeOfEnumValue})`;
     }
     return `${item.key}`;
   },
-  itemMacro({ itemIndex, model }) {
-    const originalInput = model.originalInput.enum[Number(itemIndex)];
+  itemMacro({ item }) {
     const serdeArgs = [];
-    if (typeof originalInput === 'object') {
+    if (typeof item.value === 'object') {
       serdeArgs.push('flatten');
     } else {
-      const rename = model.originalInput.enum[Number(itemIndex)].toString();
-      serdeArgs.push(`rename="${rename}"`);
+      serdeArgs.push(`rename="${item.value}"`);
     }
     return `#[serde(${serdeArgs.join(', ')})]`;
   },

--- a/src/generators/rust/renderers/EnumRenderer.ts
+++ b/src/generators/rust/renderers/EnumRenderer.ts
@@ -44,26 +44,25 @@ ${additionalContent}`;
     return this.runPreset('structMacro');
   }
 
-
   /**
    * Returns the type for the JSON value
    */
   renderEnumValueType(value: any): string {
     switch (typeof value) {
-      case 'boolean':
-        return 'bool';
-      case 'bigint':
-        return 'i64';
-      case 'number': {
-        return 'f64';
-      }
-      case 'object': {
-        return 'HashMap<String, serde_json::Value>';
-      }
-      case 'string':
-      default: {
-        return 'String';
-      }
+    case 'boolean':
+      return 'bool';
+    case 'bigint':
+      return 'i64';
+    case 'number': {
+      return 'f64';
+    }
+    case 'object': {
+      return 'HashMap<String, serde_json::Value>';
+    }
+    case 'string':
+    default: {
+      return 'String';
+    }
     }
   }
 }

--- a/test/generators/rust/constrainer/EnumConstrainer.spec.ts
+++ b/test/generators/rust/constrainer/EnumConstrainer.spec.ts
@@ -1,0 +1,58 @@
+import { RustDefaultConstraints } from '../../../../src/generators/rust/RustConstrainer';
+import { EnumModel } from '../../../../src/models/MetaModel';
+import { ConstrainedEnumModel, ConstrainedEnumValueModel } from '../../../../src';
+describe('EnumConstrainer', () => {
+  const enumModel = new EnumModel('test', undefined, []);
+  const constrainedEnumModel = new ConstrainedEnumModel('test', undefined, '', []);
+
+  describe('enum keys', () => {
+    test('should never render special chars', () => {
+      const constrainedKey = RustDefaultConstraints.enumKey({enumModel, constrainedEnumModel, enumKey: '%'});
+      expect(constrainedKey).toEqual('Percent');
+    });
+    test('should not render number as start char', () => {
+      const constrainedKey = RustDefaultConstraints.enumKey({enumModel, constrainedEnumModel, enumKey: '1'});
+      expect(constrainedKey).toEqual('Number_1');
+    });
+    test('should not contain duplicate keys', () => {
+      const existingConstrainedEnumValueModel = new ConstrainedEnumValueModel('EMPTY', 'return');
+      const constrainedEnumModel = new ConstrainedEnumModel('test', undefined, '', [existingConstrainedEnumValueModel]);
+      const constrainedKey = RustDefaultConstraints.enumKey({enumModel, constrainedEnumModel, enumKey: ''});
+      expect(constrainedKey).toEqual('Empty');
+    });
+    test('should never contain empty keys', () => {
+      const constrainedKey = RustDefaultConstraints.enumKey({enumModel, constrainedEnumModel, enumKey: ''});
+      expect(constrainedKey).toEqual('Empty');
+    });
+    test('should use constant naming format', () => {
+      const constrainedKey = RustDefaultConstraints.enumKey({enumModel, constrainedEnumModel, enumKey: 'some weird_value!"#2'});
+      expect(constrainedKey).toEqual('SomeWeirdValueExclamationQuotationHash_2');
+    });
+    test('should never render reserved keywords', () => {
+      const constrainedKey = RustDefaultConstraints.enumKey({enumModel, constrainedEnumModel, enumKey: 'return'});
+      expect(constrainedKey).toEqual('ReservedReturn');
+    });
+  });
+  describe('enum values', () => {
+    test('should render value as is', () => {
+      const constrainedValue = RustDefaultConstraints.enumValue({enumModel, constrainedEnumModel, enumValue: 'string value'});
+      expect(constrainedValue).toEqual('string value');
+    });
+    test('should render boolean values', () => {
+      const constrainedValue = RustDefaultConstraints.enumValue({enumModel, constrainedEnumModel, enumValue: true});
+      expect(constrainedValue).toEqual(true);
+    });
+    test('should render numbers', () => {
+      const constrainedValue = RustDefaultConstraints.enumValue({enumModel, constrainedEnumModel, enumValue: 123});
+      expect(constrainedValue).toEqual(123);
+    });
+    test('should render object', () => {
+      const constrainedValue = RustDefaultConstraints.enumValue({enumModel, constrainedEnumModel, enumValue: {test: 'test'}});
+      expect(constrainedValue).toEqual({test: 'test'});
+    });
+    test('should render unknown value', () => {
+      const constrainedValue = RustDefaultConstraints.enumValue({enumModel, constrainedEnumModel, enumValue: undefined});
+      expect(constrainedValue).toEqual(undefined);
+    });
+  });
+});


### PR DESCRIPTION
**Description**
This PR fixes a problem with the Rust enum renderer that assumes JSON Schema inputs. I also converted the enum value constrainer not to constrain the JSON value and then added a support function in the enum renderer to render the enum value type. To align with the other generators.

We might need to add something along the lines of `valueType` to the `ConstrainedEnumValueModel` 🤔 