### PR TITLE
fix: reserved keywords in Rust should be case-sensitive

### DIFF
--- a/src/generators/rust/Constants.ts
+++ b/src/generators/rust/Constants.ts
@@ -1,3 +1,5 @@
+import { checkForReservedKeyword } from '../../helpers';
+
 export const RESERVED_RUST_KEYWORDS = [
   // strict keywords can only be used in correct context, and are therefore invalid as:
   // Items, variables and function parameters, fields and vairants, type parameters, lifetime parameters, loop labels, macros or attributes, macro placeholders
@@ -62,5 +64,5 @@ export const RESERVED_RUST_KEYWORDS = [
 ];
 
 export function isReservedRustKeyword(word: string): boolean {
-  return RESERVED_RUST_KEYWORDS.includes(word);
+  return checkForReservedKeyword(word, RESERVED_RUST_KEYWORDS, false);
 }

--- a/src/generators/rust/constrainer/EnumConstrainer.ts
+++ b/src/generators/rust/constrainer/EnumConstrainer.ts
@@ -35,12 +35,12 @@ export function defaultEnumKeyConstraints(customConstraints?: Partial<ModelEnumK
     constrainedEnumKey = constraints.NO_SPECIAL_CHAR(constrainedEnumKey);
     constrainedEnumKey = constraints.NO_NUMBER_START_CHAR(constrainedEnumKey);
     constrainedEnumKey = constraints.NO_EMPTY_VALUE(constrainedEnumKey);
-    constrainedEnumKey = constraints.NO_RESERVED_KEYWORDS(constrainedEnumKey);
     //If the enum key has been manipulated, lets make sure it don't clash with existing keys
     if (constrainedEnumKey !== enumKey) {
       constrainedEnumKey = constraints.NO_DUPLICATE_KEYS(constrainedEnumModel, enumModel, constrainedEnumKey, constraints.NAMING_FORMATTER);
     }
     constrainedEnumKey = constraints.NAMING_FORMATTER(constrainedEnumKey);
+    constrainedEnumKey = constraints.NO_RESERVED_KEYWORDS(constrainedEnumKey);
     return constrainedEnumKey;
   };
 }

--- a/src/generators/rust/constrainer/EnumConstrainer.ts
+++ b/src/generators/rust/constrainer/EnumConstrainer.ts
@@ -40,7 +40,10 @@ export function defaultEnumKeyConstraints(customConstraints?: Partial<ModelEnumK
       constrainedEnumKey = constraints.NO_DUPLICATE_KEYS(constrainedEnumModel, enumModel, constrainedEnumKey, constraints.NAMING_FORMATTER);
     }
     constrainedEnumKey = constraints.NAMING_FORMATTER(constrainedEnumKey);
+
     constrainedEnumKey = constraints.NO_RESERVED_KEYWORDS(constrainedEnumKey);
+    // If the name is a reserved keyword, make sure to format it afterwards
+    constrainedEnumKey = constraints.NAMING_FORMATTER(constrainedEnumKey);
     return constrainedEnumKey;
   };
 }

--- a/src/generators/rust/constrainer/ModelNameConstrainer.ts
+++ b/src/generators/rust/constrainer/ModelNameConstrainer.ts
@@ -33,8 +33,8 @@ export function defaultModelNameConstraints(customConstraints?: Partial<ModelNam
     constrainedValue = constraints.NO_SPECIAL_CHAR(constrainedValue);
     constrainedValue = constraints.NO_NUMBER_START_CHAR(constrainedValue);
     constrainedValue = constraints.NO_EMPTY_VALUE(constrainedValue);
-    constrainedValue = constraints.NO_RESERVED_KEYWORDS(constrainedValue);
     constrainedValue = constraints.NAMING_FORMATTER(constrainedValue);
+    constrainedValue = constraints.NO_RESERVED_KEYWORDS(constrainedValue);
     return constrainedValue;
   };
 }

--- a/src/generators/rust/constrainer/ModelNameConstrainer.ts
+++ b/src/generators/rust/constrainer/ModelNameConstrainer.ts
@@ -34,7 +34,11 @@ export function defaultModelNameConstraints(customConstraints?: Partial<ModelNam
     constrainedValue = constraints.NO_NUMBER_START_CHAR(constrainedValue);
     constrainedValue = constraints.NO_EMPTY_VALUE(constrainedValue);
     constrainedValue = constraints.NAMING_FORMATTER(constrainedValue);
+
     constrainedValue = constraints.NO_RESERVED_KEYWORDS(constrainedValue);
+    // If the name is a reserved keyword, make sure to format it afterwards
+    constrainedValue = constraints.NAMING_FORMATTER(constrainedValue);
+
     return constrainedValue;
   };
 }

