### PR TITLE
docs: improve readme with use-cases and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 [![AsyncAPI Modelina](./docs/img/readme-banner.png)](https://www.asyncapi.com/tools/modelina)
 
-Modelina is the official AsyncAPI SDK to generate data models (i.e. <a href="#outputs">Java/TypeScript classes, Go Structs, etc</a>) from <a href="#inputs">AsyncAPI documents, among other supported inputs</a>.
-
 [![blackbox pipeline status](<https://img.shields.io/github/workflow/status/asyncapi/modelina/Blackbox%20testing%20(Stay%20Awhile%20and%20Listen)?label=blackbox%20testing>)](https://github.com/asyncapi/modelina/actions/workflows/blackbox-testing.yml?query=branch%3Amaster++)
 [![Coverage Status](https://coveralls.io/repos/github/asyncapi/modelina/badge.svg?branch=master)](https://coveralls.io/github/asyncapi/modelina?branch=master)
 [![Project Status: WIP – Initial development is in progress, but there has not yet been a stable, usable release suitable for the public.](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
@@ -26,10 +24,10 @@ This package is currently being prepared to reach version 1.0.0 and the developm
 
 <!-- toc -->
 
-- [Requirements](#requirements)
-- [Installation](#installation)
+- [Installing Modelina](#installing-modelina)
 - [Features](#features)
 - [Roadmap](#roadmap)
+- [Requirements](#requirements)
 - [Documentation](#documentation)
 - [Examples](#examples)
 - [Development](#development)
@@ -38,13 +36,7 @@ This package is currently being prepared to reach version 1.0.0 and the developm
 
 <!-- tocstop -->
 
-## Requirements
-
-- [NodeJS](https://nodejs.org/en/) >= 14
-
-Feel free to submit an issue if you require this project in other use-cases.
-
-## Installation
+## Installing Modelina
 
 Run this command to install Modelina in your project:
 
@@ -52,13 +44,136 @@ Run this command to install Modelina in your project:
 npm install @asyncapi/modelina
 ```
 
-Once you've successfully installed Modelina in your project, it's time to select your generator. Check out the [examples](#examples) for the specific code.
+<h2 align="center">What Does Modelina Do?</h2>
+
+<p align="center">Modelina put YOU in control of your data models, here is how...</p>
+
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<table>
+  <tr>
+    <td><b>Modelina lets you generate data models from many types of <a href="#inputs">inputs</a></b></td>
+<td>
+
+```typescript
+const asyncapi = ...
+const jsonschema = ...
+const openapi = ... 
+const metamodel = ... 
+...
+const models = await generator.generate(asyncapi | jsonschema | openapi | metamodel);
+```
+</td>
+  </tr>
+    <tr>
+    <td><b>Use the same inputs across a range of different <a href="#outputs">output generators.</a></b></td>
+<td>
+
+```typescript
+const generator = new TypeScriptGenerator();
+const generator = new CsharpGenerator();
+const generator = new JavaGenerator();
+const generator = new RustGenerator();
+...
+const models = await generator.generate(input);
+```
+</td>
+  </tr>
+    <tr>
+    <td><b>Easily let you interact with the generated models.</b> 
+
+- Want to show the generated models on a website? Sure! 
+- Want to generate the models into files? Sure! 
+- Want to combine all the models into one single file? Sure! 
+
+Whatever interaction you need you can create.</td>
+<td>
+
+```typescript
+const models = await generator.generate(input);
+for (const model in models) { 
+  const generatedCode = generatedModel.result;
+  const dependencies = generatedModel.dependencies;
+  const modeltype = generatedModel.model.type;
+  const modelName = generatedModel.modelName;
+  ...
+}
+```
+</td>
+  </tr>
+  <tr>
+    <td><b>Easily modify how models are <a href="./docs/constraints.md">constrained</a> into the output</b></td>
+
+<td>
+
+```typescript
+const generator = new TypeScriptGenerator({
+  constraints: {
+    modelName: ({modelName}) => {
+      // Implement your own constraining of the model name into TypeScript
+      return modelName;
+    }
+  }
+});
+```
+</td>
+  </tr>
+  <tr>
+    <td><b>Seamlessly layer additional code <a href="./docs/presets.md">on top of each other to customize the models</a> to your use-case</b></td>
+
+<td>
+
+```typescript
+const generator = new TypeScriptGenerator({
+  presets: [
+    {
+      class: {
+        additionalContent({ content }) {
+          return `${content}
+public myCustomFunction(): string {
+  return 'A custom function for each class';
+}`;
+        },
+      }
+    }
+  ]
+});
+const models = await generator.generate(input);
+```
+</td>
+  </tr>
+  <tr>
+    <td><b><a href="./docs/usage.md#generate-models-from-json-schema-documents">Seamlessly</a> let you combine multiple layers of additional or replacement code together</b></td>
+
+<td>
+
+```typescript
+const myCustomFunction1 = {
+  class: {
+    additionalContent({ content }) {
+      return `${content}
+public myCustomFunction(): string {
+return 'A custom function for each class';
+}`;
+    },
+  }
+};
+const myCustomFunction2 = {...};
+const generator = new TypeScriptGenerator({
+  presets: [
+    myCustomFunction1,
+    myCustomFunction2
+  ]
+});
+const models = await generator.generate(input);
+```
+</td>
+  </tr>
+</table>
 
 ## Features
 
-The following table provides a short summary of available features for supported output languages.
-
-To see the complete feature list for each language, please click the individual links for each language.
+The following table provides a short summary of available features for supported output languages. To see the complete feature list for each language, please click the individual links for each language.
 
 <a id="inputs"></a>
 
@@ -67,7 +182,7 @@ To see the complete feature list for each language, please click the individual 
 <table>
   <tr>
     <th>Supported inputs</th>
-    <th>description</th>
+    <th></th>
   </tr>
   <tr>
     <td><a href="./docs/usage.md#generate-models-from-asyncapi-documents">AsyncAPI</a></td>
@@ -97,7 +212,7 @@ To see the complete feature list for each language, please click the individual 
 <table>
   <tr>
     <th>Supported outputs</th>
-    <th>Features</th>
+    <th></th>
   </tr>
   <tr>
     <td><a href="./docs/usage.md#generate-java-models">Java</a></td>
@@ -134,10 +249,17 @@ To see the complete feature list for each language, please click the individual 
 </table>
 
 ## Roadmap
+This is the roadmap that is currently in focus by the [CODEOWNERS](./CODEOWNERS)
+
 - [Reach version 1.0](https://github.com/asyncapi/modelina/milestone/3)
 
+## Requirements
+The following are a requirement in order to use Modelina.
+
+- [NodeJS](https://nodejs.org/en/) >= 14
+
 ## Documentation
-Documentation for this library can be found under the [documentation folder](./docs/README.md).
+A feature in Modelina cannot exists without an example and documentation for it. You can find all the [documentation here](./docs/README.md).
 
 ## Examples
 Do you need to know how to use the library in certain scenarios? 
@@ -145,11 +267,18 @@ Do you need to know how to use the library in certain scenarios?
 We have gathered all the examples in a separate folder and they can be found under the [examples folder](./examples). 
 
 ## Development
-To setup your development environment please read the [development](./docs/development.md) document.
+We try to make it as easy for you as possible to set up your development environment to contribute to Modelina. You can find the development documentation [here](./docs/development.md).
 
 ## Contributing
+Without contributions, Modelina would not exist, it's a community project we build together to create the best possible building blocks, and we do this through [champions](./docs/champions.md).
 
-Read our [contributor](./docs/contributing.md) guide.
+We have made quite a [comprehensive contribution guide](./docs/contributing.md) to give you a lending hand in how different features and changes are introduced.
+
+If no documentation helps you, here is how you can reach out to get help:
+- On the [official AsycnAPI slack](https://asyncapi.com/slack-invite) under the `#04 Tooling` channel
+- Tag a specific [CODEOWNER](./CODEOWNERS) in your PR
+- Generally, it's always a good idea to do everything in public, but in some cases, it might not be possible. In those circumstances you can contact the following: 
+  - [jonaslagoni](github.com/jonaslagoni) (on [AsyncAPI Slack](https://asyncapi.com/slack-invite), [Twitter](twitter.com/jonaslagoni), [Email](jonas-lt@live.dk), [LinkedIn](https://www.linkedin.com/in/jonaslagoni/))
 
 ## Contributors ✨
 
@@ -216,4 +345,4 @@ Thanks go out to these wonderful people ([emoji key](https://allcontributors.org
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
-This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!
+This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind are welcome!

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ const models = await generator.generate(
 </td>
   </tr>
     <tr>
-    <td><b>Use the same inputs across a range of different <a href="#outputs">output generators.</a></b></td>
+    <td><b>Use the same inputs across a range of different <a href="#outputs">generators</a></b></td>
 <td>
 
 ```typescript
@@ -145,7 +145,7 @@ const models = await generator.generate(input);
 </td>
   </tr>
   <tr>
-    <td><b><a href="./docs/usage.md#generate-models-from-json-schema-documents">Seamlessly</a> let you combine multiple layers of additional or replacement code together</b></td>
+    <td><b>Seamlessly let you <a href="./docs/presets.md">combine multiple layers of additional or replacement code</a></b></td>
 
 <td>
 

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ If no documentation helps you, here is how you can reach out to get help:
 - On the [official AsycnAPI slack](https://asyncapi.com/slack-invite) under the `#04 Tooling` channel
 - Tag a specific [CODEOWNER](./CODEOWNERS) in your PR
 - Generally, it's always a good idea to do everything in public, but in some cases, it might not be possible. In those circumstances you can contact the following: 
-  - [jonaslagoni](github.com/jonaslagoni) (on [AsyncAPI Slack](https://asyncapi.com/slack-invite), [Twitter](twitter.com/jonaslagoni), [Email](jonas-lt@live.dk), [LinkedIn](https://www.linkedin.com/in/jonaslagoni/))
+  - [jonaslagoni](https://github.com/jonaslagoni) (on [AsyncAPI Slack](https://asyncapi.com/slack-invite), [Twitter](https://twitter.com/jonaslagoni), [Email](mailto:jonas-lt@live.dk), [LinkedIn](https://www.linkedin.com/in/jonaslagoni/))
 
 ## Contributors ✨
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ const models = await generator.generate(input);
 - Want to generate the models into files? Sure! 
 - Want to combine all the models into one single file? Sure! 
 
-Whatever interaction you need you can create.</td>
+Whatever interaction you need, you can create.</td>
 <td>
 
 ```typescript
@@ -145,7 +145,7 @@ const models = await generator.generate(input);
 </td>
   </tr>
   <tr>
-    <td><b>Seamlessly let you <a href="./docs/presets.md">combine multiple layers of additional or replacement code</a></b></td>
+    <td><b>Seamlessly lets you <a href="./docs/presets.md">combine multiple layers of additional or replacement code</a></b></td>
 
 <td>
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ const jsonschema = ...
 const openapi = ... 
 const metamodel = ... 
 ...
-const models = await generator.generate(asyncapi | jsonschema | openapi | metamodel);
+const models = await generator.generate(
+  asyncapi | jsonschema | openapi | metamodel
+);
 ```
 </td>
   </tr>
@@ -110,7 +112,7 @@ for (const model in models) {
 const generator = new TypeScriptGenerator({
   constraints: {
     modelName: ({modelName}) => {
-      // Implement your own constraining of the model name into TypeScript
+      // Implement your own constraining logic
       return modelName;
     }
   }

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ Without contributions, Modelina would not exist, it's a community project we bui
 We have made quite a [comprehensive contribution guide](./docs/contributing.md) to give you a lending hand in how different features and changes are introduced.
 
 If no documentation helps you, here is how you can reach out to get help:
-- On the [official AsycnAPI slack](https://asyncapi.com/slack-invite) under the `#04 Tooling` channel
+- On the [official AsycnAPI slack](https://asyncapi.com/slack-invite) under the `#04_tooling` channel
 - Tag a specific [CODEOWNER](./CODEOWNERS) in your PR
 - Generally, it's always a good idea to do everything in public, but in some cases, it might not be possible. In those circumstances you can contact the following: 
   - [jonaslagoni](https://github.com/jonaslagoni) (on [AsyncAPI Slack](https://asyncapi.com/slack-invite), [Twitter](https://twitter.com/jonaslagoni), [Email](mailto:jonas-lt@live.dk), [LinkedIn](https://www.linkedin.com/in/jonaslagoni/))

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ const generator = new TypeScriptGenerator({
 </td>
   </tr>
   <tr>
-    <td><b>Seamlessly layer additional code <a href="./docs/presets.md">on top of each other to customize the models</a> to your use-case</b></td>
+    <td><b>Seamlessly layer additional or replacement code <a href="./docs/presets.md">on top of each other to customize the models</a> to your use-case</b></td>
 
 <td>
 
@@ -204,7 +204,7 @@ The following table provides a short summary of available features for supported
   </tr>
   <tr>
     <td><a href="./docs/usage.md#generate-models-from-meta-models">Meta model</a></td>
-    <td>This is the internal representation of a model for Modelina, it is what inputs gets converted to, and what generators are provided to generate code. Instead of relying on an input processor, you can create your own models from scratch, and still take advantage on the generators and the features.</td>
+    <td>This is the internal representation of a model for Modelina, it is what inputs gets converted to, and what generators are provided to generate code. Instead of relying on an input processor, you can create your own models from scratch and still take advantage on the generators and the features.</td>
   </tr>
 </table>
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,8 +1,102 @@
 # Examples
 
-This directory contains a series of self-contained examples that you can use as starting points, or as snippets to pull into your existing applications:
+This directory contains a series of self-contained examples to help you get started or show how a specific feature can be utilized. The examples also serve the purpose of being part of the testing workflow to ensure they always work!
 
+We love contributions and new examples that does not already exist, you can follow [this guide to contribute one](../docs/contributing.md#adding-examples)!
+
+
+---
+
+## Groups of Examples
+
+<!-- toc is generated with GitHub Actions do not remove toc markers -->
+
+<!-- toc -->
+
+- [Input examples](#input-examples)
+- [General examples](#general-examples)
+- [Simple generator examples](#simple-generator-examples)
+- [Integrations](#integrations)
+- [Python](#python)
+- [JavaScript](#javascript)
+- [Java](#java)
+- [C#](#c%23)
+- [TypeScript](#typescript)
+- [Other examples](#other-examples)
+
+<!-- tocstop -->
+
+---
+
+## Input examples
+These examples show a specific input and how they can be used:
+- [asyncapi-from-object](./asyncapi-from-object) - A basic example where an AsyncAPI JS object is used to generate models.
+- [asyncapi-from-parser](./asyncapi-from-parser) - A basic example where an AsyncAPI JS object from the [parser-js](https://github.com/asyncapi/parser-js) is used to generate models.
+- [json-schema-draft7-from-object](./json-schema-draft7-from-object) - A basic example where a JSON Schema draft 7 JS object is used to generate models.
+- [json-schema-draft6-from-object](./json-schema-draft6-from-object) - A basic example where a JSON Schema draft 6 JS object is used to generate models.
+- [json-schema-draft4-from-object](./json-schema-draft4-from-object) - A basic example where a JSON Schema draft 4 JS object is used to generate models.
+- [swagger2.0-from-object](./swagger2.0-from-object) - A basic example where a Swagger 2.0 JS object is used to generate models.
+- [meta-model](./meta-model) - A basic example how to provide a meta model for the generator
+
+## General examples
+These are examples that can be applied in all scenarios.
+
+- [include-custom-function](./include-custom-function) - A basic example where a custom function is included.
+- [overwrite-naming-formatting](./overwrite-naming-formatting) - A basic example how to overwrite default naming format constraint in this case, overwriting returning a constant case format.
+- [overwrite-default-constraint](./overwrite-default-constraint/) -  A basic example how to overwrite the entire constraint logic and not just a single single part of the default behavior, in this case overwriting the model naming constraint.
+- [custom-logging](./custom-logging) - A basic example where a custom logger is used.
+- [generate-to-files](./generate-to-files) - A basic example that shows how you can generate the models directly to files.
+- [indentation-type-and-size](./indentation-type-and-size) - This example shows how to change the indentation type and size of the generated model.
+
+## Simple generator examples
+These are all the basic generator examples that shows a bare minimal example of a generator:
 - [generate-typescript-models](./generate-typescript-models) - A basic example to generate TypeScript data models
+- [generate-csharp-models](./generate-csharp-models) - A basic example to generate C# data models
+- [generate-python-models](./generate-python-models/) - A basic example showing how to generate Python models.
+- [rust-generate-crate](./rust-generate-crate/) - A basic example showing how to generate a Rust package.
+- [generate-java-models](./generate-java-models) - A basic example to generate Java data models.
+- [generate-go-models](./generate-go-models) - A basic example to generate Go data models
+- [generate-javascript-models](./generate-javascript-models) - A basic example to generate JavaScript data models
+
+## Integrations
+These are examples of how you can integrate Modelina into a specific scenario:
+- [integrate with React](./integrate-with-react/) - A basic example that shows how you can integrate Modelina with React.
+
+## Python
+These are all specific examples only relevant to the Python generator:
+- [generate-python-pydantic-models](./generate-python-pydantic-models/) - An example showing how to generate Python pydantic models.
+
+## JavaScript
+These are all specific examples only relevant to the JavaScript generator:
+
+- [javascript-use-esm](./javascript-use-esm) - A basic example that generate the models to use ESM module system.
+- [javascript-use-cjs](./javascript-use-cjs) - A basic example that generate the models to use CJS module system.
+- [javascript-generate-marshalling](./javascript-generate-marshalling) - A basic example of how to use the un/marshalling functionality of the javascript class.
+- [javascript-generate-example](./javascript-generate-example) - A basic example of how to use Modelina and output a JavaScript class with an example function.
+
+
+## Java
+These are all specific examples only relevant to the Java generator:
+- [java-generate-tostring](./java-generate-tostring) - A basic example that shows how to generate models that overwrite the `toString` method
+- [java-change-collection-type](./java-change-collection-type) - An example to render collections as List in Java.
+- [java-generate-hashcode](./java-generate-hashcode) - A basic example that shows how to generate models that overwrite the `hashCode` method
+- [java-from-typescript-type](./java-from-typescript-type/) - A basic example that shows how to generate a Java model from a TypeScript type input file.
+- [java-generate-marshalling](./java-generate-marshalling) - A basic example of how to use the un/marshalling functionality of the java class.
+- [java-from-typescript-type-with-options](./java-from-typescript-type-with-options/) - A basic example that shows how to generate a Java model from a TypeScript type input file along with user provided options.
+- [java-generate-equals](./java-generate-equals) - A basic example that shows how to generate models that overwrite the `equal` method
+- [java-generate-javax-constraint-annotation](./java-generate-javax-constraint-annotation) - A basic example that shows how Java data models having `javax.validation.constraints` annotations can be generated.
+- [java-generate-javadoc](./java-generate-javadoc) - A basic example of how to generate Java models including JavaDocs.
+
+## C#
+These are all specific examples only relevant to the C# generator:
+- [csharp-generate-equals-and-hashcode](./csharp-generate-equals-and-hashcode) - A basic example on how to generate models that overwrite the `Equal` and `GetHashCode` methods
+- [csharp-generate-json-serializer](./csharp-generate-json-serializer) - A basic example on how to generate models that include function to serialize the data models to and from JSON with System.Text.Json.
+- [csharp-generate-newtonsoft-serializer](./csharp-generate-newtonsoft-serializer) - A basic example on how to generate models that include function to serialize the data models to and form JSON with Newtonsoft.
+- [csharp-overwrite-enum-naming](./csharp-overwrite-enum-naming) - A basic example on how to generate enum value names.
+- [csharp-use-inheritance](./csharp-use-inheritance) - A basic example that shows how to introduce inheritance to classes 
+
+## TypeScript
+These are all specific examples only relevant to the TypeScript generator:
 - [typescript-interface](./typescript-interface) - A basic TypeScript generator that outputs interfaces.
 - [typescript-enum-type](./typescript-enum-type) - A basic example of how to use Modelina can output different types of enums in TypeScript.
 - [typescript-generate-example](./typescript-generate-example) - A basic example of how to use Modelina and output a TypeScript class with an example function.
@@ -10,44 +104,8 @@ This directory contains a series of self-contained examples that you can use as 
 - [typescript-generate-comments](./typescript-generate-comments) - A basic example of how to generate TypeScript interfaces with comments from description and example fields.
 - [typescript-use-esm](./typescript-use-esm) - A basic example that generate the models to use ESM module system.
 - [typescript-use-cjs](./typescript-use-cjs) - A basic example that generate the models to use CJS module system.
-- [indentation-type-and-size](./indentation-type-and-size) - This example shows how to change the indentation type and size of the generated model.
-- [asyncapi-from-object](./asyncapi-from-object) - A basic example where an AsyncAPI JS object is used to generate models.
-- [asyncapi-from-parser](./asyncapi-from-parser) - A basic example where an AsyncAPI JS object from the [parser-js](https://github.com/asyncapi/parser-js) is used to generate models.
-- [json-schema-draft7-from-object](./json-schema-draft7-from-object) - A basic example where a JSON Schema draft 7 JS object is used to generate models.
-- [json-schema-draft6-from-object](./json-schema-draft6-from-object) - A basic example where a JSON Schema draft 6 JS object is used to generate models.
-- [json-schema-draft4-from-object](./json-schema-draft4-from-object) - A basic example where a JSON Schema draft 4 JS object is used to generate models.
-- [swagger2.0-from-object](./swagger2.0-from-object) - A basic example where a Swagger 2.0 JS object is used to generate models.
-- [java-generate-javax-constraint-annotation](./java-generate-javax-constraint-annotation) - A basic example that shows how Java data models having `javax.validation.constraints` annotations can be generated.
-- [java-generate-javadoc](./java-generate-javadoc) - A basic example of how to generate Java models including JavaDocs.
-- [custom-logging](./custom-logging) - A basic example where a custom logger is used.
-- [generate-to-files](./generate-to-files) - A basic example that shows how you can generate the models directly to files.
-- [TEMPLATE](./TEMPLATE) - A basic template used to create new examples.
-- [java-generate-tostring](./java-generate-tostring) - A basic example that shows how to generate models that overwrite the `toString` method
-- [csharp-generate-equals-and-hashcode](./csharp-generate-equals-and-hashcode) - A basic example on how to generate models that overwrite the `Equal` and `GetHashCode` methods
-- [csharp-generate-json-serializer](./csharp-generate-json-serializer) - A basic example on how to generate models that include function to serialize the data models to and from JSON with System.Text.Json.
-- [csharp-generate-newtonsoft-serializer](./csharp-generate-newtonsoft-serializer) - A basic example on how to generate models that include function to serialize the data models to and form JSON with Newtonsoft.
-- [csharp-overwrite-enum-naming](./csharp-overwrite-enum-naming) - A basic example on how to generate enum value names.
-- [csharp-use-inheritance](./csharp-use-inheritance) - A basic example that shows how to introduce inheritance to classes 
-- [generate-javascript-models](./generate-javascript-models) - A basic example to generate JavaScript data models
-- [meta-model](./meta-model) - A basic example how to provide a meta model for the generator
-- [javascript-use-esm](./javascript-use-esm) - A basic example that generate the models to use ESM module system.
-- [javascript-use-cjs](./javascript-use-cjs) - A basic example that generate the models to use CJS module system.
-- [javascript-generate-marshalling](./javascript-generate-marshalling) - A basic example of how to use the un/marshalling functionality of the javascript class.
-- [javascript-generate-example](./javascript-generate-example) - A basic example of how to use Modelina and output a JavaScript class with an example function.
-- [generate-java-models](./generate-java-models) - A basic example to generate Java data models.
-- [generate-go-models](./generate-go-models) - A basic example to generate Go data models
-- [include-custom-function](./include-custom-function) - A basic example where a custom function is included.
-- [java-generate-equals](./java-generate-equals) - A basic example that shows how to generate models that overwrite the `equal` method
-- [generate-csharp-models](./generate-csharp-models) - A basic example to generate C# data models
-- [java-change-collection-type](./java-change-collection-type) - An example to render collections as List in Java.
-- [java-generate-hashcode](./java-generate-hashcode) - A basic example that shows how to generate models that overwrite the `hashCode` method
-- [java-from-typescript-type](./java-from-typescript-type/) - A basic example that shows how to generate a Java model from a TypeScript type input file.
-- [java-generate-marshalling](./java-generate-marshalling) - A basic example of how to use the un/marshalling functionality of the java class.
-- [java-from-typescript-type-with-options](./java-from-typescript-type-with-options/) - A basic example that shows how to generate a Java model from a TypeScript type input file along with user provided options.
-- [overwrite-naming-formatting](./overwrite-naming-formatting) - A basic example how to overwrite default naming format constraint in this case, overwriting returning a constant case format.
-- [overwrite-default-constraint](./overwrite-default-constraint/) -  A basic example how to overwrite the entire constraint logic and not just a single single part of the default behavior, in this case overwriting the model naming constraint.
-- [integrate with React](./integrate-with-react/) - A basic example that shows how you can integrate Modelina with React.
-- [rust-generate-crate](./rust-generate-crate/) - A basic example showing how to generate a Rust package.
 - [typescript-generate-jsonbinpack](./typescript-generate-jsonbinpack) - A basic example showing how to generate models that include [jsonbinpack](https://github.com/sourcemeta/jsonbinpack) functionality.
-- [generate-python-models](./generate-python-models/) - A basic example showing how to generate Python models.
-- [generate-python-pydantic-models](./generate-python-pydantic-models/) - An example showing how to generate Python pydantic models.
+
+## Other examples
+Miscelanious examples that do not fit into the otherwise grouping.
+- [TEMPLATE](./TEMPLATE) - A basic template used to create new examples.

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "lint": "eslint --max-warnings 0 --config .eslintrc .",
     "lint:fix": "eslint --max-warnings 0 --config .eslintrc . --fix",
     "release": "semantic-release",
-    "generate:readme:toc": "markdown-toc -i README.md && markdown-toc -i ./docs/languages/Python.md && markdown-toc -i ./docs/usage.md && markdown-toc -i ./docs/integration.md && markdown-toc -i ./docs/advanced.md && markdown-toc -i ./docs/languages/Dart.md && markdown-toc -i ./docs/languages/TypeScript.md && markdown-toc -i ./docs/languages/Java.md && markdown-toc -i ./docs/languages/JavaScript.md && markdown-toc -i ./docs/languages/Csharp.md && markdown-toc -i ./docs/README.md && markdown-toc -i ./docs/generators.md",
+    "generate:readme:toc": "markdown-toc -i README.md && markdown-toc -i ./examples/README.md && markdown-toc -i ./docs/languages/Python.md && markdown-toc -i ./docs/usage.md && markdown-toc -i ./docs/integration.md && markdown-toc -i ./docs/advanced.md && markdown-toc -i ./docs/languages/Dart.md && markdown-toc -i ./docs/languages/TypeScript.md && markdown-toc -i ./docs/languages/Java.md && markdown-toc -i ./docs/languages/JavaScript.md && markdown-toc -i ./docs/languages/Csharp.md && markdown-toc -i ./docs/README.md && markdown-toc -i ./docs/generators.md",
     "generate:assets": "npm run build:prod && npm run docs && npm run generate:readme:toc",
     "bump:version": "npm --no-git-tag-version --allow-same-version version $VERSION",
     "prepublishOnly": "npm run build:prod && npm run generate:readme:toc"


### PR DESCRIPTION
**Description**
After reading https://brew.sh/ main readme page, I noticed how quickly you get displayed exactly what it helps you with, and with Modelina I felt that it would take quite a read before you got to the point of a quick overview. 

So I did a few modifications using the similar concept they used with showing some of the core features Modelina provides up front 😄 

Oh, yea and I grouped the examples list just to get a better overview 😆 