### PR TITLE
chore: add dependency manager for Python

### DIFF
--- a/src/generators/python/PythonConstrainer.ts
+++ b/src/generators/python/PythonConstrainer.ts
@@ -1,10 +1,9 @@
-import { TypeMapping } from '../../helpers';
 import { defaultEnumKeyConstraints, defaultEnumValueConstraints } from './constrainer/EnumConstrainer';
 import { defaultModelNameConstraints } from './constrainer/ModelNameConstrainer';
 import { defaultPropertyKeyConstraints } from './constrainer/PropertyKeyConstrainer';
-import { PythonOptions } from './PythonGenerator';
+import { PythonTypeMapping } from './PythonGenerator';
 
-export const PythonDefaultTypeMapping: TypeMapping<PythonOptions> = {
+export const PythonDefaultTypeMapping: PythonTypeMapping = {
   Object ({constrainedModel}): string {
     //Returning name here because all object models have been split out
     return constrainedModel.name;

--- a/src/generators/python/PythonDependencyManager.ts
+++ b/src/generators/python/PythonDependencyManager.ts
@@ -1,0 +1,21 @@
+import { ConstrainedMetaModel } from 'models';
+import { AbstractDependencyManager } from '../AbstractDependencyManager';
+import { PythonOptions } from './PythonGenerator';
+
+export class PythonDependencyManager extends AbstractDependencyManager {
+  constructor(
+    public options: PythonOptions,
+    dependencies: string[] = []
+  ) {
+    super(dependencies);
+  }
+
+
+  /**
+   * Simple helper function to render a dependency based on the module system that the user defines.
+   */
+  renderDependency(model: ConstrainedMetaModel): string {
+    const useExplicitImports = this.options.importsStyle === 'explicit';
+    return `from ${useExplicitImports ? '.' : ''}${model.name} import ${model.name}`;
+  }
+}

--- a/src/generators/python/PythonGenerator.ts
+++ b/src/generators/python/PythonGenerator.ts
@@ -5,7 +5,7 @@ import {
   defaultGeneratorOptions
 } from '../AbstractGenerator';
 import { ConstrainedEnumModel, ConstrainedMetaModel, ConstrainedObjectModel, InputMetaModel, MetaModel, RenderOutput } from '../../models';
-import { split, TypeMapping } from '../../helpers';
+import { split, SplitOptions, TypeMapping } from '../../helpers';
 import { PythonPreset, PYTHON_DEFAULT_PRESET } from './PythonPreset';
 import { ClassRenderer } from './renderers/ClassRenderer';
 import { EnumRenderer } from './renderers/EnumRenderer';
@@ -13,14 +13,17 @@ import { Logger } from '../..';
 import { constrainMetaModel, Constraints } from '../../helpers/ConstrainHelpers';
 import { PythonDefaultConstraints, PythonDefaultTypeMapping } from './PythonConstrainer';
 import { DeepPartial, mergePartialAndDefault } from '../../utils/Partials';
+import { PythonDependencyManager } from './PythonDependencyManager';
+export type PythonTypeMapping = TypeMapping<PythonOptions, PythonDependencyManager>;
 
 export interface PythonOptions extends CommonGeneratorOptions<PythonPreset> {
-  typeMapping: TypeMapping<PythonOptions>;
+  typeMapping: PythonTypeMapping;
   constraints: Constraints;
   importsStyle: 'explicit' | 'implicit';
 }
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface PythonRenderCompleteModelOptions {}
+export interface PythonRenderCompleteModelOptions { }
+
 export class PythonGenerator extends AbstractGenerator<PythonOptions, PythonRenderCompleteModelOptions> {
   static defaultOptions: PythonOptions = {
     ...defaultGeneratorOptions,
@@ -30,6 +33,8 @@ export class PythonGenerator extends AbstractGenerator<PythonOptions, PythonRend
     importsStyle: 'implicit'
   };
 
+  static defaultCompleteModelOptions: PythonRenderCompleteModelOptions = { };
+
   constructor(
     options?: DeepPartial<PythonOptions>,
   ) {
@@ -38,23 +43,45 @@ export class PythonGenerator extends AbstractGenerator<PythonOptions, PythonRend
   }
 
   /**
+   * Returns the Python options by merging custom options with default ones.
+   */
+   static getPythonOptions(options?: DeepPartial<PythonOptions>): PythonOptions {
+    const optionsToUse = mergePartialAndDefault(PythonGenerator.defaultOptions, options) as PythonOptions;
+    //Always overwrite the dependency manager unless user explicitly state they want it (ignore default temporary dependency manager)
+    if (options?.dependencyManager === undefined) {
+      optionsToUse.dependencyManager = () => { return new PythonDependencyManager(optionsToUse); };
+    }
+    return optionsToUse;
+  }
+
+  /**
+   * Wrapper to get an instance of the dependency manager
+   */
+  getPythonDependencyManager(options: PythonOptions): PythonDependencyManager {
+    return this.getDependencyManagerInstance(options) as PythonDependencyManager;
+  }
+
+  /**
    * This function makes sure we split up the MetaModels accordingly to what we want to render as models.
    */
   splitMetaModel(model: MetaModel): MetaModel[] {
     //These are the models that we have separate renderers for
-    const metaModelsToSplit = {
+    const metaModelsToSplit: SplitOptions = {
       splitEnum: true, 
       splitObject: true
     };
     return split(model, metaModelsToSplit);
   }
 
-  constrainToMetaModel(model: MetaModel): ConstrainedMetaModel {
-    return constrainMetaModel<PythonOptions>(
+  constrainToMetaModel(model: MetaModel, options: DeepPartial<PythonOptions>): ConstrainedMetaModel {
+    const optionsToUse = PythonGenerator.getPythonOptions({...this.options, ...options});
+    const dependencyManagerToUse = this.getPythonDependencyManager(optionsToUse);
+    return constrainMetaModel<PythonOptions, PythonDependencyManager>(
       this.options.typeMapping, 
       this.options.constraints, 
       {
         metaModel: model,
+        dependencyManager: dependencyManagerToUse,
         options: this.options,
         constrainedName: '' //This is just a placeholder, it will be constrained within the function
       }
@@ -67,11 +94,12 @@ export class PythonGenerator extends AbstractGenerator<PythonOptions, PythonRend
    * @param model 
    * @param inputModel 
    */
-  render(model: ConstrainedMetaModel, inputModel: InputMetaModel): Promise<RenderOutput> {
+  render(model: ConstrainedMetaModel, inputModel: InputMetaModel, options?: DeepPartial<PythonOptions>): Promise<RenderOutput> {
+    const optionsToUse = PythonGenerator.getPythonOptions({...this.options, ...options});
     if (model instanceof ConstrainedObjectModel) {
-      return this.renderClass(model, inputModel);
+      return this.renderClass(model, inputModel, optionsToUse);
     } else if (model instanceof ConstrainedEnumModel) {
-      return this.renderEnum(model, inputModel);
+      return this.renderEnum(model, inputModel, optionsToUse);
     } 
     Logger.warn(`Python generator, cannot generate this type of model, ${model.name}`);
     return Promise.resolve(RenderOutput.toRenderOutput({ result: '', renderedName: '', dependencies: [] }));
@@ -86,29 +114,37 @@ export class PythonGenerator extends AbstractGenerator<PythonOptions, PythonRend
    * @param inputModel 
    * @param options used to render the full output
    */
-  async renderCompleteModel(model: ConstrainedMetaModel, inputModel: InputMetaModel, options: PythonOptions): Promise<RenderOutput> {
-    const useExplicitImports = options.importsStyle === 'explicit';
+  async renderCompleteModel(
+    model: ConstrainedMetaModel, 
+    inputModel: InputMetaModel, 
+    completeModelOptions: Partial<PythonRenderCompleteModelOptions>,
+    options: DeepPartial<PythonOptions>): Promise<RenderOutput> {
+    //const completeModelOptionsToUse = mergePartialAndDefault(PythonGenerator.defaultCompleteModelOptions, completeModelOptions) as PythonRenderCompleteModelOptions;
+    const optionsToUse = PythonGenerator.getPythonOptions({...this.options, ...options});
+    const dependencyManagerToUse = this.getPythonDependencyManager(optionsToUse);
     const outputModel = await this.render(model, inputModel);
-    const modelDependencies = model.getNearestDependencies().map((dependencyModel) => {
-      return `from ${useExplicitImports ? '.' : ''}${dependencyModel.name} import ${dependencyModel.name}`;
-    });
+    const modelDependencies = model.getNearestDependencies().map(dependencyManagerToUse.renderDependency);
     const outputContent = `${modelDependencies.join('\n')}
 ${outputModel.dependencies.join('\n')}
 ${outputModel.result}`; 
     return RenderOutput.toRenderOutput({result: outputContent, renderedName: outputModel.renderedName, dependencies: outputModel.dependencies});
   }
 
-  async renderClass(model: ConstrainedObjectModel, inputModel: InputMetaModel): Promise<RenderOutput> {
+  async renderClass(model: ConstrainedObjectModel, inputModel: InputMetaModel, options?: DeepPartial<PythonOptions>): Promise<RenderOutput> {
+    const optionsToUse = PythonGenerator.getPythonOptions({...this.options, ...options});
+    const dependencyManagerToUse = this.getPythonDependencyManager(optionsToUse);
     const presets = this.getPresets('class');
-    const renderer = new ClassRenderer(this.options, this, presets, model, inputModel);
+    const renderer = new ClassRenderer(optionsToUse, this, presets, model, inputModel, dependencyManagerToUse);
     const result = await renderer.runSelfPreset();
-    return RenderOutput.toRenderOutput({result, renderedName: model.name, dependencies: renderer.dependencies});
+    return RenderOutput.toRenderOutput({result, renderedName: model.name, dependencies: dependencyManagerToUse.dependencies});
   }
 
-  async renderEnum(model: ConstrainedEnumModel, inputModel: InputMetaModel): Promise<RenderOutput> {
+  async renderEnum(model: ConstrainedEnumModel, inputModel: InputMetaModel, options?: DeepPartial<PythonOptions>): Promise<RenderOutput> {
+    const optionsToUse = PythonGenerator.getPythonOptions({...this.options, ...options});
+    const dependencyManagerToUse = this.getPythonDependencyManager(optionsToUse);
     const presets = this.getPresets('enum'); 
-    const renderer = new EnumRenderer(this.options, this, presets, model, inputModel);
+    const renderer = new EnumRenderer(optionsToUse, this, presets, model, inputModel, dependencyManagerToUse);
     const result = await renderer.runSelfPreset();
-    return RenderOutput.toRenderOutput({result, renderedName: model.name, dependencies: renderer.dependencies});
+    return RenderOutput.toRenderOutput({result, renderedName: model.name, dependencies: dependencyManagerToUse.dependencies});
   }
 }

--- a/src/generators/python/PythonRenderer.ts
+++ b/src/generators/python/PythonRenderer.ts
@@ -2,6 +2,7 @@ import { AbstractRenderer } from '../AbstractRenderer';
 import { PythonGenerator, PythonOptions } from './PythonGenerator';
 import { ConstrainedMetaModel, InputMetaModel, Preset } from '../../models';
 import { FormatHelpers } from '../../helpers';
+import { PythonDependencyManager } from './PythonDependencyManager';
 
 /**
  * Common renderer for Python
@@ -15,6 +16,7 @@ export abstract class PythonRenderer<RendererModelType extends ConstrainedMetaMo
     presets: Array<[Preset, unknown]>,
     model: RendererModelType, 
     inputModel: InputMetaModel,
+    public dependencyManager: PythonDependencyManager
   ) {
     super(options, generator, presets, model, inputModel);
   }

--- a/src/generators/python/presets/Pydantic.ts
+++ b/src/generators/python/presets/Pydantic.ts
@@ -3,8 +3,8 @@ import { ClassPresetType, PythonPreset } from '../PythonPreset';
 
 const PYTHON_PYDANTIC_CLASS_PRESET: ClassPresetType<PythonOptions> = {
   async self({renderer, model}) {
-    renderer.addDependency('from typing import Optional, Any');
-    renderer.addDependency('from pydantic import BaseModel, Field');
+    renderer.dependencyManager.addDependency('from typing import Optional, Any');
+    renderer.dependencyManager.addDependency('from pydantic import BaseModel, Field');
 
     const defaultClassString = await renderer.defaultSelf();
 

--- a/src/generators/python/renderers/EnumRenderer.ts
+++ b/src/generators/python/renderers/EnumRenderer.ts
@@ -39,7 +39,7 @@ ${this.indent(this.renderBlock(content, 2))}`;
 
 export const PYTHON_DEFAULT_ENUM_PRESET: EnumPresetType<PythonOptions> = {
   self({ renderer }) {
-    renderer.addDependency('from enum import Enum');
+    renderer.dependencyManager.addDependency('from enum import Enum');
     return renderer.defaultSelf();
   },
   item({ item }) {

--- a/test/generators/python/PythonConstrainer.spec.ts
+++ b/test/generators/python/PythonConstrainer.spec.ts
@@ -1,11 +1,13 @@
 import { PythonDefaultTypeMapping } from '../../../src/generators/python/PythonConstrainer';
 import { PythonGenerator } from '../../../src/generators/python';
 import { ConstrainedAnyModel, ConstrainedArrayModel, ConstrainedBooleanModel, ConstrainedDictionaryModel, ConstrainedEnumModel, ConstrainedFloatModel, ConstrainedIntegerModel, ConstrainedObjectModel, ConstrainedReferenceModel, ConstrainedStringModel, ConstrainedTupleModel, ConstrainedTupleValueModel, ConstrainedUnionModel } from '../../../src';
+import { PythonDependencyManager } from '../../../src/generators/python/PythonDependencyManager';
 describe('PythonConstrainer', () => {
+  const defaultOptions = {options: PythonGenerator.defaultOptions, dependencyManager: new PythonDependencyManager(PythonGenerator.defaultOptions)};
   describe('ObjectModel', () => {
     test('should render the constrained name as type', () => {
       const model = new ConstrainedObjectModel('test', undefined, '', {});
-      const type = PythonDefaultTypeMapping.Object({ constrainedModel: model, options: PythonGenerator.defaultOptions });
+      const type = PythonDefaultTypeMapping.Object({ constrainedModel: model, ...defaultOptions });
       expect(type).toEqual(model.name);
     });
   });
@@ -13,42 +15,42 @@ describe('PythonConstrainer', () => {
     test('should render the constrained name as type', () => {
       const refModel = new ConstrainedAnyModel('test', undefined, '');
       const model = new ConstrainedReferenceModel('test', undefined, '', refModel);
-      const type = PythonDefaultTypeMapping.Reference({ constrainedModel: model, options: PythonGenerator.defaultOptions });
+      const type = PythonDefaultTypeMapping.Reference({ constrainedModel: model, ...defaultOptions });
       expect(type).toEqual(model.name);
     });
   });
   describe('Any', () => {
     test('should render type', () => {
       const model = new ConstrainedAnyModel('test', undefined, '');
-      const type = PythonDefaultTypeMapping.Any({ constrainedModel: model, options: PythonGenerator.defaultOptions });
+      const type = PythonDefaultTypeMapping.Any({ constrainedModel: model, ...defaultOptions });
       expect(type).toEqual('Any');
     });
   });
   describe('Float', () => {
     test('should render type', () => {
       const model = new ConstrainedFloatModel('test', undefined, '');
-      const type = PythonDefaultTypeMapping.Float({ constrainedModel: model, options: PythonGenerator.defaultOptions });
+      const type = PythonDefaultTypeMapping.Float({ constrainedModel: model, ...defaultOptions });
       expect(type).toEqual('float');
     });
   });
   describe('Integer', () => {
     test('should render type', () => {
       const model = new ConstrainedIntegerModel('test', undefined, '');
-      const type = PythonDefaultTypeMapping.Integer({ constrainedModel: model, options: PythonGenerator.defaultOptions });
+      const type = PythonDefaultTypeMapping.Integer({ constrainedModel: model, ...defaultOptions });
       expect(type).toEqual('int');
     });
   });
   describe('String', () => {
     test('should render type', () => {
       const model = new ConstrainedStringModel('test', undefined, '');
-      const type = PythonDefaultTypeMapping.String({ constrainedModel: model, options: PythonGenerator.defaultOptions });
+      const type = PythonDefaultTypeMapping.String({ constrainedModel: model, ...defaultOptions });
       expect(type).toEqual('str');
     });
   });
   describe('Boolean', () => {
     test('should render type', () => {
       const model = new ConstrainedBooleanModel('test', undefined, '');
-      const type = PythonDefaultTypeMapping.Boolean({ constrainedModel: model, options: PythonGenerator.defaultOptions });
+      const type = PythonDefaultTypeMapping.Boolean({ constrainedModel: model, ...defaultOptions });
       expect(type).toEqual('bool');
     });
   });
@@ -58,7 +60,7 @@ describe('PythonConstrainer', () => {
       const stringModel = new ConstrainedStringModel('test', undefined, 'str');
       const tupleValueModel = new ConstrainedTupleValueModel(0, stringModel);
       const model = new ConstrainedTupleModel('test', undefined, '', [tupleValueModel]);
-      const type = PythonDefaultTypeMapping.Tuple({constrainedModel: model, options: PythonGenerator.defaultOptions});
+      const type = PythonDefaultTypeMapping.Tuple({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('tuple[str]');
     });
     test('should render multiple tuple types', () => {
@@ -66,7 +68,7 @@ describe('PythonConstrainer', () => {
       const tupleValueModel0 = new ConstrainedTupleValueModel(0, stringModel);
       const tupleValueModel1 = new ConstrainedTupleValueModel(1, stringModel);
       const model = new ConstrainedTupleModel('test', undefined, '', [tupleValueModel0, tupleValueModel1]);
-      const type = PythonDefaultTypeMapping.Tuple({constrainedModel: model, options: PythonGenerator.defaultOptions});
+      const type = PythonDefaultTypeMapping.Tuple({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('tuple[str, str]');
     });
   });
@@ -75,7 +77,7 @@ describe('PythonConstrainer', () => {
     test('should render type', () => {
       const arrayModel = new ConstrainedStringModel('test', undefined, 'str');
       const model = new ConstrainedArrayModel('test', undefined, '', arrayModel);
-      const type = PythonDefaultTypeMapping.Array({ constrainedModel: model, options: PythonGenerator.defaultOptions });
+      const type = PythonDefaultTypeMapping.Array({ constrainedModel: model, ...defaultOptions });
       expect(type).toEqual('list[str]');
     });
   });
@@ -83,7 +85,7 @@ describe('PythonConstrainer', () => {
   describe('Enum', () => {
     test('should render the constrained name as type', () => {
       const model = new ConstrainedEnumModel('Test', undefined, '', []);
-      const type = PythonDefaultTypeMapping.Enum({ constrainedModel: model, options: PythonGenerator.defaultOptions });
+      const type = PythonDefaultTypeMapping.Enum({ constrainedModel: model, ...defaultOptions });
       expect(type).toEqual(model.name);
     });
   });
@@ -92,14 +94,14 @@ describe('PythonConstrainer', () => {
     test('should render type', () => {
       const unionModel = new ConstrainedStringModel('test', undefined, 'str');
       const model = new ConstrainedUnionModel('test', undefined, '', [unionModel]);
-      const type = PythonDefaultTypeMapping.Union({constrainedModel: model, options: PythonGenerator.defaultOptions});
+      const type = PythonDefaultTypeMapping.Union({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('str');
     });
     test('should render multiple types', () => {
       const unionModel1 = new ConstrainedStringModel('test', undefined, 'str');
       const unionModel2 = new ConstrainedStringModel('test', undefined, 'str');
       const model = new ConstrainedUnionModel('test', undefined, '', [unionModel1, unionModel2]);
-      const type = PythonDefaultTypeMapping.Union({constrainedModel: model, options: PythonGenerator.defaultOptions});
+      const type = PythonDefaultTypeMapping.Union({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('str | str');
     });
   });
@@ -109,7 +111,7 @@ describe('PythonConstrainer', () => {
       const keyModel = new ConstrainedStringModel('test', undefined, 'str');
       const valueModel = new ConstrainedStringModel('test', undefined, 'str');
       const model = new ConstrainedDictionaryModel('test', undefined, '', keyModel, valueModel);
-      const type = PythonDefaultTypeMapping.Dictionary({ constrainedModel: model, options: PythonGenerator.defaultOptions });
+      const type = PythonDefaultTypeMapping.Dictionary({ constrainedModel: model, ...defaultOptions });
       expect(type).toEqual('dict[str, str]');
     });
   });

--- a/test/generators/python/PythonRenderer.spec.ts
+++ b/test/generators/python/PythonRenderer.spec.ts
@@ -1,4 +1,5 @@
 import { PythonGenerator } from '../../../src/generators/python';
+import { PythonDependencyManager } from '../../../src/generators/python/PythonDependencyManager';
 import { PythonRenderer } from '../../../src/generators/python/PythonRenderer';
 import { ConstrainedObjectModel, InputMetaModel } from '../../../src/models';
 import { MockPythonRenderer } from '../../TestUtils/TestRenderers';
@@ -6,7 +7,7 @@ import { MockPythonRenderer } from '../../TestUtils/TestRenderers';
 describe('PythonRenderer', () => {
   let renderer: PythonRenderer<any>;
   beforeEach(() => {
-    renderer = new MockPythonRenderer(PythonGenerator.defaultOptions, new PythonGenerator(), [], new ConstrainedObjectModel('', undefined, '', {}), new InputMetaModel());
+    renderer = new MockPythonRenderer(PythonGenerator.defaultOptions, new PythonGenerator(), [], new ConstrainedObjectModel('', undefined, '', {}), new InputMetaModel(), new PythonDependencyManager(PythonGenerator.defaultOptions));
   });
 
   describe('renderComments()', () => {


### PR DESCRIPTION
**Description**
This PR adds the new dependency manager alongside a few changes:
- Allow the user to add dependencies for each model in the constraint and presets phase.
- As a side effect of the implementation, this enables the user to selectively overwrite options so you do not have to create a new generator instance all the time. 

These changes currently live on the `dependency_-manager` (wups) branch and are a WIP until all generators are adapted, that is why the tests are failing. 

**Related issue(s)**
Read more about the change here: https://github.com/asyncapi/modelina/pull/947
Fixes: https://github.com/asyncapi/modelina/issues/851