### PR TITLE
fix: CSharp: Using dependency management / partOfProperty to render optional types with question mark

### DIFF
--- a/docs/presets.md
+++ b/docs/presets.md
@@ -283,16 +283,20 @@ const generator2 = new TypeScriptGenerator({
 ```
 
 ### Adding new dependencies
-Sometimes the preset might need to use some kind of foreign dependency. To achieve this each preset hook has the possibility of adding its own dependencies through the `addDependency` function from `renderer` property.
+Sometimes the preset might need to use some kind of foreign dependency. To achieve this each preset hook has the possibility of adding its own dependencies through a dependency manager, which can be accessed in `dependencyManager`.
 
 ```ts
 ...
-self({ renderer, content }) {
-  renderer.addDependency('import java.util.*;');
+self({ dependencyManager, content }) {
+  dependencyManager.addDependency('import java.util.*;');
   return content;
 }
 ...
 ```
+
+Some languages has specific helper functions, and some very basic interfaces, such as for Java.
+
+In TypeScript because you can have different import syntaxes based on the module system such as [CJS](../examples/typescript-use-cjs/) or [ESM](../examples/typescript-use-esm/), therefore it provies a specific function `addTypeScriptDependency` that takes care of that logic, and you just have to remember `addTypeScriptDependency('ImportanWhat', 'FromWhere')`.
 
 ### Overriding the default preset
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -51,3 +51,5 @@ This directory contains a series of self-contained examples that you can use as 
 - [typescript-generate-jsonbinpack](./typescript-generate-jsonbinpack) - A basic example showing how to generate models that include [jsonbinpack](https://github.com/sourcemeta/jsonbinpack) functionality.
 - [generate-python-models](./generate-python-models/) - A basic example showing how to generate Python models.
 - [generate-python-pydantic-models](./generate-python-pydantic-models/) - An example showing how to generate Python pydantic models.
+- [change-type-mapping](./change-type-mapping/) - A basic example showing how to change the type of a model in some context.
+- [change-type-mapping-with-dependency](./change-type-mapping-with-dependency/) - A basic example showing how to use the dependency manager to inject your own custom type with a dependency instead of the default type.

--- a/examples/change-type-mapping-with-dependency/README.md
+++ b/examples/change-type-mapping-with-dependency/README.md
@@ -1,0 +1,17 @@
+# Change type mapping that adds a new dependency
+
+This example shows how to use a new custom type for the FloatModel, that changes its type from `number` to `MyCustomClass`, which also needs to be added as a dependency.
+
+## How to run this example
+
+Run this example using:
+
+```sh
+npm i && npm run start
+```
+
+If you are on Windows, use the `start:windows` script instead:
+
+```sh
+npm i && npm run start:windows
+```

--- a/examples/change-type-mapping-with-dependency/__snapshots__/index.spec.ts.snap
+++ b/examples/change-type-mapping-with-dependency/__snapshots__/index.spec.ts.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Should be able to render models with custom dependency and type for property and should log expected output to console 1`] = `
+Array [
+  "class Root {
+  private _someProperty?: MyCustomClass;
+
+  constructor(input: {
+    someProperty?: MyCustomClass,
+  }) {
+    this._someProperty = input.someProperty;
+  }
+
+  get someProperty(): MyCustomClass | undefined { return this._someProperty; }
+  set someProperty(someProperty: MyCustomClass | undefined) { this._someProperty = someProperty; }
+}",
+]
+`;

--- a/examples/change-type-mapping-with-dependency/index.spec.ts
+++ b/examples/change-type-mapping-with-dependency/index.spec.ts
@@ -1,0 +1,13 @@
+const spy = jest.spyOn(global.console, 'log').mockImplementation(() => { return; });
+import {generate} from './index';
+
+describe('Should be able to render models with custom dependency and type for property', () => {
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+  test('and should log expected output to console', async () => {
+    await generate();
+    expect(spy.mock.calls.length).toEqual(1);
+    expect(spy.mock.calls[0]).toMatchSnapshot();
+  });
+});

--- a/examples/change-type-mapping-with-dependency/index.ts
+++ b/examples/change-type-mapping-with-dependency/index.ts
@@ -1,0 +1,36 @@
+import { TypeScriptGenerator } from '../../src';
+
+const generator = new TypeScriptGenerator({
+  typeMapping: {
+    Float: ({dependencyManager}) => {
+      // Let let the TypeScript dependency manager handle rendering the dependency based on the TypeScript options (i.e moduleSystem).
+      dependencyManager.addTypeScriptDependency('MyCustomClass', '../some/path/to/MyCustomClass');
+      // Or just do it manually, but then the moduleSystem options is not uphold. This is what most generators support
+      // dependencyManager.addDependency('import MyCustomClass from \'../some/path/to/class\';');
+
+      // Return the type to use for this float model
+      return 'MyCustomClass';
+    }
+  }
+});
+
+const jsonSchemaDraft7 = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    someProperty: {
+      type: 'number'
+    }
+  }
+};
+
+export async function generate() : Promise<void> {
+  const models = await generator.generate(jsonSchemaDraft7);
+  for (const model of models) {
+    console.log(model.result);
+  }
+}
+if (require.main === module) {
+  generate();
+}

--- a/examples/change-type-mapping-with-dependency/package-lock.json
+++ b/examples/change-type-mapping-with-dependency/package-lock.json
@@ -1,0 +1,10 @@
+{
+  "name": "change-type-mapping",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "hasInstallScript": true
+    }
+  }
+}

--- a/examples/change-type-mapping-with-dependency/package.json
+++ b/examples/change-type-mapping-with-dependency/package.json
@@ -1,0 +1,10 @@
+{
+  "config" : { "example_name" : "change-type-mapping-with-dependency" },
+  "scripts": {
+    "install": "cd ../.. && npm i",
+    "start": "../../node_modules/.bin/ts-node --cwd ../../ ./examples/$npm_package_config_example_name/index.ts",
+    "start:windows": "..\\..\\node_modules\\.bin\\ts-node --cwd ..\\..\\ .\\examples\\%npm_package_config_example_name%\\index.ts",
+    "test": "../../node_modules/.bin/jest --config=../../jest.config.js ./examples/$npm_package_config_example_name/index.spec.ts",
+    "test:windows": "..\\..\\node_modules\\.bin\\jest --config=..\\..\\jest.config.js examples/%npm_package_config_example_name%/index.spec.ts"
+  }
+}

--- a/examples/change-type-mapping/README.md
+++ b/examples/change-type-mapping/README.md
@@ -1,6 +1,6 @@
 # Change type mapping
 
-This example shows how to overwrite the default type mapping, and in this case we overwrite the default rendering of the NumberMetaModel `number` and instead use `integer`.
+This example shows how to overwrite the default type mapping, and in this case we overwrite the default rendering of the FloatModel `number` and instead use `integer`.
 
 ## How to run this example
 

