### PR TITLE
chore: add dependency manager to CSharp

### DIFF
--- a/src/generators/AbstractDependencyManager.ts
+++ b/src/generators/AbstractDependencyManager.ts
@@ -4,7 +4,7 @@ export abstract class AbstractDependencyManager {
   ) {}
   
   /**
-   * Adds a dependency while ensuring that only one dependency is preset at a time.
+   * Adds a dependency while ensuring that unique dependencies.
    * 
    * @param dependency complete dependency string so it can be rendered as is.
    */

--- a/src/generators/csharp/CSharpConstrainer.ts
+++ b/src/generators/csharp/CSharpConstrainer.ts
@@ -1,10 +1,9 @@
-import { TypeMapping } from '../../helpers';
 import { defaultEnumKeyConstraints, defaultEnumValueConstraints } from './constrainer/EnumConstrainer';
 import { defaultModelNameConstraints } from './constrainer/ModelNameConstrainer';
 import { defaultPropertyKeyConstraints } from './constrainer/PropertyKeyConstrainer';
-import { CSharpOptions } from './CSharpGenerator';
+import { CSharpTypeMapping } from './CSharpGenerator';
 
-export const CSharpDefaultTypeMapping: TypeMapping<CSharpOptions> = {
+export const CSharpDefaultTypeMapping: CSharpTypeMapping = {
   Object ({constrainedModel}): string {
     return constrainedModel.name;
   },

--- a/src/generators/csharp/CSharpDependencyManager.ts
+++ b/src/generators/csharp/CSharpDependencyManager.ts
@@ -1,0 +1,11 @@
+import { AbstractDependencyManager } from '../AbstractDependencyManager';
+import { CSharpOptions } from './CSharpGenerator';
+
+export class CSharpDependencyManager extends AbstractDependencyManager {
+  constructor(
+    public options: CSharpOptions,
+    dependencies: string[] = []
+  ) {
+    super(dependencies);
+  }
+}

--- a/src/generators/csharp/CSharpFileGenerator.ts
+++ b/src/generators/csharp/CSharpFileGenerator.ts
@@ -3,6 +3,7 @@ import { InputMetaModel, OutputModel } from '../../models';
 import * as path from 'path';
 import { AbstractFileGenerator } from '../AbstractFileGenerator';
 import { FileHelpers } from '../../helpers';
+import { DeepPartial } from '../../utils';
 
 export class CSharpFileGenerator extends CSharpGenerator implements AbstractFileGenerator<CSharpRenderCompleteModelOptions> {
   /**
@@ -13,7 +14,7 @@ export class CSharpFileGenerator extends CSharpGenerator implements AbstractFile
    * @param options
    * @param ensureFilesWritten verify that the files is completely written before returning, this can happen if the file system is swamped with write requests. 
    */
-  public async generateToFiles(input: Record<string, unknown> | InputMetaModel, outputDirectory: string, options: CSharpRenderCompleteModelOptions, ensureFilesWritten = false): Promise<OutputModel[]> {
+  public async generateToFiles(input: Record<string, unknown> | InputMetaModel, outputDirectory: string, options: DeepPartial<CSharpRenderCompleteModelOptions>, ensureFilesWritten = false): Promise<OutputModel[]> {
     let generatedModels = await this.generateCompleteModels(input, options);
     //Filter anything out that have not been successfully generated
     generatedModels = generatedModels.filter((outputModel) => { return outputModel.modelName !== ''; });

--- a/src/generators/csharp/CSharpGenerator.ts
+++ b/src/generators/csharp/CSharpGenerator.ts
@@ -93,7 +93,6 @@ export class CSharpGenerator extends AbstractGenerator<CSharpOptions, CSharpRend
         dependencyManager: dependencyManagerToUse,
         options: this.options,
         constrainedName: '' //This is just a placeholder, it will be constrained within the function,
-        
       }
     );
   }

--- a/src/generators/csharp/CSharpGenerator.ts
+++ b/src/generators/csharp/CSharpGenerator.ts
@@ -4,7 +4,7 @@ import {
   defaultGeneratorOptions
 } from '../AbstractGenerator';
 import { ConstrainedEnumModel, ConstrainedMetaModel, ConstrainedObjectModel, InputMetaModel, MetaModel, RenderOutput } from '../../models';
-import { FormatHelpers, TypeMapping, Constraints, constrainMetaModel, split } from '../../helpers';
+import { FormatHelpers, TypeMapping, Constraints, constrainMetaModel, split, SplitOptions } from '../../helpers';
 import { CSharpPreset, CSHARP_DEFAULT_PRESET } from './CSharpPreset';
 import { EnumRenderer } from './renderers/EnumRenderer';
 import { ClassRenderer } from './renderers/ClassRenderer';
@@ -12,9 +12,12 @@ import { isReservedCSharpKeyword } from './Constants';
 import { Logger } from '../../index';
 import { CSharpDefaultConstraints, CSharpDefaultTypeMapping } from './CSharpConstrainer';
 import { DeepPartial, mergePartialAndDefault } from '../../utils/Partials';
+import { CSharpDependencyManager } from './CSharpDependencyManager';
+
+export type CSharpTypeMapping = TypeMapping<CSharpOptions, CSharpDependencyManager>
 export interface CSharpOptions extends CommonGeneratorOptions<CSharpPreset> {
   collectionType: 'List' | 'Array';
-  typeMapping: TypeMapping<CSharpOptions>;
+  typeMapping: CSharpTypeMapping;
   constraints: Constraints;
   autoImplementedProperties: boolean;
 }
@@ -33,33 +36,64 @@ export class CSharpGenerator extends AbstractGenerator<CSharpOptions, CSharpRend
     defaultPreset: CSHARP_DEFAULT_PRESET,
     typeMapping: CSharpDefaultTypeMapping,
     constraints: CSharpDefaultConstraints,
-    autoImplementedProperties: false
+    autoImplementedProperties: false,
+    // Temporarily set
+    dependencyManager: () => { return {} as CSharpDependencyManager;}
+  };
+
+
+  static defaultCompleteModelOptions: CSharpRenderCompleteModelOptions = {
+    namespace: 'Asyncapi.Models'
   };
 
   constructor(
     options?: DeepPartial<CSharpOptions>
   ) {
-    const realizedOptions = mergePartialAndDefault(CSharpGenerator.defaultOptions, options) as CSharpOptions;
+    const realizedOptions = CSharpGenerator.getCSharpOptions(options);
     super('CSharp', realizedOptions);
+  }
+
+
+  /**
+   * Returns the CSharp options by merging custom options with default ones.
+   */
+   static getCSharpOptions(options?: DeepPartial<CSharpOptions>): CSharpOptions {
+    const optionsToUse = mergePartialAndDefault(this.defaultOptions, options) as CSharpOptions;
+    //Always overwrite the dependency manager unless user explicitly state they want it (ignore default temporary dependency manager)
+    if (options?.dependencyManager === undefined) {
+      optionsToUse.dependencyManager = () => { return new CSharpDependencyManager(optionsToUse); };
+    }
+    return optionsToUse;
+  }
+
+  /**
+   * Wrapper to get an instance of the dependency manager
+   */
+  getCSharpDependencyManager(options: CSharpOptions): CSharpDependencyManager {
+    return this.getDependencyManagerInstance(options) as CSharpDependencyManager;
   }
 
   splitMetaModel(model: MetaModel): MetaModel[] {
     //These are the models that we have separate renderers for
-    const metaModelsToSplit = {
+    const metaModelsToSplit: SplitOptions = {
       splitEnum: true, 
       splitObject: true
     };
     return split(model, metaModelsToSplit);
   }
 
-  constrainToMetaModel(model: MetaModel): ConstrainedMetaModel {
-    return constrainMetaModel<CSharpOptions>(
+  constrainToMetaModel(model: MetaModel, options: DeepPartial<CSharpOptions>): ConstrainedMetaModel {
+    const optionsToUse = CSharpGenerator.getCSharpOptions({...this.options, ...options});
+    const dependencyManagerToUse = this.getCSharpDependencyManager(optionsToUse);
+    return constrainMetaModel<CSharpOptions, CSharpDependencyManager>(
       this.options.typeMapping, 
       this.options.constraints, 
       {
         metaModel: model,
+        dependencyManager: dependencyManagerToUse,
         options: this.options,
-        constrainedName: '' //This is just a placeholder, it will be constrained within the function
+        constrainedName: '' //This is just a placeholder, it will be constrained within the function,
+        
       }
     );
   }
@@ -73,44 +107,51 @@ export class CSharpGenerator extends AbstractGenerator<CSharpOptions, CSharpRend
    * @param inputModel 
    * @param options used to render the full output
    */
-  async renderCompleteModel(model: ConstrainedMetaModel, inputModel: InputMetaModel, options: CSharpRenderCompleteModelOptions): Promise<RenderOutput> {
-    if (isReservedCSharpKeyword(options.namespace)) {
-      throw new Error(`You cannot use reserved CSharp keyword (${options.namespace}) as namespace, please use another.`);
+  async renderCompleteModel(model: ConstrainedMetaModel, inputModel: InputMetaModel, completeModelOptions: DeepPartial<CSharpRenderCompleteModelOptions>, options: DeepPartial<CSharpOptions>): Promise<RenderOutput> {
+    const completeModelOptionsToUse = mergePartialAndDefault(CSharpGenerator.defaultCompleteModelOptions, completeModelOptions) as CSharpRenderCompleteModelOptions;
+    const optionsToUse = CSharpGenerator.getCSharpOptions({...this.options, ...options});
+    if (isReservedCSharpKeyword(completeModelOptionsToUse.namespace)) {
+      throw new Error(`You cannot use reserved CSharp keyword (${completeModelOptionsToUse.namespace}) as namespace, please use another.`);
     }
 
     const outputModel = await this.render(model, inputModel);
 
     const outputDependencies = outputModel.dependencies.length === 0 ? '' : `${outputModel.dependencies.join('\n')}\n\n`;
 
-    const outputContent = `namespace ${options.namespace}
+    const outputContent = `namespace ${completeModelOptionsToUse.namespace}
 {
-${FormatHelpers.indent(outputDependencies + outputModel.result, this.options.indentation?.size, this.options.indentation?.type)}
+${FormatHelpers.indent(outputDependencies + outputModel.result, optionsToUse.indentation?.size, optionsToUse.indentation?.type)}
 }`;
 
     return RenderOutput.toRenderOutput({ result: outputContent, renderedName: outputModel.renderedName, dependencies: outputModel.dependencies });
   }
 
-  render(model: ConstrainedMetaModel, inputModel: InputMetaModel): Promise<RenderOutput> {
+  render(model: ConstrainedMetaModel, inputModel: InputMetaModel, options?: DeepPartial<CSharpOptions>): Promise<RenderOutput> {
+    const optionsToUse = CSharpGenerator.getCSharpOptions({...this.options, ...options});
     if (model instanceof ConstrainedObjectModel) {
-      return this.renderClass(model, inputModel);
+      return this.renderClass(model, inputModel, optionsToUse);
     } else if (model instanceof ConstrainedEnumModel) {
-      return this.renderEnum(model, inputModel);
+      return this.renderEnum(model, inputModel, optionsToUse);
     } 
     Logger.warn(`C# generator, cannot generate this type of model, ${model.name}`);
     return Promise.resolve(RenderOutput.toRenderOutput({ result: '', renderedName: '', dependencies: [] }));
   }
 
-  async renderEnum(model: ConstrainedEnumModel, inputModel: InputMetaModel): Promise<RenderOutput> {
+  async renderEnum(model: ConstrainedEnumModel, inputModel: InputMetaModel, options?: Partial<CSharpOptions>): Promise<RenderOutput> {
+    const optionsToUse = CSharpGenerator.getCSharpOptions({...this.options, ...options});
+    const dependencyManagerToUse = this.getCSharpDependencyManager(optionsToUse);
     const presets = this.getPresets('enum');
-    const renderer = new EnumRenderer(this.options, this, presets, model, inputModel);
+    const renderer = new EnumRenderer(this.options, this, presets, model, inputModel, dependencyManagerToUse);
     const result = await renderer.runSelfPreset();
-    return RenderOutput.toRenderOutput({ result, renderedName: model.name, dependencies: renderer.dependencies });
+    return RenderOutput.toRenderOutput({ result, renderedName: model.name, dependencies: dependencyManagerToUse.dependencies });
   }
 
-  async renderClass(model: ConstrainedObjectModel, inputModel: InputMetaModel): Promise<RenderOutput> {
+  async renderClass(model: ConstrainedObjectModel, inputModel: InputMetaModel, options?: Partial<CSharpOptions>): Promise<RenderOutput> {
+    const optionsToUse = CSharpGenerator.getCSharpOptions({...this.options, ...options});
+    const dependencyManagerToUse = this.getCSharpDependencyManager(optionsToUse);
     const presets = this.getPresets('class');
-    const renderer = new ClassRenderer(this.options, this, presets, model, inputModel);
+    const renderer = new ClassRenderer(this.options, this, presets, model, inputModel, dependencyManagerToUse);
     const result = await renderer.runSelfPreset();
-    return RenderOutput.toRenderOutput({ result, renderedName: model.name, dependencies: renderer.dependencies });
+    return RenderOutput.toRenderOutput({ result, renderedName: model.name, dependencies: dependencyManagerToUse.dependencies });
   }
 }

--- a/src/generators/csharp/CSharpRenderer.ts
+++ b/src/generators/csharp/CSharpRenderer.ts
@@ -2,6 +2,7 @@ import { AbstractRenderer } from '../AbstractRenderer';
 import { CSharpGenerator, CSharpOptions } from './CSharpGenerator';
 import { Preset, ConstrainedMetaModel, InputMetaModel, ConstrainedObjectPropertyModel } from '../../models';
 import { FormatHelpers } from '../../helpers/FormatHelpers';
+import { CSharpDependencyManager } from './CSharpDependencyManager';
 
 /**
  * Common renderer for CSharp types
@@ -15,6 +16,7 @@ export abstract class CSharpRenderer<RendererModelType extends ConstrainedMetaMo
     presets: Array<[Preset, unknown]>,
     model: RendererModelType,
     inputModel: InputMetaModel,
+    public dependencyManager: CSharpDependencyManager
   ) {
     super(options, generator, presets, model, inputModel);
   }

--- a/src/generators/csharp/presets/CommonPreset.ts
+++ b/src/generators/csharp/presets/CommonPreset.ts
@@ -70,7 +70,7 @@ export const CSHARP_COMMON_PRESET: CSharpPreset<CSharpCommonPresetOptions> = {
         blocks.push(renderEqual({ renderer, model })); 
       }
       if (options.hash === undefined || options.hash === true) {
-        renderer.addDependency('using System;');
+        renderer.dependencyManager.addDependency('using System;');
         blocks.push(renderHashCode({ renderer, model }));
       }
 

--- a/src/generators/csharp/presets/JsonSerializerPreset.ts
+++ b/src/generators/csharp/presets/JsonSerializerPreset.ts
@@ -52,7 +52,7 @@ function renderPropertiesList(model: ConstrainedObjectModel, renderer: CSharpRen
   
   let propertiesList = 'var properties = value.GetType().GetProperties();';
   if (unwrappedDictionaryProperties.length > 0) {
-    renderer.addDependency('using System.Linq;');
+    renderer.dependencyManager.addDependency('using System.Linq;');
     propertiesList = `var properties = value.GetType().GetProperties().Where(prop => ${unwrappedDictionaryProperties.join(' && ')});`;
   }
   return propertiesList;
@@ -160,9 +160,9 @@ ${renderer.indent(deserializeProperties, 4)}
 export const CSHARP_JSON_SERIALIZER_PRESET: CSharpPreset<CSharpOptions> = {
   class: {
     self({ renderer, model, content}) {
-      renderer.addDependency('using System.Text.Json;');
-      renderer.addDependency('using System.Text.Json.Serialization;');
-      renderer.addDependency('using System.Text.RegularExpressions;');
+      renderer.dependencyManager.addDependency('using System.Text.Json;');
+      renderer.dependencyManager.addDependency('using System.Text.Json.Serialization;');
+      renderer.dependencyManager.addDependency('using System.Text.RegularExpressions;');
       
       const deserialize = renderDeserialize({renderer, model});
       const serialize = renderSerialize({renderer, model});

--- a/src/generators/csharp/presets/NewtonsoftSerializerPreset.ts
+++ b/src/generators/csharp/presets/NewtonsoftSerializerPreset.ts
@@ -112,10 +112,10 @@ function renderDeserialize({ model }: {
 export const CSHARP_NEWTONSOFT_SERIALIZER_PRESET: CSharpPreset<CSharpOptions> = {
   class: {
     self: ({ renderer, content, model }) => {
-      renderer.addDependency('using Newtonsoft.Json;');
-      renderer.addDependency('using Newtonsoft.Json.Linq;');
-      renderer.addDependency('using System.Collections.Generic;');
-      renderer.addDependency('using System.Linq;');
+      renderer.dependencyManager.addDependency('using Newtonsoft.Json;');
+      renderer.dependencyManager.addDependency('using Newtonsoft.Json.Linq;');
+      renderer.dependencyManager.addDependency('using System.Collections.Generic;');
+      renderer.dependencyManager.addDependency('using System.Linq;');
 
       const deserialize = renderDeserialize({ model });
       const serialize = renderSerialize({ model });

--- a/src/generators/csharp/renderers/ClassRenderer.ts
+++ b/src/generators/csharp/renderers/ClassRenderer.ts
@@ -20,7 +20,7 @@ export class ClassRenderer extends CSharpRenderer<ConstrainedObjectModel> {
 
     if (this.options?.collectionType === 'List' ||
       this.model.containsPropertyType(ConstrainedDictionaryModel)) {
-      this.addDependency('using System.Collections.Generic;');
+      this.dependencyManager.addDependency('using System.Collections.Generic;');
     }
 
     return `public class ${this.model.name}

--- a/test/generators/csharp/CSharpConstrainer.spec.ts
+++ b/test/generators/csharp/CSharpConstrainer.spec.ts
@@ -1,10 +1,13 @@
 import { CSharpDefaultTypeMapping } from '../../../src/generators/csharp/CSharpConstrainer';
 import { ConstrainedAnyModel, ConstrainedArrayModel, ConstrainedBooleanModel, ConstrainedDictionaryModel, ConstrainedEnumModel, ConstrainedFloatModel, ConstrainedIntegerModel, ConstrainedObjectModel, ConstrainedReferenceModel, ConstrainedStringModel, ConstrainedTupleModel, ConstrainedTupleValueModel, ConstrainedUnionModel, CSharpGenerator, CSharpOptions } from '../../../src';
+import { CSharpDependencyManager } from '../../../src/generators/csharp/CSharpDependencyManager';
 describe('CSharpConstrainer', () => {
+  const dependencyManagerInstance = new CSharpDependencyManager(CSharpGenerator.defaultOptions);
+  const defaultOptions = { options: CSharpGenerator.defaultOptions, dependencyManager: dependencyManagerInstance}; 
   describe('ObjectModel', () => { 
     test('should render the constrained name as type', () => {
       const model = new ConstrainedObjectModel('test', undefined, '', {});
-      const type = CSharpDefaultTypeMapping.Object({constrainedModel: model, options: CSharpGenerator.defaultOptions});
+      const type = CSharpDefaultTypeMapping.Object({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual(model.name);
     });
   });
@@ -12,42 +15,42 @@ describe('CSharpConstrainer', () => {
     test('should render the constrained name as type', () => {
       const refModel = new ConstrainedAnyModel('test', undefined, '');
       const model = new ConstrainedReferenceModel('test', undefined, '', refModel);
-      const type = CSharpDefaultTypeMapping.Reference({constrainedModel: model, options: CSharpGenerator.defaultOptions});
+      const type = CSharpDefaultTypeMapping.Reference({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual(model.name);
     });
   });
   describe('Any', () => { 
     test('should render type', () => {
       const model = new ConstrainedAnyModel('test', undefined, '');
-      const type = CSharpDefaultTypeMapping.Any({constrainedModel: model, options: CSharpGenerator.defaultOptions});
+      const type = CSharpDefaultTypeMapping.Any({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('dynamic');
     });
   });
   describe('Float', () => { 
     test('should render type', () => {
       const model = new ConstrainedFloatModel('test', undefined, '');
-      const type = CSharpDefaultTypeMapping.Float({constrainedModel: model, options: CSharpGenerator.defaultOptions});
+      const type = CSharpDefaultTypeMapping.Float({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('double');
     });
   });
   describe('Integer', () => { 
     test('should render type', () => {
       const model = new ConstrainedIntegerModel('test', undefined, '');
-      const type = CSharpDefaultTypeMapping.Integer({constrainedModel: model, options: CSharpGenerator.defaultOptions});
+      const type = CSharpDefaultTypeMapping.Integer({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('int');
     });
   });
   describe('String', () => { 
     test('should render type', () => {
       const model = new ConstrainedStringModel('test', undefined, '');
-      const type = CSharpDefaultTypeMapping.String({constrainedModel: model, options: CSharpGenerator.defaultOptions});
+      const type = CSharpDefaultTypeMapping.String({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('string');
     });
   });
   describe('Boolean', () => { 
     test('should render type', () => {
       const model = new ConstrainedBooleanModel('test', undefined, '');
-      const type = CSharpDefaultTypeMapping.Boolean({constrainedModel: model, options: CSharpGenerator.defaultOptions});
+      const type = CSharpDefaultTypeMapping.Boolean({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('bool');
     });
   });
@@ -57,7 +60,7 @@ describe('CSharpConstrainer', () => {
       const tupleModel = new ConstrainedBooleanModel('test', undefined, 'string');
       const tupleValueModel = new ConstrainedTupleValueModel(0, tupleModel);
       const model = new ConstrainedTupleModel('test', undefined, '', [tupleValueModel]);
-      const type = CSharpDefaultTypeMapping.Tuple({constrainedModel: model, options: CSharpGenerator.defaultOptions});
+      const type = CSharpDefaultTypeMapping.Tuple({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('(string)');
     });
     test('should render multiple types', () => {
@@ -65,7 +68,7 @@ describe('CSharpConstrainer', () => {
       const tupleValueModel0 = new ConstrainedTupleValueModel(0, tupleModel);
       const tupleValueModel1 = new ConstrainedTupleValueModel(1, tupleModel);
       const model = new ConstrainedTupleModel('test', undefined, '', [tupleValueModel0, tupleValueModel1]);
-      const type = CSharpDefaultTypeMapping.Tuple({constrainedModel: model, options: CSharpGenerator.defaultOptions});
+      const type = CSharpDefaultTypeMapping.Tuple({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('(string, string)');
     });
   });
@@ -75,14 +78,14 @@ describe('CSharpConstrainer', () => {
       const arrayModel = new ConstrainedStringModel('test', undefined, 'String');
       const model = new ConstrainedArrayModel('test', undefined, '', arrayModel);
       const options: CSharpOptions = {...CSharpGenerator.defaultOptions, collectionType: 'Array'};
-      const type = CSharpDefaultTypeMapping.Array({constrainedModel: model, options});
+      const type = CSharpDefaultTypeMapping.Array({constrainedModel: model, options, dependencyManager: dependencyManagerInstance});
       expect(type).toEqual('String[]');
     });
     test('should render array as a list', () => {
       const arrayModel = new ConstrainedStringModel('test', undefined, 'String');
       const model = new ConstrainedArrayModel('test', undefined, '', arrayModel);
       const options: CSharpOptions = {...CSharpGenerator.defaultOptions, collectionType: 'List'};
-      const type = CSharpDefaultTypeMapping.Array({constrainedModel: model, options});
+      const type = CSharpDefaultTypeMapping.Array({constrainedModel: model, options, dependencyManager: dependencyManagerInstance});
       expect(type).toEqual('IEnumerable<String>');
     });
   });
@@ -90,7 +93,7 @@ describe('CSharpConstrainer', () => {
   describe('Enum', () => { 
     test('should render the constrained name as type', () => {
       const model = new ConstrainedEnumModel('test', undefined, '', []);
-      const type = CSharpDefaultTypeMapping.Enum({constrainedModel: model, options: CSharpGenerator.defaultOptions});
+      const type = CSharpDefaultTypeMapping.Enum({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual(model.name);
     });
   });
@@ -98,7 +101,7 @@ describe('CSharpConstrainer', () => {
   describe('Union', () => { 
     test('should render type', () => {
       const model = new ConstrainedUnionModel('test', undefined, '', []);
-      const type = CSharpDefaultTypeMapping.Union({constrainedModel: model, options: CSharpGenerator.defaultOptions});
+      const type = CSharpDefaultTypeMapping.Union({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('dynamic');
     });
   });
@@ -108,7 +111,7 @@ describe('CSharpConstrainer', () => {
       const keyModel = new ConstrainedStringModel('test', undefined, 'String');
       const valueModel = new ConstrainedStringModel('test', undefined, 'String');
       const model = new ConstrainedDictionaryModel('test', undefined, '', keyModel, valueModel);
-      const type = CSharpDefaultTypeMapping.Dictionary({constrainedModel: model, options: CSharpGenerator.defaultOptions});
+      const type = CSharpDefaultTypeMapping.Dictionary({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('Dictionary<String, String>');
     });
   });

--- a/test/generators/csharp/CSharpRenderer.spec.ts
+++ b/test/generators/csharp/CSharpRenderer.spec.ts
@@ -1,11 +1,12 @@
 import { CSharpGenerator } from '../../../src';
+import { CSharpDependencyManager } from '../../../src/generators/csharp/CSharpDependencyManager';
 import { CSharpRenderer } from '../../../src/generators/csharp/CSharpRenderer';
 import { ConstrainedObjectModel, InputMetaModel } from '../../../src/models';
 import { MockCSharpRenderer } from '../../TestUtils/TestRenderers';
 describe('CSharpRenderer', () => {
   let renderer: CSharpRenderer<any>;
   beforeEach(() => {
-    renderer = new MockCSharpRenderer(CSharpGenerator.defaultOptions, new CSharpGenerator(), [], new ConstrainedObjectModel('', undefined, '', {}), new InputMetaModel());
+    renderer = new MockCSharpRenderer(CSharpGenerator.defaultOptions, new CSharpGenerator(), [], new ConstrainedObjectModel('', undefined, '', {}), new InputMetaModel(), new CSharpDependencyManager(CSharpGenerator.defaultOptions));
   });
 
   describe('renderComments()', () => {


### PR DESCRIPTION
**Description**
This PR adds the new dependency manager to the CSharp generator alongside a few changes:
- Allow the user to add dependencies for each model in the constraint and presets phase.
- As a side effect of the implementation, this enables the user to selectively overwrite options so you do not have to create a new generator instance all the time. 

These changes currently live on the `dependency_-manager` (wups) branch and are a WIP until all generators are adapted, that is why the tests are failing. 

**Related issue(s)**
Read more about the change here: https://github.com/asyncapi/modelina/pull/947
Fixes: https://github.com/asyncapi/modelina/issues/851