--- a/src/generators/rust/constrainer/PropertyKeyConstrainer.ts
+++ b/src/generators/rust/constrainer/PropertyKeyConstrainer.ts
@@ -32,7 +32,6 @@ export function defaultPropertyKeyConstraints(customConstraints?: Partial<Proper
 
   return ({ objectPropertyModel, constrainedObjectModel, objectModel }) => {
     let constrainedPropertyKey = objectPropertyModel.propertyName;
-
     
     constrainedPropertyKey = constraints.NO_SPECIAL_CHAR(constrainedPropertyKey);
     constrainedPropertyKey = constraints.NO_NUMBER_START_CHAR(constrainedPropertyKey);
@@ -47,7 +46,6 @@ export function defaultPropertyKeyConstraints(customConstraints?: Partial<Proper
     if (constrainedPropertyKey !== objectPropertyModel.propertyName) {
       constrainedPropertyKey = constraints.NO_DUPLICATE_PROPERTIES(constrainedObjectModel, objectModel, constrainedPropertyKey, constraints.NAMING_FORMATTER);
     }
-
     
     return constrainedPropertyKey;
   };

--- a/src/generators/rust/constrainer/PropertyKeyConstrainer.ts
+++ b/src/generators/rust/constrainer/PropertyKeyConstrainer.ts
@@ -33,15 +33,22 @@ export function defaultPropertyKeyConstraints(customConstraints?: Partial<Proper
   return ({ objectPropertyModel, constrainedObjectModel, objectModel }) => {
     let constrainedPropertyKey = objectPropertyModel.propertyName;
 
+    
     constrainedPropertyKey = constraints.NO_SPECIAL_CHAR(constrainedPropertyKey);
     constrainedPropertyKey = constraints.NO_NUMBER_START_CHAR(constrainedPropertyKey);
     constrainedPropertyKey = constraints.NO_EMPTY_VALUE(constrainedPropertyKey);
+    constrainedPropertyKey = constraints.NAMING_FORMATTER(constrainedPropertyKey);
+
     constrainedPropertyKey = constraints.NO_RESERVED_KEYWORDS(constrainedPropertyKey);
+    // If the property key is a reserved keyword, make sure to format it afterwards
+    constrainedPropertyKey = constraints.NAMING_FORMATTER(constrainedPropertyKey);
+    
     //If the property name has been manipulated, lets make sure it don't clash with existing properties
     if (constrainedPropertyKey !== objectPropertyModel.propertyName) {
       constrainedPropertyKey = constraints.NO_DUPLICATE_PROPERTIES(constrainedObjectModel, objectModel, constrainedPropertyKey, constraints.NAMING_FORMATTER);
     }
-    constrainedPropertyKey = constraints.NAMING_FORMATTER(constrainedPropertyKey);
+
+    
     return constrainedPropertyKey;
   };
 }

--- a/test/generators/rust/__snapshots__/RustGenerator.spec.ts.snap
+++ b/test/generators/rust/__snapshots__/RustGenerator.spec.ts.snap
@@ -4,8 +4,10 @@ exports[`RustGenerator Enum should not render reserved keyword 1`] = `
 "// Address represents a Address model.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct Address {
-    #[serde(rename=\\"reservedEnum\\", skip_serializing_if = \\"Option::is_none\\")]
+    #[serde(rename=\\"enum\\", skip_serializing_if = \\"Option::is_none\\")]
     pub reserved_enum: Option<String>,
+    #[serde(rename=\\"reservedEnum\\", skip_serializing_if = \\"Option::is_none\\")]
+    pub reserved_reserved_enum: Option<String>,
 }
 "
 `;
@@ -37,7 +39,7 @@ pub enum Things123 {
     #[serde(rename=\\"1\\")]
     ReservedNumber_1,
     #[serde(rename=\\"false\\")]
-    ReservedFalse,
+    False,
     #[serde(flatten)]
     CurlyleftQuotationTestQuotationColonQuotationTestQuotationCurlyright(HashMap<String, serde_json::Value>),
 }

--- a/test/generators/rust/constrainer/EnumConstrainer.spec.ts
+++ b/test/generators/rust/constrainer/EnumConstrainer.spec.ts
@@ -1,6 +1,8 @@
 import { RustDefaultConstraints } from '../../../../src/generators/rust/RustConstrainer';
 import { EnumModel } from '../../../../src/models/MetaModel';
-import { ConstrainedEnumModel, ConstrainedEnumValueModel } from '../../../../src';
+import { ConstrainedEnumModel, ConstrainedEnumValueModel, EnumKeyConstraint } from '../../../../src';
+import { RESERVED_RUST_KEYWORDS } from '../../../../src/generators/rust/Constants';
+import { defaultEnumKeyConstraints } from '../../../../src/generators/rust/constrainer/EnumConstrainer';
 describe('EnumConstrainer', () => {
   const enumModel = new EnumModel('test', undefined, []);
   const constrainedEnumModel = new ConstrainedEnumModel('test', undefined, '', []);
@@ -28,9 +30,20 @@ describe('EnumConstrainer', () => {
       const constrainedKey = RustDefaultConstraints.enumKey({enumModel, constrainedEnumModel, enumKey: 'some weird_value!"#2'});
       expect(constrainedKey).toEqual('SomeWeirdValueExclamationQuotationHash_2');
     });
-    test('should never render reserved keywords', () => {
+    test('Reserved keywords should not take effect when naming formatter changes its format', () => {
       const constrainedKey = RustDefaultConstraints.enumKey({enumModel, constrainedEnumModel, enumKey: 'return'});
-      expect(constrainedKey).toEqual('ReservedReturn');
+      expect(constrainedKey).toEqual('Return');
+    });
+
+    describe('custom constraints', () => {
+      test('should make sure reserved keywords cannot be rendered', () => {
+        const customNamingFormat: Partial<EnumKeyConstraint> = {
+          NAMING_FORMATTER: (value) => value
+        };
+        const constrainFunction = defaultEnumKeyConstraints(customNamingFormat);
+        const constrainedKey = constrainFunction({enumModel, constrainedEnumModel, enumKey: 'return'});
+        expect(constrainedKey).toEqual('reserved_return');
+      });
     });
   });
   describe('enum values', () => {

--- a/test/generators/rust/constrainer/ModelNameConstrainer.spec.ts
+++ b/test/generators/rust/constrainer/ModelNameConstrainer.spec.ts
@@ -1,0 +1,34 @@
+import { RustDefaultConstraints } from '../../../../src/generators/rust/RustConstrainer';
+import { defaultModelNameConstraints, ModelNameConstraints } from '../../../../src/generators/rust/constrainer/ModelNameConstrainer';
+describe('ModelNameConstrainer', () => {
+  test('should never render special chars', () => {
+    const constrainedKey = RustDefaultConstraints.modelName({modelName: '%'});
+    expect(constrainedKey).toEqual('Percent');
+  });
+  test('should never render number as start char', () => {
+    const constrainedKey = RustDefaultConstraints.modelName({modelName: '1'});
+    expect(constrainedKey).toEqual('Number1');
+  });
+  test('should never contain empty name', () => {
+    const constrainedKey = RustDefaultConstraints.modelName({modelName: ''});
+    expect(constrainedKey).toEqual('Empty');
+  });
+  test('should use constant naming format', () => {
+    const constrainedKey = RustDefaultConstraints.modelName({modelName: 'some weird_value!"#2'});
+    expect(constrainedKey).toEqual('SomeWeirdValueExclamationQuotationHash2');
+  });
+  test('Reserved keywords should not take effect when naming formatter changes its format', () => {
+    const constrainedKey = RustDefaultConstraints.modelName({modelName: 'return'});
+    expect(constrainedKey).toEqual('Return');
+  });
+  describe('custom constraints', () => {
+    test('should make sure reserved keywords cannot be rendered', () => {
+      const customNamingFormat: Partial<ModelNameConstraints> = {
+        NAMING_FORMATTER: (value) => value
+      };
+      const constrainFunction = defaultModelNameConstraints(customNamingFormat);
+      const constrainedKey = constrainFunction({modelName: 'return'});
+      expect(constrainedKey).toEqual('reserved_return');
+    });
+  });
+});

--- a/test/generators/rust/constrainer/PropertyKeyConstrainer.spec.ts
+++ b/test/generators/rust/constrainer/PropertyKeyConstrainer.spec.ts
@@ -1,0 +1,45 @@
+import { RustDefaultConstraints } from '../../../../src/generators/rust/RustConstrainer';
+import { ConstrainedObjectModel, ConstrainedObjectPropertyModel, ObjectModel, ObjectPropertyModel } from '../../../../src';
+describe('PropertyKeyConstrainer', () => {
+  const objectModel = new ObjectModel('test', undefined, {});
+  const constrainedObjectModel = new ConstrainedObjectModel('test', undefined, '', {});
+
+  const constrainPropertyName = (propertyName: string) => {
+    const objectPropertyModel = new ObjectPropertyModel(propertyName, false, objectModel);
+    const constrainedObjectPropertyModel = new ConstrainedObjectPropertyModel('', '', objectPropertyModel.required, constrainedObjectModel);
+    return RustDefaultConstraints.propertyKey({constrainedObjectModel, objectModel, objectPropertyModel, constrainedObjectPropertyModel });
+  };
+
+  test('should never render special chars', () => {
+    const constrainedKey = constrainPropertyName('%');
+    expect(constrainedKey).toEqual('percent');
+  });
+  test('should not render number as start char', () => {
+    const constrainedKey = constrainPropertyName('1');
+    expect(constrainedKey).toEqual('number_1');
+  });
+  test('should never contain empty name', () => {
+    const constrainedKey = constrainPropertyName('');
+    expect(constrainedKey).toEqual('empty');
+  });
+  test('should use constant naming format', () => {
+    const constrainedKey = constrainPropertyName('some weird_value!"#2');
+    expect(constrainedKey).toEqual('some_weird_value_exclamation_quotation_hash_2');
+  });
+  test('should not contain duplicate properties', () => {
+    const objectModel = new ObjectModel('test', undefined, {});
+    const constrainedObjectModel = new ConstrainedObjectModel('test', undefined, '', {});
+    const objectPropertyModel = new ObjectPropertyModel('reserved_return', false, objectModel);
+    const constrainedObjectPropertyModel = new ConstrainedObjectPropertyModel('reserved_return', '', objectPropertyModel.required, constrainedObjectModel);
+    const objectPropertyModel2 = new ObjectPropertyModel('return', false, objectModel);
+    const constrainedObjectPropertyModel2 = new ConstrainedObjectPropertyModel('return', '', objectPropertyModel.required, constrainedObjectModel);
+    constrainedObjectModel.properties['reserved_return'] = constrainedObjectPropertyModel;
+    constrainedObjectModel.properties['return'] = constrainedObjectPropertyModel2;
+    const constrainedKey = RustDefaultConstraints.propertyKey({constrainedObjectModel, objectModel, objectPropertyModel: objectPropertyModel2, constrainedObjectPropertyModel: constrainedObjectPropertyModel2});
+    expect(constrainedKey).toEqual('reserved_reserved_return');
+  });
+  test('should never render reserved keywords', () => {
+    const constrainedKey = constrainPropertyName('return');
+    expect(constrainedKey).toEqual('reserved_return');
+  });
+});

--- a/test/generators/rust/presets/__snapshots__/CommonPreset.spec.ts.snap
+++ b/test/generators/rust/presets/__snapshots__/CommonPreset.spec.ts.snap
@@ -119,7 +119,7 @@ pub enum Things {
     #[serde(rename=\\"1\\")]
     ReservedNumber_1,
     #[serde(rename=\\"false\\")]
-    ReservedFalse,
+    False,
     #[serde(flatten)]
     CurlyleftQuotationTestQuotationColonQuotationTestQuotationCurlyright(HashMap<String, serde_json::Value>),
 }
@@ -141,7 +141,7 @@ pub enum Things {
     #[serde(rename=\\"1\\")]
     ReservedNumber_1,
     #[serde(rename=\\"false\\")]
-    ReservedFalse,
+    False,
     #[serde(flatten)]
     CurlyleftQuotationTestQuotationColonQuotationTestQuotationCurlyright(HashMap<String, serde_json::Value>),
 }
@@ -193,13 +193,13 @@ exports[`RUST_COMMON_PRESET Enum should render reserved union for dict array 1`]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Class {
     #[serde(rename=\\"students\\")]
-    pub students: Vec<crate::ReservedUnion>,
+    pub students: Vec<crate::Union>,
     #[serde(rename=\\"additionalProperties\\", skip_serializing_if = \\"Option::is_none\\")]
     pub additional_properties: Option<std::collections::HashMap<String, serde_json::Value>>,
 }
 
 impl Class {
-    pub fn new(students: Vec<crate::ReservedUnion>, additional_properties: Option<std::collections::HashMap<String, serde_json::Value>>) -> Class {
+    pub fn new(students: Vec<crate::Union>, additional_properties: Option<std::collections::HashMap<String, serde_json::Value>>) -> Class {
         Class {
             students,
             additional_properties,
@@ -210,9 +210,9 @@ impl Class {
 `;
 
 exports[`RUST_COMMON_PRESET Enum should render reserved union for dict array 2`] = `
-"// ReservedUnion represents a union of types: Student0, serde_json::Value
+"// Union represents a union of types: Student0, serde_json::Value
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub enum ReservedUnion {
+pub enum Union {
     #[serde(rename=\\"Student0\\")]
     Student0(crate::Student),
     #[serde(rename=\\"Undefined1\\")]


### PR DESCRIPTION
**Description**
This PR makes sure that reserved keywords are case-sensitive to make sure `Static` is not rendered as `ReservedStatic`. I also added specific tests for the constraint rules.

**Related issue(s)**
Fixes #1030 