### PR TITLE
chore: add dependency manager for Go

### DIFF
--- a/src/generators/go/GoConstrainer.ts
+++ b/src/generators/go/GoConstrainer.ts
@@ -1,10 +1,10 @@
-import { Constraints, TypeMapping } from '../../helpers';
+import { Constraints } from '../../helpers';
 import { defaultEnumKeyConstraints, defaultEnumValueConstraints } from './constrainer/EnumConstrainer';
 import { defaultModelNameConstraints } from './constrainer/ModelNameConstrainer';
 import { defaultPropertyKeyConstraints } from './constrainer/PropertyKeyConstrainer';
-import { GoOptions } from './GoGenerator';
+import { GoTypeMapping } from './GoGenerator';
 
-export const GoDefaultTypeMapping: TypeMapping<GoOptions> = {
+export const GoDefaultTypeMapping: GoTypeMapping = {
   Object ({constrainedModel}): string {
     return constrainedModel.name;
   },

--- a/src/generators/go/GoDependencyManager.ts
+++ b/src/generators/go/GoDependencyManager.ts
@@ -1,0 +1,11 @@
+import { AbstractDependencyManager } from '../AbstractDependencyManager';
+import { GoOptions } from './GoGenerator';
+
+export class GoDependencyManager extends AbstractDependencyManager {
+  constructor(
+    public options: GoOptions,
+    dependencies: string[] = []
+  ) {
+    super(dependencies);
+  }
+}

--- a/src/generators/go/GoGenerator.ts
+++ b/src/generators/go/GoGenerator.ts
@@ -4,16 +4,18 @@ import {
   defaultGeneratorOptions
 } from '../AbstractGenerator';
 import { InputMetaModel, RenderOutput, ConstrainedObjectModel, ConstrainedEnumModel, ConstrainedMetaModel, MetaModel } from '../../models';
-import { constrainMetaModel, Constraints, split, TypeMapping } from '../../helpers';
+import { constrainMetaModel, Constraints, split, SplitOptions, TypeMapping } from '../../helpers';
 import { GoPreset, GO_DEFAULT_PRESET } from './GoPreset';
 import { StructRenderer } from './renderers/StructRenderer';
 import { EnumRenderer } from './renderers/EnumRenderer';
 import { Logger } from '../../utils/LoggingInterface';
 import { GoDefaultConstraints, GoDefaultTypeMapping } from './GoConstrainer';
 import { DeepPartial, mergePartialAndDefault } from '../../utils/Partials';
+import { GoDependencyManager } from './GoDependencyManager';
+export type GoTypeMapping = TypeMapping<GoOptions, GoDependencyManager>;
 
 export interface GoOptions extends CommonGeneratorOptions<GoPreset> {
-  typeMapping: TypeMapping<GoOptions>;
+  typeMapping: GoTypeMapping;
   constraints: Constraints
 }
 
@@ -32,6 +34,11 @@ export class GoGenerator extends AbstractGenerator<GoOptions, GoRenderCompleteMo
     constraints: GoDefaultConstraints
   };
 
+  static defaultCompleteModelOptions: GoRenderCompleteModelOptions = {
+    packageName: 'AsyncapiModels'
+  };
+
+
   constructor(
     options?: DeepPartial<GoOptions>,
   ) {
@@ -39,32 +46,55 @@ export class GoGenerator extends AbstractGenerator<GoOptions, GoRenderCompleteMo
     super('Go', realizedOptions);
   }
 
+  /**
+   * Returns the Go options by merging custom options with default ones.
+   */
+   static getGoOptions(options?: DeepPartial<GoOptions>): GoOptions {
+    const optionsToUse = mergePartialAndDefault(GoGenerator.defaultOptions, options) as GoOptions;
+    //Always overwrite the dependency manager unless user explicitly state they want it (ignore default temporary dependency manager)
+    if (options?.dependencyManager === undefined) {
+      optionsToUse.dependencyManager = () => { return new GoDependencyManager(optionsToUse); };
+    }
+    return optionsToUse;
+  }
+
+  /**
+   * Wrapper to get an instance of the dependency manager
+   */
+  getGoDependencyManager(options: GoOptions): GoDependencyManager {
+    return this.getDependencyManagerInstance(options) as GoDependencyManager;
+  }
+
   splitMetaModel(model: MetaModel): MetaModel[] {
     //These are the models that we have separate renderers for
-    const metaModelsToSplit = {
+    const metaModelsToSplit: SplitOptions = {
       splitEnum: true, 
       splitObject: true
     };
     return split(model, metaModelsToSplit);
   }
 
-  constrainToMetaModel(model: MetaModel): ConstrainedMetaModel {
-    return constrainMetaModel<GoOptions>(
+  constrainToMetaModel(model: MetaModel, options: DeepPartial<GoOptions>): ConstrainedMetaModel {
+    const optionsToUse = GoGenerator.getGoOptions({...this.options, ...options});
+    const dependencyManagerToUse = this.getGoDependencyManager(optionsToUse);
+    return constrainMetaModel<GoOptions, GoDependencyManager>(
       this.options.typeMapping, 
       this.options.constraints, 
       {
         metaModel: model,
+        dependencyManager: dependencyManagerToUse,
         options: this.options,
         constrainedName: '' //This is just a placeholder, it will be constrained within the function
       }
     );
   }
 
-  render(model: ConstrainedMetaModel, inputModel: InputMetaModel): Promise<RenderOutput> {
+  render(model: ConstrainedMetaModel, inputModel: InputMetaModel, options?: DeepPartial<GoOptions>): Promise<RenderOutput> {
+    const optionsToUse = GoGenerator.getGoOptions({...this.options, ...options});
     if (model instanceof ConstrainedObjectModel) {
-      return this.renderStruct(model, inputModel);
+      return this.renderStruct(model, inputModel, optionsToUse);
     } else if (model instanceof ConstrainedEnumModel) {
-      return this.renderEnum(model, inputModel);
+      return this.renderEnum(model, inputModel, optionsToUse);
     } 
     Logger.warn(`Go generator, cannot generate this type of model, ${model.name}`);
     return Promise.resolve(RenderOutput.toRenderOutput({ result: '', renderedName: '', dependencies: [] }));
@@ -77,8 +107,14 @@ export class GoGenerator extends AbstractGenerator<GoOptions, GoRenderCompleteMo
    * @param inputModel
    * @param options
    */
-  async renderCompleteModel(model: ConstrainedMetaModel, inputModel: InputMetaModel, options: GoRenderCompleteModelOptions): Promise<RenderOutput> {
-    const outputModel = await this.render(model, inputModel);
+  async renderCompleteModel(
+    model: ConstrainedMetaModel, 
+    inputModel: InputMetaModel, 
+    completeModelOptions: Partial<GoRenderCompleteModelOptions>,
+    options: DeepPartial<GoOptions>): Promise<RenderOutput> {
+    const completeModelOptionsToUse = mergePartialAndDefault(GoGenerator.defaultCompleteModelOptions, completeModelOptions) as GoRenderCompleteModelOptions;
+    const optionsToUse = GoGenerator.getGoOptions({...this.options, ...options});
+    const outputModel = await this.render(model, inputModel, optionsToUse);
     let importCode = '';
     if (outputModel.dependencies.length > 0) {
       const dependencies = outputModel.dependencies.map((dependency) => { return `"${dependency}"`; }).join('\n');
@@ -87,23 +123,27 @@ export class GoGenerator extends AbstractGenerator<GoOptions, GoRenderCompleteMo
 )`;
     }
     const outputContent = `
-package ${options.packageName}
+package ${completeModelOptionsToUse.packageName}
 ${importCode}
 ${outputModel.result}`;
     return RenderOutput.toRenderOutput({ result: outputContent, renderedName: outputModel.renderedName, dependencies: outputModel.dependencies });
   }
 
-  async renderEnum(model: ConstrainedEnumModel, inputModel: InputMetaModel): Promise<RenderOutput> {
+  async renderEnum(model: ConstrainedEnumModel, inputModel: InputMetaModel, options?: DeepPartial<GoOptions>): Promise<RenderOutput> {
+    const optionsToUse = GoGenerator.getGoOptions({...this.options, ...options});
+    const dependencyManagerToUse = this.getGoDependencyManager(optionsToUse);
     const presets = this.getPresets('enum');
-    const renderer = new EnumRenderer(this.options, this, presets, model, inputModel);
+    const renderer = new EnumRenderer(optionsToUse, this, presets, model, inputModel, dependencyManagerToUse);
     const result = await renderer.runSelfPreset();
-    return RenderOutput.toRenderOutput({ result, renderedName: model.name, dependencies: renderer.dependencies });
+    return RenderOutput.toRenderOutput({ result, renderedName: model.name, dependencies: dependencyManagerToUse.dependencies });
   }
 
-  async renderStruct(model: ConstrainedObjectModel, inputModel: InputMetaModel): Promise<RenderOutput> {
+  async renderStruct(model: ConstrainedObjectModel, inputModel: InputMetaModel, options?: DeepPartial<GoOptions>): Promise<RenderOutput> {
+    const optionsToUse = GoGenerator.getGoOptions({...this.options, ...options});
+    const dependencyManagerToUse = this.getGoDependencyManager(optionsToUse);
     const presets = this.getPresets('struct');
-    const renderer = new StructRenderer(this.options, this, presets, model, inputModel);
+    const renderer = new StructRenderer(optionsToUse, this, presets, model, inputModel, dependencyManagerToUse);
     const result = await renderer.runSelfPreset();
-    return RenderOutput.toRenderOutput({ result, renderedName: model.name, dependencies: renderer.dependencies });
+    return RenderOutput.toRenderOutput({ result, renderedName: model.name, dependencies: dependencyManagerToUse.dependencies });
   }
 }

--- a/src/generators/go/GoRenderer.ts
+++ b/src/generators/go/GoRenderer.ts
@@ -2,6 +2,7 @@ import { AbstractRenderer } from '../AbstractRenderer';
 import { GoGenerator, GoOptions } from './GoGenerator';
 import { InputMetaModel, Preset, ConstrainedMetaModel } from '../../models';
 import { FormatHelpers } from '../../helpers/FormatHelpers';
+import { GoDependencyManager } from './GoDependencyManager';
 
 /**
  * Common renderer for Go types
@@ -15,6 +16,7 @@ export abstract class GoRenderer<RendererModelType extends ConstrainedMetaModel>
     presets: Array<[Preset, unknown]>,
     model: RendererModelType,
     inputModel: InputMetaModel,
+    public dependencyManager: GoDependencyManager
   ) {
     super(options, generator, presets, model, inputModel);
   }

--- a/test/generators/go/GoConstrainer.spec.ts
+++ b/test/generators/go/GoConstrainer.spec.ts
@@ -1,10 +1,12 @@
 import {GoDefaultTypeMapping } from '../../../src/generators/go/GoConstrainer';
 import { ConstrainedAnyModel, ConstrainedArrayModel, ConstrainedBooleanModel, ConstrainedDictionaryModel, ConstrainedEnumModel, ConstrainedFloatModel, ConstrainedIntegerModel, ConstrainedObjectModel, ConstrainedReferenceModel, ConstrainedStringModel, ConstrainedTupleModel, ConstrainedUnionModel, GoGenerator } from '../../../src';
+import { GoDependencyManager } from '../../../src/generators/go/GoDependencyManager';
 describe('GoConstrainer', () => {
+  const defaultOptions = {options: GoGenerator.defaultOptions, dependencyManager: new GoDependencyManager(GoGenerator.defaultOptions)};
   describe('ObjectModel', () => { 
     test('should render the constrained name as type', () => {
       const model = new ConstrainedObjectModel('test', undefined, '', {});
-      const type = GoDefaultTypeMapping.Object({constrainedModel: model, options: GoGenerator.defaultOptions});
+      const type = GoDefaultTypeMapping.Object({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual(model.name);
     });
   });
@@ -12,42 +14,42 @@ describe('GoConstrainer', () => {
     test('should render the constrained name as type', () => {
       const refModel = new ConstrainedAnyModel('test', undefined, '');
       const model = new ConstrainedReferenceModel('test', undefined, '', refModel);
-      const type = GoDefaultTypeMapping.Reference({constrainedModel: model, options: GoGenerator.defaultOptions});
+      const type = GoDefaultTypeMapping.Reference({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual(model.name);
     });
   });
   describe('Any', () => { 
     test('should render type', () => {
       const model = new ConstrainedAnyModel('test', undefined, '');
-      const type = GoDefaultTypeMapping.Any({constrainedModel: model, options: GoGenerator.defaultOptions});
+      const type = GoDefaultTypeMapping.Any({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('interface{}');
     });
   });
   describe('Float', () => { 
     test('should render type', () => {
       const model = new ConstrainedFloatModel('test', undefined, '');
-      const type = GoDefaultTypeMapping.Float({constrainedModel: model, options: GoGenerator.defaultOptions});
+      const type = GoDefaultTypeMapping.Float({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('float64');
     });
   });
   describe('Integer', () => { 
     test('should render type', () => {
       const model = new ConstrainedIntegerModel('test', undefined, '');
-      const type = GoDefaultTypeMapping.Integer({constrainedModel: model, options: GoGenerator.defaultOptions});
+      const type = GoDefaultTypeMapping.Integer({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('int');
     });
   });
   describe('String', () => { 
     test('should render type', () => {
       const model = new ConstrainedStringModel('test', undefined, '');
-      const type = GoDefaultTypeMapping.String({constrainedModel: model, options: GoGenerator.defaultOptions});
+      const type = GoDefaultTypeMapping.String({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('string');
     });
   });
   describe('Boolean', () => { 
     test('should render type', () => {
       const model = new ConstrainedBooleanModel('test', undefined, '');
-      const type = GoDefaultTypeMapping.Boolean({constrainedModel: model, options: GoGenerator.defaultOptions});
+      const type = GoDefaultTypeMapping.Boolean({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('bool');
     });
   });
@@ -55,7 +57,7 @@ describe('GoConstrainer', () => {
   describe('Tuple', () => { 
     test('should render type', () => {
       const model = new ConstrainedTupleModel('test', undefined, '', []);
-      const type = GoDefaultTypeMapping.Tuple({constrainedModel: model, options: GoGenerator.defaultOptions});
+      const type = GoDefaultTypeMapping.Tuple({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('[]interface{}');
     });
   });
@@ -64,7 +66,7 @@ describe('GoConstrainer', () => {
     test('should render type', () => {
       const arrayModel = new ConstrainedStringModel('test', undefined, 'string');
       const model = new ConstrainedArrayModel('test', undefined, '', arrayModel);
-      const type = GoDefaultTypeMapping.Array({constrainedModel: model, options: GoGenerator.defaultOptions});
+      const type = GoDefaultTypeMapping.Array({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('[]string');
     });
   });
@@ -72,7 +74,7 @@ describe('GoConstrainer', () => {
   describe('Enum', () => { 
     test('should render the constrained name as type', () => {
       const model = new ConstrainedEnumModel('test', undefined, '', []);
-      const type = GoDefaultTypeMapping.Enum({constrainedModel: model, options: GoGenerator.defaultOptions});
+      const type = GoDefaultTypeMapping.Enum({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual(model.name);
     });
   });
@@ -80,7 +82,7 @@ describe('GoConstrainer', () => {
   describe('Union', () => { 
     test('should render type', () => {
       const model = new ConstrainedUnionModel('test', undefined, '', []);
-      const type = GoDefaultTypeMapping.Union({constrainedModel: model, options: GoGenerator.defaultOptions});
+      const type = GoDefaultTypeMapping.Union({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('interface{}');
     });
   });
@@ -90,7 +92,7 @@ describe('GoConstrainer', () => {
       const keyModel = new ConstrainedStringModel('test', undefined, 'string');
       const valueModel = new ConstrainedStringModel('test', undefined, 'string');
       const model = new ConstrainedDictionaryModel('test', undefined, '', keyModel, valueModel);
-      const type = GoDefaultTypeMapping.Dictionary({constrainedModel: model, options: GoGenerator.defaultOptions});
+      const type = GoDefaultTypeMapping.Dictionary({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('map[string]string');
     });
   });

--- a/test/generators/go/GoRenderer.spec.ts
+++ b/test/generators/go/GoRenderer.spec.ts
@@ -1,3 +1,4 @@
+import { GoDependencyManager } from '../../../src/generators/go/GoDependencyManager';
 import { GoGenerator } from '../../../src/generators/go/GoGenerator';
 import { GoRenderer } from '../../../src/generators/go/GoRenderer';
 import { ConstrainedObjectModel, InputMetaModel } from '../../../src/models';
@@ -6,7 +7,7 @@ import { MockGoRenderer } from '../../TestUtils/TestRenderers';
 describe('GoRenderer', () => {
   let renderer: GoRenderer<any>;
   beforeEach(() => {
-    renderer = new MockGoRenderer(GoGenerator.defaultOptions, new GoGenerator(), [], new ConstrainedObjectModel('', undefined, '', {}), new InputMetaModel());
+    renderer = new MockGoRenderer(GoGenerator.defaultOptions, new GoGenerator(), [], new ConstrainedObjectModel('', undefined, '', {}), new InputMetaModel(), new GoDependencyManager(GoGenerator.defaultOptions));
   });
   describe('renderComments()', () => {
     test('should render single lines correctly', () => {


### PR DESCRIPTION
**Description**
This PR adds the new dependency manager alongside a few changes:
- Allow the user to add dependencies for each model in the constraint and presets phase.
- As a side effect of the implementation, this enables the user to selectively overwrite options so you do not have to create a new generator instance all the time. 

These changes currently live on the `dependency_-manager` (wups) branch and are a WIP until all generators are adapted, that is why the tests are failing. 

**Related issue(s)**
Read more about the change here: https://github.com/asyncapi/modelina/pull/947
Fixes: https://github.com/asyncapi/modelina/issues/851