--- a/examples/change-type-mapping/index.ts
+++ b/examples/change-type-mapping/index.ts
@@ -2,7 +2,7 @@ import { TypeScriptGenerator } from '../../src';
 
 const generator = new TypeScriptGenerator({
   typeMapping: {
-    String: ({constrainedModel, options, propertyKey}) => {
+    String: ({constrainedModel, options, partOfProperty, dependencyManager}) => {
       return 'integer';
     }
   }

--- a/examples/csharp-generate-required-properties/__snapshots__/index.spec.ts.snap
+++ b/examples/csharp-generate-required-properties/__snapshots__/index.spec.ts.snap
@@ -5,9 +5,9 @@ Array [
   "public class Root
 {
   private bool requiredBoolean;
-  private bool notRequiredBoolean;
+  private bool? notRequiredBoolean;
   private string requiredString;
-  private string notRequiredString;
+  private string? notRequiredString;
 
   public bool RequiredBoolean 
   {
@@ -15,7 +15,7 @@ Array [
     set { requiredBoolean = value; }
   }
 
-  public bool NotRequiredBoolean 
+  public bool? NotRequiredBoolean 
   {
     get { return notRequiredBoolean; }
     set { notRequiredBoolean = value; }
@@ -27,7 +27,7 @@ Array [
     set { requiredString = value; }
   }
 
-  public string NotRequiredString 
+  public string? NotRequiredString 
   {
     get { return notRequiredString; }
     set { notRequiredString = value; }

--- a/src/generators/AbstractDependencyManager.ts
+++ b/src/generators/AbstractDependencyManager.ts
@@ -1,0 +1,16 @@
+export abstract class AbstractDependencyManager {
+  constructor(
+    public dependencies: string[] = []
+  ) {}
+  
+  /**
+   * Adds a dependency while ensuring that only one dependency is preset at a time.
+   * 
+   * @param dependency complete dependency string so it can be rendered as is.
+   */
+  addDependency(dependency: string): void {
+    if (!this.dependencies.includes(dependency)) {
+      this.dependencies.push(dependency);
+    }
+  }
+}

--- a/src/generators/AbstractGenerator.ts
+++ b/src/generators/AbstractGenerator.ts
@@ -1,15 +1,25 @@
 import { InputMetaModel, OutputModel, Preset, Presets, RenderOutput, ProcessorOptions, MetaModel, ConstrainedMetaModel } from '../models';
 import { InputProcessor } from '../processors';
 import { IndentationTypes } from '../helpers';
-import { isPresetWithOptions } from '../utils';
-export interface CommonGeneratorOptions<P extends Preset = Preset> {
+import { DeepPartial, isPresetWithOptions } from '../utils';
+import { AbstractDependencyManager } from './AbstractDependencyManager';
+
+export interface CommonGeneratorOptions<P extends Preset = Preset, DependencyManager extends AbstractDependencyManager = AbstractDependencyManager> {
   indentation?: {
     type: IndentationTypes;
     size: number;
   };
   defaultPreset?: P;
   presets?: Presets<P>;
-  processorOptions?: ProcessorOptions
+  processorOptions?: ProcessorOptions;
+  /**
+   * This dependency manager type serves two functions.
+   * 1. It can be used to provide a factory for generate functions 
+   * 2. It can be used to provide a single instance of a dependency manager, to add all dependencies together
+   * 
+   * This depends on context and where it's used. 
+   */
+  dependencyManager?: (() => DependencyManager) | DependencyManager;
 }
 
 export const defaultGeneratorOptions: CommonGeneratorOptions = {
@@ -23,16 +33,16 @@ export const defaultGeneratorOptions: CommonGeneratorOptions = {
  * Abstract generator which must be implemented by each language
  */
 export abstract class AbstractGenerator<
-  Options extends CommonGeneratorOptions = CommonGeneratorOptions, 
-  RenderCompleteModelOptions = any> {
+  Options extends CommonGeneratorOptions, 
+  RenderCompleteModelOptions> {
   constructor(
     public readonly languageName: string,
     public readonly options: Options
   ) { }
 
-  public abstract render(model: MetaModel, inputModel: InputMetaModel): Promise<RenderOutput>;
-  public abstract renderCompleteModel(model: MetaModel, inputModel: InputMetaModel, options: RenderCompleteModelOptions): Promise<RenderOutput>;
-  public abstract constrainToMetaModel(model: MetaModel): ConstrainedMetaModel;
+  public abstract render(model: MetaModel, inputModel: InputMetaModel, options?: DeepPartial<Options>): Promise<RenderOutput>;
+  public abstract renderCompleteModel(model: MetaModel, inputModel: InputMetaModel, completeOptions: Partial<RenderCompleteModelOptions>, options?: DeepPartial<Options>): Promise<RenderOutput>;
+  public abstract constrainToMetaModel(model: MetaModel, options: DeepPartial<Options>): ConstrainedMetaModel;
   public abstract splitMetaModel(model: MetaModel): MetaModel[];
 
   public process(input: Record<string, unknown>): Promise<InputMetaModel> {
@@ -40,18 +50,30 @@ export abstract class AbstractGenerator<
   }
 
   /**
+   * This function returns an instance of the dependency manager.
+   */
+  protected getDependencyManagerInstance(options: Options): AbstractDependencyManager {
+    if (options.dependencyManager === undefined) {
+      throw new Error('Internal error, could not find dependency manager instance');
+    }
+    if (typeof options.dependencyManager === 'function') {
+      return options.dependencyManager();
+    }
+    return options.dependencyManager;
+  }
+
+  /**
    * Generates the full output of a model, instead of a scattered model.
    * 
    * OutputModels result is no longer the model itself, but including package, package dependencies and model dependencies.
    * 
-   * @param input 
-   * @param options to use for rendering full output
    */
-  public async generateCompleteModels(input: any | InputMetaModel, options: RenderCompleteModelOptions): Promise<OutputModel[]> {
+  public async generateCompleteModels(input: any | InputMetaModel, completeOptions: Partial<RenderCompleteModelOptions>): Promise<OutputModel[]> {
     const inputModel = await this.processInput(input);
     const renders = Object.values(inputModel.models).map(async (model) => {
-      const constrainedModel = this.constrainToMetaModel(model);
-      const renderedOutput = await this.renderCompleteModel(constrainedModel, inputModel, options);
+      const dependencyManager = this.getDependencyManagerInstance(this.options);
+      const constrainedModel = this.constrainToMetaModel(model, {dependencyManager} as any);
+      const renderedOutput = await this.renderCompleteModel(constrainedModel, inputModel, completeOptions, {dependencyManager} as any);
       return OutputModel.toOutputModel({ 
         result: renderedOutput.result,
         modelName: renderedOutput.renderedName, 
@@ -65,14 +87,13 @@ export abstract class AbstractGenerator<
 
   /**
    * Generates a scattered model where dependencies and rendered results are separated. 
-   * 
-   * @param input 
    */
   public async generate(input: any | InputMetaModel): Promise<OutputModel[]> {
     const inputModel = await this.processInput(input);
     const renders = Object.values(inputModel.models).map(async (model) => {
-      const constrainedModel = this.constrainToMetaModel(model);
-      const renderedOutput = await this.render(constrainedModel, inputModel);
+      const dependencyManager = this.getDependencyManagerInstance(this.options);
+      const constrainedModel = this.constrainToMetaModel(model, dependencyManager as any);
+      const renderedOutput = await this.render(constrainedModel, inputModel, {dependencyManager} as any);
       return OutputModel.toOutputModel({ 
         result: renderedOutput.result,
         modelName: renderedOutput.renderedName, 
@@ -105,6 +126,9 @@ export abstract class AbstractGenerator<
     return rawInputModel;
   }
 
+  /**
+   * Get all presets (default and custom ones from options) for a given preset type (class, enum, etc).  
+   */
   protected getPresets(presetType: string): Array<[Preset, unknown]> {
     const filteredPresets: Array<[Preset, unknown]> = [];
 

--- a/src/generators/AbstractRenderer.ts
+++ b/src/generators/AbstractRenderer.ts
@@ -15,20 +15,8 @@ export abstract class AbstractRenderer<
     readonly generator: G,
     protected readonly presets: Array<[Preset, unknown]>,
     protected readonly model: RendererModelType, 
-    protected readonly inputModel: InputMetaModel,
-    public dependencies: string[] = []
+    protected readonly inputModel: InputMetaModel
   ) {}
-
-  /**
-   * Adds a dependency while ensuring that only one dependency is preset at a time.
-   * 
-   * @param dependency complete dependency string so it can be rendered as is.
-   */
-  addDependency(dependency: string): void {
-    if (!this.dependencies.includes(dependency)) {
-      this.dependencies.push(dependency);
-    }
-  }
 
   renderLine(line: string): string {
     return `${line}\n`;

--- a/src/generators/csharp/CSharpConstrainer.ts
+++ b/src/generators/csharp/CSharpConstrainer.ts
@@ -1,52 +1,63 @@
+import { AbstractDependencyManager } from 'generators/AbstractDependencyManager';
+import { ConstrainedObjectPropertyModel } from 'models';
 import { TypeMapping } from '../../helpers';
 import { defaultEnumKeyConstraints, defaultEnumValueConstraints } from './constrainer/EnumConstrainer';
 import { defaultModelNameConstraints } from './constrainer/ModelNameConstrainer';
 import { defaultPropertyKeyConstraints } from './constrainer/PropertyKeyConstrainer';
 import { CSharpOptions } from './CSharpGenerator';
 
-export const CSharpDefaultTypeMapping: TypeMapping<CSharpOptions> = {
-  Object ({constrainedModel}): string {
-    return constrainedModel.name;
+function getFullTypeDefinition(typeName: string, partOfProperty: ConstrainedObjectPropertyModel | undefined) {
+  return partOfProperty?.required ?? true
+    ? typeName
+    : `${typeName}?`;
+};
+
+export const CSharpDefaultTypeMapping: TypeMapping<CSharpOptions, AbstractDependencyManager> = {
+
+  Object({ constrainedModel, partOfProperty }): string {
+    return getFullTypeDefinition(constrainedModel.name, partOfProperty);
   },
-  Reference ({constrainedModel}): string {
-    return constrainedModel.name;
+  Reference({ constrainedModel, partOfProperty }): string {
+    return getFullTypeDefinition(constrainedModel.name, partOfProperty);
   },
-  Any (): string {
-    return 'dynamic';
+  Any({ partOfProperty }): string {
+    return getFullTypeDefinition('dynamic', partOfProperty);
   },
-  Float (): string {
-    return 'double';
+  Float({ partOfProperty }): string {
+    return getFullTypeDefinition('double', partOfProperty);
   },
-  Integer (): string {
-    return 'int';
+  Integer({ partOfProperty }): string {
+    return getFullTypeDefinition('int', partOfProperty);
   },
-  String (): string {
-    return 'string';
+  String({ partOfProperty }): string {
+    return getFullTypeDefinition('string', partOfProperty);
   },
-  Boolean (): string {
-    return 'bool';
+  Boolean({ partOfProperty }): string {
+    return getFullTypeDefinition('bool', partOfProperty);
   },
-  Tuple ({constrainedModel}): string {
+  Tuple({ constrainedModel, partOfProperty }): string {
     const tupleTypes = constrainedModel.tuple.map((constrainedType) => {
       return constrainedType.value.type;
     });
-    return `(${tupleTypes.join(', ')})`;
+    return getFullTypeDefinition(`(${tupleTypes.join(', ')})`, partOfProperty);
   },
-  Array ({constrainedModel, options}): string {
-    if (options.collectionType && options.collectionType === 'List') {
-      return `IEnumerable<${constrainedModel.valueModel.type}>`;
-    }
-    return `${constrainedModel.valueModel.type}[]`;
+  Array({ constrainedModel, options, partOfProperty }): string {
+    const typeString = options.collectionType && options.collectionType === 'List'
+      ? `IEnumerable<${constrainedModel.valueModel.type}>`
+      : `${constrainedModel.valueModel.type}[]`;
+
+    return getFullTypeDefinition(typeString, partOfProperty);
   },
-  Enum ({constrainedModel}): string {
-    return constrainedModel.name;
+  Enum({ constrainedModel, partOfProperty }): string {
+    return getFullTypeDefinition(constrainedModel.name, partOfProperty);
   },
-  Union (): string {
-    //Because CSharp have no notion of unions (and no custom implementation), we have to render it as any value.
-    return 'dynamic';
+  Union({ partOfProperty }): string {
+    //BecauserenderPrivateType( CSharp , partOfProperty) have no notion of unions (and no custom implementation), we have to render it as any value.
+
+    return getFullTypeDefinition('dynamic', partOfProperty);
   },
-  Dictionary ({constrainedModel}): string {
-    return `Dictionary<${constrainedModel.key.type}, ${constrainedModel.value.type}>`;
+  Dictionary({ constrainedModel, partOfProperty }): string {
+    return getFullTypeDefinition(`Dictionary<${constrainedModel.key.type}, ${constrainedModel.value.type}>`, partOfProperty);
   }
 };
 

--- a/src/generators/typescript/TypeScriptConstrainer.ts
+++ b/src/generators/typescript/TypeScriptConstrainer.ts
@@ -1,12 +1,11 @@
 import { ConstrainedUnionModel } from '../../models';
 import { Logger } from '../../utils';
-import { TypeMapping } from '../../helpers';
 import { defaultEnumKeyConstraints, defaultEnumValueConstraints } from './constrainer/EnumConstrainer';
 import { defaultModelNameConstraints } from './constrainer/ModelNameConstrainer';
 import { defaultPropertyKeyConstraints } from './constrainer/PropertyKeyConstrainer';
-import { TypeScriptOptions } from './TypeScriptGenerator';
+import { TypeScriptTypeMapping } from './TypeScriptGenerator';
 
-export const TypeScriptDefaultTypeMapping: TypeMapping<TypeScriptOptions> = {
+export const TypeScriptDefaultTypeMapping: TypeScriptTypeMapping = {
   Object ({constrainedModel}): string {
     return constrainedModel.name;
   },

--- a/src/generators/typescript/TypeScriptDependencyManager.ts
+++ b/src/generators/typescript/TypeScriptDependencyManager.ts
@@ -1,0 +1,36 @@
+import { AbstractDependencyManager } from '../AbstractDependencyManager';
+import { renderJavaScriptDependency } from '../../utils';
+import { ConstrainedMetaModel } from '../../models';
+import { TypeScriptExportType, TypeScriptOptions } from './TypeScriptGenerator';
+
+export class TypeScriptDependencyManager extends AbstractDependencyManager {
+  constructor(
+    public options: TypeScriptOptions,
+    dependencies: string[] = []
+  ) {
+    super(dependencies);
+  }
+
+  /**
+   * Simple helper function to add a dependency correct based on the module system that the user defines.
+   */
+  addTypeScriptDependency(toImport: string, fromModule: string): void {
+    const dependencyImport = this.renderDependency(toImport, fromModule);
+    this.addDependency(dependencyImport);
+  }
+
+  /**
+   * Simple helper function to render a dependency based on the module system that the user defines.
+   */
+  renderDependency(toImport: string, fromModule: string): string {
+    return renderJavaScriptDependency(toImport, fromModule, this.options.moduleSystem);
+  }
+  
+  /**
+   * Render the model dependencies based on the option
+   */
+  renderCompleteModelDependencies(model: ConstrainedMetaModel, exportType: TypeScriptExportType): string {
+    const dependencyObject = exportType === 'named' ? `{${model.name}}` : model.name;
+    return this.renderDependency(dependencyObject, `./${model.name}`);
+  }
+}

--- a/src/generators/typescript/TypeScriptFileGenerator.ts
+++ b/src/generators/typescript/TypeScriptFileGenerator.ts
@@ -1,10 +1,9 @@
 import { TypeScriptGenerator, TypeScriptRenderCompleteModelOptions } from './';
 import { InputMetaModel, OutputModel } from '../../models';
 import * as path from 'path';
-import { AbstractFileGenerator } from '../AbstractFileGenerator';
 import { FileHelpers } from '../../helpers';
 
-export class TypeScriptFileGenerator extends TypeScriptGenerator implements AbstractFileGenerator<TypeScriptRenderCompleteModelOptions> {
+export class TypeScriptFileGenerator extends TypeScriptGenerator {
   /**
    * Generates all the models to an output directory each model with their own separate files. 
    * 

--- a/src/generators/typescript/TypeScriptGenerator.ts
+++ b/src/generators/typescript/TypeScriptGenerator.ts
@@ -4,28 +4,31 @@ import {
   defaultGeneratorOptions
 } from '../AbstractGenerator';
 import { ConstrainedEnumModel, ConstrainedMetaModel, ConstrainedObjectModel, InputMetaModel, MetaModel, RenderOutput } from '../../models';
-import { constrainMetaModel, Constraints, split, TypeMapping, hasPreset, SplitOptions, renderJavaScriptDependency } from '../../helpers';
+import { constrainMetaModel, Constraints, hasPreset, split, TypeMapping } from '../../helpers';
 import { TypeScriptPreset, TS_DEFAULT_PRESET } from './TypeScriptPreset';
 import { ClassRenderer } from './renderers/ClassRenderer';
 import { InterfaceRenderer } from './renderers/InterfaceRenderer';
 import { EnumRenderer } from './renderers/EnumRenderer';
 import { TypeRenderer } from './renderers/TypeRenderer';
 import { TypeScriptDefaultConstraints, TypeScriptDefaultTypeMapping } from './TypeScriptConstrainer';
-import { TS_EXPORT_KEYWORD_PRESET } from './presets';
 import { DeepPartial, mergePartialAndDefault } from '../../utils';
+import { TypeScriptDependencyManager } from './TypeScriptDependencyManager';
+import { TS_EXPORT_KEYWORD_PRESET } from './presets/ExportKeywordPreset';
 
-export interface TypeScriptOptions extends CommonGeneratorOptions<TypeScriptPreset> {
+export type TypeScriptModuleSystemType = 'ESM' | 'CJS';
+export type TypeScriptExportType = 'named' | 'default';
+export interface TypeScriptOptions extends CommonGeneratorOptions<TypeScriptPreset, TypeScriptDependencyManager> {
   renderTypes: boolean;
   modelType: 'class' | 'interface';
   enumType: 'enum' | 'union';
   mapType: 'indexedObject' | 'map' | 'record';
-  typeMapping: TypeMapping<TypeScriptOptions>;
+  typeMapping: TypeMapping<TypeScriptOptions, TypeScriptDependencyManager>;
   constraints: Constraints;
-  moduleSystem: 'ESM' | 'CJS';
+  moduleSystem: TypeScriptModuleSystemType;
 }
-
+export type TypeScriptTypeMapping = TypeMapping<TypeScriptOptions, TypeScriptDependencyManager>;
 export interface TypeScriptRenderCompleteModelOptions {
-  exportType?: 'default' | 'named';
+  exportType: TypeScriptExportType;
 }
 
 /**
@@ -41,14 +44,39 @@ export class TypeScriptGenerator extends AbstractGenerator<TypeScriptOptions, Ty
     defaultPreset: TS_DEFAULT_PRESET,
     typeMapping: TypeScriptDefaultTypeMapping,
     constraints: TypeScriptDefaultConstraints,
-    moduleSystem: 'ESM'
+    moduleSystem: 'ESM',
+    // Temporarily set
+    dependencyManager: () => { return {} as TypeScriptDependencyManager;}
+  };
+  
+  static defaultCompleteModelOptions: TypeScriptRenderCompleteModelOptions = {
+    exportType: 'default'
   };
 
   constructor(
     options?: DeepPartial<TypeScriptOptions>,
   ) {
-    const realizedOptions = mergePartialAndDefault(TypeScriptGenerator.defaultOptions, options) as TypeScriptOptions;
+    const realizedOptions = TypeScriptGenerator.getTypeScriptOptions(options);
     super('TypeScript', realizedOptions);
+  }
+
+  /**
+   * Returns the TypeScript options by merging custom options with default ones.
+   */
+  static getTypeScriptOptions(options?: DeepPartial<TypeScriptOptions>): TypeScriptOptions {
+    const optionsToUse = mergePartialAndDefault(TypeScriptGenerator.defaultOptions, options) as TypeScriptOptions;
+    //Always overwrite the dependency manager unless user explicitly state they want it (ignore default temporary dependency manager)
+    if (options?.dependencyManager === undefined) {
+      optionsToUse.dependencyManager = () => { return new TypeScriptDependencyManager(optionsToUse); };
+    }
+    return optionsToUse;
+  }
+
+  /**
+   * Wrapper to get an instance of the dependency manager
+   */
+  getTypeScriptDependencyManager(options: TypeScriptOptions): TypeScriptDependencyManager {
+    return this.getDependencyManagerInstance(options) as TypeScriptDependencyManager;
   }
 
   splitMetaModel(model: MetaModel): MetaModel[] {
@@ -60,13 +88,16 @@ export class TypeScriptGenerator extends AbstractGenerator<TypeScriptOptions, Ty
     return split(model, metaModelsToSplit);
   }
 
-  constrainToMetaModel(model: MetaModel): ConstrainedMetaModel {
-    return constrainMetaModel<TypeScriptOptions>(
+  constrainToMetaModel(model: MetaModel, options: DeepPartial<TypeScriptOptions>): ConstrainedMetaModel {
+    const optionsToUse = TypeScriptGenerator.getTypeScriptOptions({...this.options, ...options});
+    const dependencyManagerToUse = this.getTypeScriptDependencyManager(optionsToUse);
+    return constrainMetaModel<TypeScriptOptions, TypeScriptDependencyManager>(
       this.options.typeMapping, 
       this.options.constraints, 
       {
         metaModel: model,
-        options: this.options,
+        dependencyManager: dependencyManagerToUse,
+        options: {...this.options},
         constrainedName: '' //This is just a placeholder, it will be constrained within the function
       }
     );
@@ -79,85 +110,90 @@ export class TypeScriptGenerator extends AbstractGenerator<TypeScriptOptions, Ty
    * @param inputModel
    * @param options
    */
-  async renderCompleteModel(model: ConstrainedMetaModel, inputModel: InputMetaModel, {exportType = 'default'}: TypeScriptRenderCompleteModelOptions): Promise<RenderOutput> {
+  async renderCompleteModel(
+    model: ConstrainedMetaModel, 
+    inputModel: InputMetaModel, 
+    completeModelOptions: Partial<TypeScriptRenderCompleteModelOptions>,
+    options: DeepPartial<TypeScriptOptions>): Promise<RenderOutput> {
+    const completeModelOptionsToUse = mergePartialAndDefault(TypeScriptGenerator.defaultCompleteModelOptions, completeModelOptions) as TypeScriptRenderCompleteModelOptions;
+    const optionsToUse = TypeScriptGenerator.getTypeScriptOptions({...this.options, ...options});
+    const dependencyManagerToUse = this.getTypeScriptDependencyManager(optionsToUse);
+    const outputModel = await this.render(model, inputModel, {dependencyManager: dependencyManagerToUse});
+    const modelDependencies = model.getNearestDependencies();
     // Shallow copy presets so that we can restore it once we are done
     const originalPresets = [...(this.options.presets ? this.options.presets : [])];
 
     // Add preset that adds the `export` keyword if it hasn't already been added
     if (
       this.options.moduleSystem === 'ESM' &&
-      exportType === 'named' &&
+      completeModelOptionsToUse.exportType === 'named' &&
       !hasPreset(originalPresets, TS_EXPORT_KEYWORD_PRESET)
     ) {
       this.options.presets = [TS_EXPORT_KEYWORD_PRESET, ...originalPresets];
     }
-
-    const outputModel = await this.render(model, inputModel);
-    const modelDependencies = model.getNearestDependencies();
-    //Create the correct dependency imports
-    const modelDependencyImports = modelDependencies.map(({name}) => {
-      const dependencyObject =
-        exportType === 'named' ? `{${name}}` : name;
-      return renderJavaScriptDependency(dependencyObject, `./${name}`, this.options.moduleSystem);
+    //Create the correct model dependency imports
+    const modelDependencyImports = modelDependencies.map((model) => {
+      return dependencyManagerToUse.renderCompleteModelDependencies(model, completeModelOptionsToUse.exportType); 
     });
+    const modelExport = dependencyManagerToUse.renderCompleteModelDependencies(model, completeModelOptionsToUse.exportType);
 
-    //Ensure we expose the model correctly, based on the module system and export type
-    const cjsExport =
-      exportType === 'default'
-        ? `module.exports = ${outputModel.renderedName};`
-        : `exports.${outputModel.renderedName} = ${outputModel.renderedName};`;
-    const esmExport =
-      exportType === 'default'
-        ? `export default ${outputModel.renderedName};\n`
-        : '';
-    const modelCode = `${outputModel.result}\n${this.options.moduleSystem === 'CJS' ? cjsExport : esmExport}`;
+    const modelCode = `${outputModel.result}\n${modelExport}`;
 
     const outputContent = `${[...modelDependencyImports, ...outputModel.dependencies].join('\n')}
 ${modelCode}`;
 
-    // Restore presets array from original copy
-    this.options.presets = originalPresets;
-
     return RenderOutput.toRenderOutput({ result: outputContent, renderedName: outputModel.renderedName, dependencies: outputModel.dependencies });
   }
 
-  render(model: ConstrainedMetaModel, inputModel: InputMetaModel): Promise<RenderOutput> {
+  /**
+   * Render any ConstrainedMetaModel to code based on the type
+   */
+  render(model: ConstrainedMetaModel, inputModel: InputMetaModel, options?: DeepPartial<TypeScriptOptions>): Promise<RenderOutput> {
+    const optionsToUse = TypeScriptGenerator.getTypeScriptOptions({...this.options, ...options});
     if (model instanceof ConstrainedObjectModel) {
       if (this.options.modelType === 'interface') {
-        return this.renderInterface(model, inputModel);
+        return this.renderInterface(model, inputModel, optionsToUse);
       }
-      return this.renderClass(model, inputModel);
+      return this.renderClass(model, inputModel, optionsToUse);
     } else if (model instanceof ConstrainedEnumModel) {
-      return this.renderEnum(model, inputModel);
+      return this.renderEnum(model, inputModel, optionsToUse);
     } 
-    return this.renderType(model, inputModel);
+    return this.renderType(model, inputModel, optionsToUse);
   }
 
-  async renderClass(model: ConstrainedObjectModel, inputModel: InputMetaModel): Promise<RenderOutput> {
-    const presets = this.getPresets('class'); 
-    const renderer = new ClassRenderer(this.options, this, presets, model, inputModel);
+  async renderClass(model: ConstrainedObjectModel, inputModel: InputMetaModel, options?: DeepPartial<TypeScriptOptions>): Promise<RenderOutput> {
+    const optionsToUse = TypeScriptGenerator.getTypeScriptOptions({...this.options, ...options});
+    const dependencyManagerToUse = this.getTypeScriptDependencyManager(optionsToUse);
+    const presets = this.getPresets('class');
+    const renderer = new ClassRenderer(optionsToUse, this, presets, model, inputModel, dependencyManagerToUse);
     const result = await renderer.runSelfPreset();
-    return RenderOutput.toRenderOutput({result, renderedName: model.name, dependencies: renderer.dependencies});
+    return RenderOutput.toRenderOutput({result, renderedName: model.name, dependencies: dependencyManagerToUse.dependencies});
   }
 
-  async renderInterface(model: ConstrainedObjectModel, inputModel: InputMetaModel): Promise<RenderOutput> {
+  async renderInterface(model: ConstrainedObjectModel, inputModel: InputMetaModel, options?: Partial<TypeScriptOptions>): Promise<RenderOutput> {
+    const optionsToUse = TypeScriptGenerator.getTypeScriptOptions({...this.options, ...options});
+    const dependencyManagerToUse = this.getTypeScriptDependencyManager(optionsToUse);
     const presets = this.getPresets('interface'); 
-    const renderer = new InterfaceRenderer(this.options, this, presets, model, inputModel);
+    const renderer = new InterfaceRenderer(optionsToUse, this, presets, model, inputModel, dependencyManagerToUse);
     const result = await renderer.runSelfPreset();
-    return RenderOutput.toRenderOutput({result, renderedName: model.name, dependencies: renderer.dependencies});
+    return RenderOutput.toRenderOutput({result, renderedName: model.name, dependencies: dependencyManagerToUse.dependencies});
   }
 
-  async renderEnum(model: ConstrainedEnumModel, inputModel: InputMetaModel): Promise<RenderOutput> {
+  async renderEnum(model: ConstrainedEnumModel, inputModel: InputMetaModel, options?: DeepPartial<TypeScriptOptions>): Promise<RenderOutput> {
+    const optionsToUse = TypeScriptGenerator.getTypeScriptOptions({...this.options, ...options});
+    const dependencyManagerToUse = this.getTypeScriptDependencyManager(optionsToUse);
     const presets = this.getPresets('enum'); 
-    const renderer = new EnumRenderer(this.options, this, presets, model, inputModel);
+    const renderer = new EnumRenderer(optionsToUse, this, presets, model, inputModel, dependencyManagerToUse);
     const result = await renderer.runSelfPreset();
-    return RenderOutput.toRenderOutput({result, renderedName: model.name, dependencies: renderer.dependencies});
+    return RenderOutput.toRenderOutput({result, renderedName: model.name, dependencies: dependencyManagerToUse.dependencies});
   }
 
-  async renderType(model: ConstrainedMetaModel, inputModel: InputMetaModel): Promise<RenderOutput> {
+  async renderType(model: ConstrainedMetaModel, inputModel: InputMetaModel, options?: DeepPartial<TypeScriptOptions>): Promise<RenderOutput> {
+    const optionsToUse = TypeScriptGenerator.getTypeScriptOptions({...this.options, ...options});
+    const dependencyManagerToUse = this.getTypeScriptDependencyManager(optionsToUse);
     const presets = this.getPresets('type'); 
-    const renderer = new TypeRenderer(this.options, this, presets, model, inputModel);
+    const renderer = new TypeRenderer(optionsToUse, this, presets, model, inputModel, dependencyManagerToUse);
     const result = await renderer.runSelfPreset();
-    return RenderOutput.toRenderOutput({result, renderedName: model.name, dependencies: renderer.dependencies});
+    return RenderOutput.toRenderOutput({result, renderedName: model.name, dependencies: dependencyManagerToUse.dependencies});
   }
 }

--- a/src/generators/typescript/TypeScriptObjectRenderer.ts
+++ b/src/generators/typescript/TypeScriptObjectRenderer.ts
@@ -1,6 +1,7 @@
 import { TypeScriptGenerator, TypeScriptOptions } from './TypeScriptGenerator';
 import { ConstrainedObjectModel, ConstrainedObjectPropertyModel, InputMetaModel, Preset } from '../../models';
 import { TypeScriptRenderer } from './TypeScriptRenderer';
+import { TypeScriptDependencyManager } from './TypeScriptDependencyManager';
 
 /**
  * Common renderer for TypeScript types
@@ -14,8 +15,9 @@ export abstract class TypeScriptObjectRenderer extends TypeScriptRenderer<Constr
     presets: Array<[Preset, unknown]>,
     model: ConstrainedObjectModel, 
     inputModel: InputMetaModel,
+    dependencyManager: TypeScriptDependencyManager
   ) {
-    super(options, generator, presets, model, inputModel);
+    super(options, generator, presets, model, inputModel, dependencyManager);
   }
 
   /**

--- a/src/generators/typescript/TypeScriptRenderer.ts
+++ b/src/generators/typescript/TypeScriptRenderer.ts
@@ -2,20 +2,21 @@ import { AbstractRenderer } from '../AbstractRenderer';
 import { TypeScriptGenerator, TypeScriptOptions } from './TypeScriptGenerator';
 import { FormatHelpers } from '../../helpers';
 import { ConstrainedMetaModel, InputMetaModel, Preset } from '../../models';
-import { renderJavaScriptDependency } from '../../helpers/DependencyHelpers';
+import { TypeScriptDependencyManager } from './TypeScriptDependencyManager';
 
 /**
  * Common renderer for TypeScript types
  * 
  * @extends AbstractRenderer
  */
-export abstract class TypeScriptRenderer<RendererModelType extends ConstrainedMetaModel> extends AbstractRenderer<TypeScriptOptions, TypeScriptGenerator, RendererModelType> {
+export abstract class TypeScriptRenderer<RendererModelType extends ConstrainedMetaModel = ConstrainedMetaModel> extends AbstractRenderer<TypeScriptOptions, TypeScriptGenerator, RendererModelType> {
   constructor(
     options: TypeScriptOptions,
     generator: TypeScriptGenerator,
     presets: Array<[Preset, unknown]>,
     model: RendererModelType, 
     inputModel: InputMetaModel,
+    public dependencyManager: TypeScriptDependencyManager
   ) {
     super(options, generator, presets, model, inputModel);
   }
@@ -26,15 +27,5 @@ export abstract class TypeScriptRenderer<RendererModelType extends ConstrainedMe
     return `/**
 ${renderedLines}
  */`;
-  }
-
-  /**
-   * Simple helper function to render a dependency based on the module systme.
-   * 
-   * @param toImport 
-   * @param fromModule 
-   */
-  renderDependency(toImport: string, fromModule: string): string {
-    return renderJavaScriptDependency(toImport, fromModule, this.options.moduleSystem);
   }
 }

--- a/src/generators/typescript/presets/JsonBinPackPreset.ts
+++ b/src/generators/typescript/presets/JsonBinPackPreset.ts
@@ -22,7 +22,7 @@ function getInputSchema(originalInput: any): string {
 export const TS_JSONBINPACK_PRESET: TypeScriptPreset = {
   class: {
     async additionalContent({renderer, content, model}) {
-      renderer.addDependency(renderer.renderDependency('jsonbinpack', 'jsonbinpack'));
+      renderer.dependencyManager.addTypeScriptDependency('jsonbinpack', 'jsonbinpack');
     
       const jsonSchema = await alterschema(model.originalInput, getInputSchema(model.originalInput), '2020-12');
       const json = JSON.stringify(jsonSchema);

--- a/src/generators/typescript/presets/index.ts
+++ b/src/generators/typescript/presets/index.ts
@@ -1,4 +1,3 @@
 export * from './CommonPreset';
-export * from './ExportKeywordPreset';
 export * from './DescriptionPreset';
 export * from './JsonBinPackPreset';

--- a/src/helpers/ConstrainHelpers.ts
+++ b/src/helpers/ConstrainHelpers.ts
@@ -1,14 +1,17 @@
+import { AbstractDependencyManager } from '../generators/AbstractDependencyManager';
 import { ConstrainedAnyModel, ConstrainedBooleanModel, ConstrainedFloatModel, ConstrainedIntegerModel, ConstrainedMetaModel, ConstrainedObjectModel, ConstrainedReferenceModel, ConstrainedStringModel, ConstrainedTupleModel, ConstrainedTupleValueModel, ConstrainedArrayModel, ConstrainedUnionModel, ConstrainedEnumModel, ConstrainedDictionaryModel, ConstrainedEnumValueModel, ConstrainedObjectPropertyModel } from '../models/ConstrainedMetaModel';
 import { AnyModel, BooleanModel, FloatModel, IntegerModel, ObjectModel, ReferenceModel, StringModel, TupleModel, ArrayModel, UnionModel, EnumModel, DictionaryModel, MetaModel, ObjectPropertyModel } from '../models/MetaModel';
 import { getTypeFromMapping, TypeMapping } from './TypeHelpers';
 
 export type ConstrainContext<
   Options, 
-  M extends MetaModel> = {
+  M extends MetaModel, 
+  DependencyManager extends AbstractDependencyManager> = {
   partOfProperty?: ConstrainedObjectPropertyModel,
   metaModel: M,
   constrainedName: string,
-  options: Options
+  options: Options,
+  dependencyManager: DependencyManager
 }
 
 export type EnumKeyContext = {
@@ -48,7 +51,7 @@ export interface Constraints {
 
 const placeHolderConstrainedObject = new ConstrainedAnyModel('', undefined, '');
 
-function constrainReferenceModel<Options>(typeMapping: TypeMapping<Options>, constrainRules: Constraints, context: ConstrainContext<Options, ReferenceModel>, alreadySeenModels: Map<MetaModel, ConstrainedMetaModel>): ConstrainedReferenceModel {
+function constrainReferenceModel<Options, DependencyManager extends AbstractDependencyManager>(typeMapping: TypeMapping<Options, DependencyManager>, constrainRules: Constraints, context: ConstrainContext<Options, ReferenceModel, DependencyManager>, alreadySeenModels: Map<MetaModel, ConstrainedMetaModel>): ConstrainedReferenceModel {
   const constrainedModel = new ConstrainedReferenceModel(context.constrainedName, context.metaModel.originalInput, '', placeHolderConstrainedObject);
   alreadySeenModels.set(context.metaModel, constrainedModel); 
 
@@ -57,56 +60,62 @@ function constrainReferenceModel<Options>(typeMapping: TypeMapping<Options>, con
   constrainedModel.type = getTypeFromMapping(typeMapping, {
     constrainedModel,
     options: context.options,
-    partOfProperty: context.partOfProperty
+    partOfProperty: context.partOfProperty,
+    dependencyManager: context.dependencyManager
   });
   return constrainedModel;
 }
-function constrainAnyModel<Options>(typeMapping: TypeMapping<Options>, context: ConstrainContext<Options, AnyModel>): ConstrainedAnyModel {
+function constrainAnyModel<Options, DependencyManager extends AbstractDependencyManager>(typeMapping: TypeMapping<Options, DependencyManager>, context: ConstrainContext<Options, AnyModel, DependencyManager>): ConstrainedAnyModel {
   const constrainedModel = new ConstrainedAnyModel(context.constrainedName, context.metaModel.originalInput, '');
   constrainedModel.type = getTypeFromMapping(typeMapping, {
     constrainedModel,
     options: context.options,
-    partOfProperty: context.partOfProperty
+    partOfProperty: context.partOfProperty,
+    dependencyManager: context.dependencyManager
   });
   return constrainedModel; 
 }
-function constrainFloatModel<Options>(typeMapping: TypeMapping<Options>, context: ConstrainContext<Options, FloatModel>): ConstrainedFloatModel {
+function constrainFloatModel<Options, DependencyManager extends AbstractDependencyManager>(typeMapping: TypeMapping<Options, DependencyManager>, context: ConstrainContext<Options, FloatModel, DependencyManager>): ConstrainedFloatModel {
   const constrainedModel = new ConstrainedFloatModel(context.constrainedName, context.metaModel.originalInput, '');
   constrainedModel.type = getTypeFromMapping(typeMapping, {
     constrainedModel,
     options: context.options,
-    partOfProperty: context.partOfProperty
+    partOfProperty: context.partOfProperty,
+    dependencyManager: context.dependencyManager
   });
   return constrainedModel;
 }
-function constrainIntegerModel<Options>(typeMapping: TypeMapping<Options>, context: ConstrainContext<Options, IntegerModel>): ConstrainedIntegerModel {
+function constrainIntegerModel<Options, DependencyManager extends AbstractDependencyManager>(typeMapping: TypeMapping<Options, DependencyManager>, context: ConstrainContext<Options, IntegerModel, DependencyManager>): ConstrainedIntegerModel {
   const constrainedModel = new ConstrainedIntegerModel(context.constrainedName, context.metaModel.originalInput, '');
   constrainedModel.type = getTypeFromMapping(typeMapping, {
     constrainedModel,
     options: context.options,
-    partOfProperty: context.partOfProperty
+    partOfProperty: context.partOfProperty,
+    dependencyManager: context.dependencyManager
   });
   return constrainedModel;
 }
-function constrainStringModel<Options>(typeMapping: TypeMapping<Options>, context: ConstrainContext<Options, StringModel>): ConstrainedStringModel {
+function constrainStringModel<Options, DependencyManager extends AbstractDependencyManager>(typeMapping: TypeMapping<Options, DependencyManager>, context: ConstrainContext<Options, StringModel, DependencyManager>): ConstrainedStringModel {
   const constrainedModel = new ConstrainedStringModel(context.constrainedName, context.metaModel.originalInput, '');
   constrainedModel.type = getTypeFromMapping(typeMapping, {
     constrainedModel,
     options: context.options,
-    partOfProperty: context.partOfProperty
+    partOfProperty: context.partOfProperty,
+    dependencyManager: context.dependencyManager
   });
   return constrainedModel;
 }
-function constrainBooleanModel<Options>(typeMapping: TypeMapping<Options>, context: ConstrainContext<Options, BooleanModel>): ConstrainedBooleanModel {
+function constrainBooleanModel<Options, DependencyManager extends AbstractDependencyManager>(typeMapping: TypeMapping<Options, DependencyManager>, context: ConstrainContext<Options, BooleanModel, DependencyManager>): ConstrainedBooleanModel {
   const constrainedModel = new ConstrainedBooleanModel(context.constrainedName, context.metaModel.originalInput, '');
   constrainedModel.type = getTypeFromMapping(typeMapping, {
     constrainedModel,
     options: context.options,
-    partOfProperty: context.partOfProperty
+    partOfProperty: context.partOfProperty,
+    dependencyManager: context.dependencyManager
   });
   return constrainedModel;
 }
-function constrainTupleModel<Options>(typeMapping: TypeMapping<Options>, constrainRules: Constraints, context: ConstrainContext<Options, TupleModel>, alreadySeenModels: Map<MetaModel, ConstrainedMetaModel>): ConstrainedTupleModel {
+function constrainTupleModel<Options, DependencyManager extends AbstractDependencyManager>(typeMapping: TypeMapping<Options, DependencyManager>, constrainRules: Constraints, context: ConstrainContext<Options, TupleModel, DependencyManager>, alreadySeenModels: Map<MetaModel, ConstrainedMetaModel>): ConstrainedTupleModel {
   const constrainedModel = new ConstrainedTupleModel(context.constrainedName, context.metaModel.originalInput, '', []);
   alreadySeenModels.set(context.metaModel, constrainedModel); 
 
@@ -118,11 +127,12 @@ function constrainTupleModel<Options>(typeMapping: TypeMapping<Options>, constra
   constrainedModel.type = getTypeFromMapping(typeMapping, {
     constrainedModel,
     options: context.options,
-    partOfProperty: context.partOfProperty
+    partOfProperty: context.partOfProperty,
+    dependencyManager: context.dependencyManager
   });
   return constrainedModel;
 }
-function constrainArrayModel<Options>(typeMapping: TypeMapping<Options>, constrainRules: Constraints, context: ConstrainContext<Options, ArrayModel>, alreadySeenModels: Map<MetaModel, ConstrainedMetaModel>): ConstrainedArrayModel {
+function constrainArrayModel<Options, DependencyManager extends AbstractDependencyManager>(typeMapping: TypeMapping<Options, DependencyManager>, constrainRules: Constraints, context: ConstrainContext<Options, ArrayModel, DependencyManager>, alreadySeenModels: Map<MetaModel, ConstrainedMetaModel>): ConstrainedArrayModel {
   const constrainedModel = new ConstrainedArrayModel(context.constrainedName, context.metaModel.originalInput, '', placeHolderConstrainedObject);
   alreadySeenModels.set(context.metaModel, constrainedModel);
   const constrainedValueModel = constrainMetaModel(typeMapping, constrainRules, {...context, metaModel: context.metaModel.valueModel, partOfProperty: undefined}, alreadySeenModels);
@@ -130,11 +140,12 @@ function constrainArrayModel<Options>(typeMapping: TypeMapping<Options>, constra
   constrainedModel.type = getTypeFromMapping(typeMapping, {
     constrainedModel,
     options: context.options,
-    partOfProperty: context.partOfProperty
+    partOfProperty: context.partOfProperty,
+    dependencyManager: context.dependencyManager
   });
   return constrainedModel;
 }
-function constrainUnionModel<Options>(typeMapping: TypeMapping<Options>, constrainRules: Constraints, context: ConstrainContext<Options, UnionModel>, alreadySeenModels: Map<MetaModel, ConstrainedMetaModel>): ConstrainedUnionModel {
+function constrainUnionModel<Options, DependencyManager extends AbstractDependencyManager>(typeMapping: TypeMapping<Options, DependencyManager>, constrainRules: Constraints, context: ConstrainContext<Options, UnionModel, DependencyManager>, alreadySeenModels: Map<MetaModel, ConstrainedMetaModel>): ConstrainedUnionModel {
   const constrainedModel = new ConstrainedUnionModel(context.constrainedName, context.metaModel.originalInput, '', []);
   alreadySeenModels.set(context.metaModel, constrainedModel); 
 
@@ -145,11 +156,12 @@ function constrainUnionModel<Options>(typeMapping: TypeMapping<Options>, constra
   constrainedModel.type = getTypeFromMapping(typeMapping, {
     constrainedModel,
     options: context.options,
-    partOfProperty: context.partOfProperty
+    partOfProperty: context.partOfProperty,
+    dependencyManager: context.dependencyManager
   });
   return constrainedModel;
 }
-function constrainDictionaryModel<Options>(typeMapping: TypeMapping<Options>, constrainRules: Constraints, context: ConstrainContext<Options, DictionaryModel>, alreadySeenModels: Map<MetaModel, ConstrainedMetaModel>): ConstrainedDictionaryModel {
+function constrainDictionaryModel<Options, DependencyManager extends AbstractDependencyManager>(typeMapping: TypeMapping<Options, DependencyManager>, constrainRules: Constraints, context: ConstrainContext<Options, DictionaryModel, DependencyManager>, alreadySeenModels: Map<MetaModel, ConstrainedMetaModel>): ConstrainedDictionaryModel {
   const constrainedModel = new ConstrainedDictionaryModel(context.constrainedName, context.metaModel.originalInput, '', placeHolderConstrainedObject, placeHolderConstrainedObject, context.metaModel.serializationType);
   alreadySeenModels.set(context.metaModel, constrainedModel);
 
@@ -160,12 +172,13 @@ function constrainDictionaryModel<Options>(typeMapping: TypeMapping<Options>, co
   constrainedModel.type = getTypeFromMapping(typeMapping, {
     constrainedModel,
     options: context.options,
-    partOfProperty: context.partOfProperty
+    partOfProperty: context.partOfProperty,
+    dependencyManager: context.dependencyManager
   });
   return constrainedModel;
 }
 
-function constrainObjectModel<Options>(typeMapping: TypeMapping<Options>, constrainRules: Constraints, context: ConstrainContext<Options, ObjectModel>, alreadySeenModels: Map<MetaModel, ConstrainedMetaModel>): ConstrainedObjectModel {
+function constrainObjectModel<Options, DependencyManager extends AbstractDependencyManager>(typeMapping: TypeMapping<Options, DependencyManager>, constrainRules: Constraints, context: ConstrainContext<Options, ObjectModel, DependencyManager>, alreadySeenModels: Map<MetaModel, ConstrainedMetaModel>): ConstrainedObjectModel {
   const constrainedModel = new ConstrainedObjectModel(context.constrainedName, context.metaModel.originalInput, '', {});
   alreadySeenModels.set(context.metaModel, constrainedModel); 
 
@@ -180,12 +193,13 @@ function constrainObjectModel<Options>(typeMapping: TypeMapping<Options>, constr
   constrainedModel.type = getTypeFromMapping(typeMapping, {
     constrainedModel,
     options: context.options,
-    partOfProperty: context.partOfProperty
+    partOfProperty: context.partOfProperty,
+    dependencyManager: context.dependencyManager
   });
   return constrainedModel;
 }
 
-function ConstrainEnumModel<Options>(typeMapping: TypeMapping<Options>, constrainRules: Constraints, context: ConstrainContext<Options, EnumModel>): ConstrainedEnumModel {
+function ConstrainEnumModel<Options, DependencyManager extends AbstractDependencyManager>(typeMapping: TypeMapping<Options, DependencyManager>, constrainRules: Constraints, context: ConstrainContext<Options, EnumModel, DependencyManager>): ConstrainedEnumModel {
   const constrainedModel = new ConstrainedEnumModel(context.constrainedName, context.metaModel.originalInput, '', []);
 
   for (const enumValue of context.metaModel.values) {
@@ -195,11 +209,11 @@ function ConstrainEnumModel<Options>(typeMapping: TypeMapping<Options>, constrai
     const constrainedEnumValueModel = new ConstrainedEnumValueModel(constrainedEnumKey, constrainedEnumValue);
     constrainedModel.values.push(constrainedEnumValueModel);
   }
-  constrainedModel.type = getTypeFromMapping(typeMapping, {constrainedModel, options: context.options, partOfProperty: context.partOfProperty});
+  constrainedModel.type = getTypeFromMapping(typeMapping, {constrainedModel, options: context.options, partOfProperty: context.partOfProperty, dependencyManager: context.dependencyManager});
   return constrainedModel;
 }
 
-export function constrainMetaModel<Options>(typeMapping: TypeMapping<Options>, constrainRules: Constraints, context: ConstrainContext<Options, MetaModel>, alreadySeenModels: Map<MetaModel, ConstrainedMetaModel> = new Map()): ConstrainedMetaModel {
+export function constrainMetaModel<Options, DependencyManager extends AbstractDependencyManager>(typeMapping: TypeMapping<Options, DependencyManager>, constrainRules: Constraints, context: ConstrainContext<Options, MetaModel, DependencyManager>, alreadySeenModels: Map<MetaModel, ConstrainedMetaModel> = new Map()): ConstrainedMetaModel {
   if (alreadySeenModels.has(context.metaModel)) {
     return alreadySeenModels.get(context.metaModel) as ConstrainedMetaModel;
   }

--- a/src/helpers/TypeHelpers.ts
+++ b/src/helpers/TypeHelpers.ts
@@ -1,29 +1,43 @@
+import { AbstractDependencyManager } from 'generators/AbstractDependencyManager';
 import { ConstrainedAnyModel, ConstrainedBooleanModel, ConstrainedFloatModel, ConstrainedIntegerModel, ConstrainedMetaModel, ConstrainedObjectModel, ConstrainedReferenceModel, ConstrainedStringModel, ConstrainedTupleModel, ConstrainedArrayModel, ConstrainedUnionModel, ConstrainedEnumModel, ConstrainedDictionaryModel, ConstrainedObjectPropertyModel } from '../models/ConstrainedMetaModel';
 
-export type TypeContext<T extends ConstrainedMetaModel, Options> = {
+export type TypeContext<T extends ConstrainedMetaModel, Options, DependencyManager extends AbstractDependencyManager> = {
+  /**
+   * If the model is a property in an object model this can be used to conditionally change types based on property information.
+   */
   partOfProperty?: ConstrainedObjectPropertyModel,
+  /**
+   * The underlying options provided to the generator
+   */
   options: Options,
+  /**
+   * The specific constrained model that we are trying to find the type for
+   */
   constrainedModel: T,
+  /**
+   * Dependency manager that can be used to add custom dependencies to the rendering of the model, such as when using external types.
+   */
+  dependencyManager: DependencyManager
 }
 
-export type TypeMappingFunction<T extends ConstrainedMetaModel, Options> = (context: TypeContext<T, Options>) => string;
+export type TypeMappingFunction<T extends ConstrainedMetaModel, Options, DependencyManager extends AbstractDependencyManager> = (context: TypeContext<T, Options, DependencyManager>) => string;
 
-export type TypeMapping<Options> = {
-  Object: TypeMappingFunction<ConstrainedObjectModel, Options>,
-  Reference: TypeMappingFunction<ConstrainedReferenceModel, Options>,
-  Any: TypeMappingFunction<ConstrainedAnyModel, Options>,
-  Float: TypeMappingFunction<ConstrainedFloatModel, Options>,
-  Integer: TypeMappingFunction<ConstrainedIntegerModel, Options>,
-  String: TypeMappingFunction<ConstrainedStringModel, Options>,
-  Boolean: TypeMappingFunction<ConstrainedBooleanModel, Options>,
-  Tuple: TypeMappingFunction<ConstrainedTupleModel, Options>,
-  Array: TypeMappingFunction<ConstrainedArrayModel, Options>,
-  Enum: TypeMappingFunction<ConstrainedEnumModel, Options>,
-  Union: TypeMappingFunction<ConstrainedUnionModel, Options>,
-  Dictionary: TypeMappingFunction<ConstrainedDictionaryModel, Options>
+export type TypeMapping<Options, DependencyManager extends AbstractDependencyManager> = {
+  Object: TypeMappingFunction<ConstrainedObjectModel, Options, DependencyManager>,
+  Reference: TypeMappingFunction<ConstrainedReferenceModel, Options, DependencyManager>,
+  Any: TypeMappingFunction<ConstrainedAnyModel, Options, DependencyManager>,
+  Float: TypeMappingFunction<ConstrainedFloatModel, Options, DependencyManager>,
+  Integer: TypeMappingFunction<ConstrainedIntegerModel, Options, DependencyManager>,
+  String: TypeMappingFunction<ConstrainedStringModel, Options, DependencyManager>,
+  Boolean: TypeMappingFunction<ConstrainedBooleanModel, Options, DependencyManager>,
+  Tuple: TypeMappingFunction<ConstrainedTupleModel, Options, DependencyManager>,
+  Array: TypeMappingFunction<ConstrainedArrayModel, Options, DependencyManager>,
+  Enum: TypeMappingFunction<ConstrainedEnumModel, Options, DependencyManager>,
+  Union: TypeMappingFunction<ConstrainedUnionModel, Options, DependencyManager>,
+  Dictionary: TypeMappingFunction<ConstrainedDictionaryModel, Options, DependencyManager>
 };
 
-export function getTypeFromMapping<T extends ConstrainedMetaModel, Options>(typeMapping: TypeMapping<Options>, context: TypeContext<T, Options>): string {
+export function getTypeFromMapping<T extends ConstrainedMetaModel, Options, DependencyManager extends AbstractDependencyManager>(typeMapping: TypeMapping<Options, DependencyManager>, context: TypeContext<T, Options, DependencyManager>): string {
   if (context.constrainedModel instanceof ConstrainedObjectModel) {
     return typeMapping.Object({...context, constrainedModel: context.constrainedModel});
   } else if (context.constrainedModel instanceof ConstrainedReferenceModel) {

--- a/test/generators/typescript/TypeScriptDependencyManager.spec.ts
+++ b/test/generators/typescript/TypeScriptDependencyManager.spec.ts
@@ -1,0 +1,10 @@
+import { TypeScriptGenerator } from '../../../src/generators';
+import { TypeScriptDependencyManager } from '../../../src/generators/typescript/TypeScriptDependencyManager';
+describe('TypeScriptDependencyManager', () => {
+  describe('renderDependency()', () => {
+    test('Should be able to render dependency', () => {
+      const dependencyManager = new TypeScriptDependencyManager(TypeScriptGenerator.defaultOptions, []);
+      expect(dependencyManager.renderDependency('someComment', 'someComment2')).toEqual('import someComment from \'someComment2\';');
+    });
+  });
+});

--- a/test/generators/typescript/TypeScriptGenerator.spec.ts
+++ b/test/generators/typescript/TypeScriptGenerator.spec.ts
@@ -116,10 +116,6 @@ ${content}`;
         property: { type: 'string' },
       }
     };
-    const expected = `interface CustomInterface {
-  property?: string;
-  additionalProperties?: Map<String, object | string | number | Array<unknown> | boolean | null>;
-}`;
 
     generator = new TypeScriptGenerator({
       presets: [
@@ -157,7 +153,6 @@ ${content}`;
       type: 'string',
       enum: ['Texas', 'Alabama', 'California'],
     };
-    const expected = 'type States = "Texas" | "Alabama" | "California";';
 
     generator = new TypeScriptGenerator({ enumType: 'union' });
     const models = await generator.generate(doc);
@@ -171,13 +166,6 @@ ${content}`;
       $id: 'States',
       enum: [2, '2', 'test', true, { test: 'test' }]
     };
-    const expected = `enum States {
-  NUMBER_2 = 2,
-  STRING_2 = "2",
-  TEST = "test",
-  TRUE = "true",
-  TEST_TEST = '{"test":"test"}',
-}`;
     const models = await generator.generate(doc);
     expect(models).toHaveLength(1);
     expect(models[0].result).toMatchSnapshot();

--- a/test/generators/typescript/TypeScriptRenderer.spec.ts
+++ b/test/generators/typescript/TypeScriptRenderer.spec.ts
@@ -15,10 +15,4 @@ describe('TypeScriptRenderer', () => {
  */`);
     });
   });
-
-  describe('renderDependency()', () => {
-    test('Should be able to render dependency', () => {
-      expect(renderer.renderDependency('someComment', 'someComment2')).toEqual('import someComment from \'someComment2\';');
-    });
-  });
 });


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Using ConstrainedObjectPropertyModel to get info on if the property is required
- I wasn't able to test changes since tests are falling with
```
    Internal error, could not find dependency manager instance

      55 |   protected getDependencyManagerInstance(options: Options): AbstractDependencyManager {
      56 |     if (options.dependencyManager === undefined) {
    > 57 |       throw new Error('Internal error, could not find dependency manager instance');
         |             ^
      58 |     }
      59 |     if (typeof options.dependencyManager === 'function') {
      60 |       return options.dependencyManager();

      at CSharpGenerator.getDependencyManagerInstance (src/generators/AbstractGenerator.ts:57:13)
      at map (src/generators/AbstractGenerator.ts:94:38)
          at Array.map (<anonymous>)
      at CSharpGenerator.generate (src/generators/AbstractGenerator.ts:93:54)
      at generate (examples/csharp-generate-required-properties/index.ts:26:18)
      at Object.<anonymous> (examples/csharp-generate-required-properties/index.spec.ts:9:5)
```

**Related issue(s)**
Fixes #941 

<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->