### PR TITLE
fix: generated TS interfaces extend type defined by additional properties

### DIFF
--- a/examples/typescript-generate-comments/__snapshots__/index.spec.ts.snap
+++ b/examples/typescript-generate-comments/__snapshots__/index.spec.ts.snap
@@ -6,7 +6,7 @@ Array [
     "/**
  * Main Description
  */
-interface Test {
+interface Test extends Map<string, any> {
   stringProp: string;
   /**
    * Description
@@ -17,7 +17,6 @@ interface Test {
    * @example Example 1, Example 2
    */
   objectProp?: NestedTest;
-  additionalProperties?: Map<string, any>;
 }",
   ],
   Array [
@@ -26,7 +25,6 @@ interface Test {
  */
 interface NestedTest {
   stringProp?: string;
-  additionalProperties?: Map<string, any>;
 }",
   ],
 ]

--- a/examples/typescript-generate-comments/index.ts
+++ b/examples/typescript-generate-comments/index.ts
@@ -25,6 +25,7 @@ const jsonSchemaDraft7 = {
       $id: 'NestedTest',
       properties: { stringProp: { type: 'string' } },
       examples: ['Example 1', 'Example 2'],
+      additionalProperties: false,
     },
   },
 };

--- a/src/generators/typescript/TypeScriptGenerator.ts
+++ b/src/generators/typescript/TypeScriptGenerator.ts
@@ -22,6 +22,7 @@ export interface TypeScriptOptions extends CommonGeneratorOptions<TypeScriptPres
   typeMapping: TypeMapping<TypeScriptOptions>;
   constraints: Constraints;
   moduleSystem: 'ESM' | 'CJS';
+  extendInterfaceWithAdditionalProperties: boolean;
 }
 
 export interface TypeScriptRenderCompleteModelOptions {
@@ -41,7 +42,8 @@ export class TypeScriptGenerator extends AbstractGenerator<TypeScriptOptions, Ty
     defaultPreset: TS_DEFAULT_PRESET,
     typeMapping: TypeScriptDefaultTypeMapping,
     constraints: TypeScriptDefaultConstraints,
-    moduleSystem: 'ESM'
+    moduleSystem: 'ESM',
+    extendInterfaceWithAdditionalProperties: true
   };
 
   constructor(

--- a/src/generators/typescript/renderers/InterfaceRenderer.ts
+++ b/src/generators/typescript/renderers/InterfaceRenderer.ts
@@ -1,6 +1,8 @@
 import { TypeScriptOptions } from '../TypeScriptGenerator';
 import { TypeScriptObjectRenderer } from '../TypeScriptObjectRenderer';
 import { InterfacePresetType } from '../TypeScriptPreset';
+import { ConstrainedObjectPropertyModel } from '../../../models';
+import { Logger } from '../../../utils';
 
 /**
  * Renderer for TypeScript's `interface` type
@@ -14,9 +16,37 @@ export class InterfaceRenderer extends TypeScriptObjectRenderer {
       await this.runAdditionalContentPreset()
     ];
 
-    return `interface ${this.model.name} {
+    const extendsType = this.getExtendsWithAdditionalProperties();
+
+    return `interface ${this.model.name}${extendsType} {
 ${this.indent(this.renderBlock(content, 2))}
 }`;
+  }
+
+  renderProperty(property: ConstrainedObjectPropertyModel): string {
+    if (property.propertyName === 'additionalProperties') {
+      return '';
+    }
+
+    return `${property.propertyName}${property.required === false ? '?' : ''}: ${property.property.type};`;
+  }
+
+  getExtendsWithAdditionalProperties(): string {
+    if (!this.options.extendInterfaceWithAdditionalProperties) {
+      return '';
+    }
+
+    if (this.options.mapType === 'indexedObject') {
+      Logger.error('Extending indexedObject as interface is not supported.');
+      return '';
+    }
+
+    if (this.model.properties.additionalProperties === undefined) {
+      return '';
+    }
+
+    const extendsType = this.model.properties.additionalProperties.property.type;
+    return ` extends ${extendsType}`;
   }
 }
 

--- a/test/generators/typescript/TypeScriptGenerator.spec.ts
+++ b/test/generators/typescript/TypeScriptGenerator.spec.ts
@@ -108,6 +108,24 @@ ${content}`;
     expect(models[0].dependencies).toEqual([]);
   });
 
+  test('should render `interface` type not extended with additionalProperties definition', async () => {
+    const doc = {
+      $id: 'Address',
+      type: 'object',
+      properties: {
+        street_name: { type: 'string' },
+      },
+      required: ['street_name'],
+      additionalProperties: false,
+    };
+
+    generator = new TypeScriptGenerator({ modelType: 'interface' });
+    const models = await generator.generate(doc);
+    expect(models).toHaveLength(1);
+    expect(models[0].result).toMatchSnapshot();
+    expect(models[0].dependencies).toEqual([]);
+  });
+
   test('should work custom preset for `interface` type', async () => {
     const doc = {
       $id: 'CustomInterface',

--- a/test/generators/typescript/__snapshots__/TypeScriptGenerator.spec.ts.snap
+++ b/test/generators/typescript/__snapshots__/TypeScriptGenerator.spec.ts.snap
@@ -330,7 +330,7 @@ exports[`TypeScriptGenerator should render \`enum\` type 1`] = `
 exports[`TypeScriptGenerator should render \`enum\` type as \`union\` if option enumType = \`union\` 1`] = `"type States = \\"Texas\\" | \\"Alabama\\" | \\"California\\";"`;
 
 exports[`TypeScriptGenerator should render \`interface\` type 1`] = `
-"interface Address {
+"interface Address extends Map<string, any> {
   streetName: string;
   city: string;
   state: string;
@@ -340,7 +340,12 @@ exports[`TypeScriptGenerator should render \`interface\` type 1`] = `
   tupleType?: [string, number];
   tupleTypeWithAdditionalItems?: (string | number | any)[];
   arrayType: (string | any)[];
-  additionalProperties?: Map<string, any>;
+}"
+`;
+
+exports[`TypeScriptGenerator should render \`interface\` type not extended with additionalProperties definition 1`] = `
+"interface Address {
+  streetName: string;
 }"
 `;
 


### PR DESCRIPTION

**Description**

When generating TS interfaces right now, additionalPropertes are added as actual property to the intrerface, eg:
```ts
interface Foo {
  additionalProperties?: Map<string, any>
}
```

this is wrong, instead interface should extend such type:
```ts
interface Foo extends Map<string, any> {

}
```

This PR fixes that:
- interfaces do not contain `additionalProperties` property
- interfaces extend type defined by additional properties when using `record` and `map` mapType
- extending can be turned off using `extendInterfaceWithAdditionalProperties` config

**Related issue(s)**
Resolves #959