### PR TITLE
fix: rust impl new fn for Boxed values

### DIFF
--- a/examples/rust-generate-crate/__snapshots__/index.spec.ts.snap
+++ b/examples/rust-generate-crate/__snapshots__/index.spec.ts.snap
@@ -30,16 +30,16 @@ pub struct Address {
 impl Address {
     pub fn new(street_name: String, city: String, state: String, house_number: f64, marriage: Option<bool>, members: Option<crate::Members>, tuple_type: Option<crate::TupleType>, array_type: Vec<String>, enum_type: Option<crate::EnumType>, additional_properties: Option<std::collections::HashMap<String, String>>) -> Address {
         Address {
-        street_name,
-        city,
-        state,
-        house_number,
-        marriage,
-        members: members.map(Box::new),
-        tuple_type: tuple_type.map(Box::new),
-        array_type,
-        enum_type: enum_type.map(Box::new),
-        additional_properties,
+            street_name,
+            city,
+            state,
+            house_number,
+            marriage,
+            members: members.map(Box::new),
+            tuple_type: tuple_type.map(Box::new),
+            array_type,
+            enum_type: enum_type.map(Box::new),
+            additional_properties,
         }
     }
 }

--- a/src/generators/rust/presets/CommonPreset.ts
+++ b/src/generators/rust/presets/CommonPreset.ts
@@ -67,7 +67,7 @@ function renderImplementNew({ model, renderer }: {
     if (v.required) {
       args.push(`${v.propertyName}: ${fieldType}`);
       if (v.property instanceof ConstrainedReferenceModel) {
-        fields.push(`Box::new(${v.propertyName}),`);
+        fields.push(`${v.propertyName}: Box::new(${v.propertyName}),`);
       } else {
         fields.push(`${v.propertyName},`);
       }

--- a/src/generators/rust/presets/CommonPreset.ts
+++ b/src/generators/rust/presets/CommonPreset.ts
@@ -83,7 +83,7 @@ function renderImplementNew({ model, renderer }: {
   const fieldsBlock = renderer.renderBlock(fields);
   return `pub fn new(${args.join(', ')}) -> ${model.name} {
     ${model.name} {
-${renderer.indent(fieldsBlock, 4)}
+${renderer.indent(fieldsBlock, 8)}
     }
 }`;
 }

--- a/test/generators/rust/presets/__snapshots__/CommonPreset.spec.ts.snap
+++ b/test/generators/rust/presets/__snapshots__/CommonPreset.spec.ts.snap
@@ -15,7 +15,7 @@ pub struct Address {
 impl Address {
     pub fn new(members: crate::Members, optional_members: Option<crate::OptionalMembers>, additional_properties: Option<std::collections::HashMap<String, String>>) -> Address {
         Address {
-        members: Box::new(members),
+            members: Box::new(members),
             optional_members: optional_members.map(Box::new),
             additional_properties,
         }
@@ -69,7 +69,7 @@ pub struct Address {
 impl Address {
     pub fn new(members: crate::Members, optional_members: Option<crate::OptionalMembers>, additional_properties: Option<std::collections::HashMap<String, String>>) -> Address {
         Address {
-        members: Box::new(members),
+            members: Box::new(members),
             optional_members: optional_members.map(Box::new),
             additional_properties,
         }
@@ -201,8 +201,8 @@ pub struct Class {
 impl Class {
     pub fn new(students: Vec<crate::ReservedUnion>, additional_properties: Option<std::collections::HashMap<String, serde_json::Value>>) -> Class {
         Class {
-        students,
-        additional_properties,
+            students,
+            additional_properties,
         }
     }
 }
@@ -273,15 +273,15 @@ pub struct Address {
 impl Address {
     pub fn new(street_name: String, city: String, state: String, house_number: f64, marriage: Option<bool>, members: Option<crate::Members>, tuple_type: Option<crate::TupleType>, array_type: Vec<String>, additional_properties: Option<std::collections::HashMap<String, String>>) -> Address {
         Address {
-        street_name,
-        city,
-        state,
-        house_number,
-        marriage,
-        members: members.map(Box::new),
-        tuple_type: tuple_type.map(Box::new),
-        array_type,
-        additional_properties,
+            street_name,
+            city,
+            state,
+            house_number,
+            marriage,
+            members: members.map(Box::new),
+            tuple_type: tuple_type.map(Box::new),
+            array_type,
+            additional_properties,
         }
     }
 }

--- a/test/generators/rust/presets/__snapshots__/CommonPreset.spec.ts.snap
+++ b/test/generators/rust/presets/__snapshots__/CommonPreset.spec.ts.snap
@@ -15,7 +15,7 @@ pub struct Address {
 impl Address {
     pub fn new(members: crate::Members, optional_members: Option<crate::OptionalMembers>, additional_properties: Option<std::collections::HashMap<String, String>>) -> Address {
         Address {
-        Box::new(members),
+        members: Box::new(members),
         optional_members: optional_members.map(Box::new),
         additional_properties,
         }
@@ -69,7 +69,7 @@ pub struct Address {
 impl Address {
     pub fn new(members: crate::Members, optional_members: Option<crate::OptionalMembers>, additional_properties: Option<std::collections::HashMap<String, String>>) -> Address {
         Address {
-        Box::new(members),
+        members: Box::new(members),
         optional_members: optional_members.map(Box::new),
         additional_properties,
         }

--- a/test/generators/rust/presets/__snapshots__/CommonPreset.spec.ts.snap
+++ b/test/generators/rust/presets/__snapshots__/CommonPreset.spec.ts.snap
@@ -16,8 +16,8 @@ impl Address {
     pub fn new(members: crate::Members, optional_members: Option<crate::OptionalMembers>, additional_properties: Option<std::collections::HashMap<String, String>>) -> Address {
         Address {
         members: Box::new(members),
-        optional_members: optional_members.map(Box::new),
-        additional_properties,
+            optional_members: optional_members.map(Box::new),
+            additional_properties,
         }
     }
 }
@@ -70,8 +70,8 @@ impl Address {
     pub fn new(members: crate::Members, optional_members: Option<crate::OptionalMembers>, additional_properties: Option<std::collections::HashMap<String, String>>) -> Address {
         Address {
         members: Box::new(members),
-        optional_members: optional_members.map(Box::new),
-        additional_properties,
+            optional_members: optional_members.map(Box::new),
+            additional_properties,
         }
     }
 }
@@ -237,9 +237,9 @@ pub struct Student {
 impl Student {
     pub fn new(name: String, birth: f64, additional_properties: Option<std::collections::HashMap<String, serde_json::Value>>) -> Student {
         Student {
-        name,
-        birth,
-        additional_properties,
+            name,
+            birth,
+            additional_properties,
         }
     }
 }


### PR DESCRIPTION
**Description**

I upgraded to `1.0.0-next.30` and noticed Rust's `new()` function implementation is broken for any schema with a `$ref` to another schema.

Schema where I first noticed this issue: https://github.com/bitsy-ai/printnanny-asyncapi-schema/blob/main/2.4.0/printnanny-os.yml

Edit: I also noticed indentation is off by 4 spaces in struct implementation fns. I fixed that as well: https://github.com/asyncapi/modelina/pull/1013/commits/0db9d9f09f90c5d2ad2fec1a4360571a186f929d

**Related issue(s)**
closes issue #1012