### PR TITLE
chore: add dependency manager for Dart

### DIFF
--- a/src/generators/dart/DartConstrainer.ts
+++ b/src/generators/dart/DartConstrainer.ts
@@ -1,10 +1,9 @@
-import { TypeMapping } from '../../helpers';
 import { defaultEnumKeyConstraints, defaultEnumValueConstraints } from './constrainer/EnumConstrainer';
 import { defaultModelNameConstraints } from './constrainer/ModelNameConstrainer';
 import { defaultPropertyKeyConstraints } from './constrainer/PropertyKeyConstrainer';
-import { DartOptions } from './DartGenerator';
+import { DartTypeMapping } from './DartGenerator';
 
-export const DartDefaultTypeMapping: TypeMapping<DartOptions> = {
+export const DartDefaultTypeMapping: DartTypeMapping = {
   Object ({constrainedModel}): string {
     return constrainedModel.name;
   },

--- a/src/generators/dart/DartDependencyManager.ts
+++ b/src/generators/dart/DartDependencyManager.ts
@@ -1,0 +1,11 @@
+import { AbstractDependencyManager } from '../AbstractDependencyManager';
+import { DartOptions } from './DartGenerator';
+
+export class DartDependencyManager extends AbstractDependencyManager {
+  constructor(
+    public options: DartOptions,
+    dependencies: string[] = []
+  ) {
+    super(dependencies);
+  }
+}

--- a/src/generators/dart/DartGenerator.ts
+++ b/src/generators/dart/DartGenerator.ts
@@ -4,7 +4,7 @@ import {
   defaultGeneratorOptions
 } from '../AbstractGenerator';
 import {RenderOutput, ConstrainedMetaModel, MetaModel, ConstrainedObjectModel, ConstrainedEnumModel, InputMetaModel} from '../../models';
-import {constrainMetaModel, Constraints, split, TypeMapping} from '../../helpers';
+import {constrainMetaModel, Constraints, split, SplitOptions, TypeMapping} from '../../helpers';
 import {DartPreset, DART_DEFAULT_PRESET} from './DartPreset';
 import {ClassRenderer} from './renderers/ClassRenderer';
 import {EnumRenderer} from './renderers/EnumRenderer';
@@ -13,10 +13,11 @@ import {Logger} from '../../';
 import {FormatHelpers} from '../../helpers/FormatHelpers';
 import { DartDefaultConstraints, DartDefaultTypeMapping } from './DartConstrainer';
 import { DeepPartial, mergePartialAndDefault } from '../../utils/Partials';
-
+import { DartDependencyManager } from './DartDependencyManager';
+export type DartTypeMapping = TypeMapping<DartOptions, DartDependencyManager>;
 export interface DartOptions extends CommonGeneratorOptions<DartPreset> {
   collectionType?: 'List';
-  typeMapping: TypeMapping<DartOptions>;
+  typeMapping: DartTypeMapping;
   constraints: Constraints;
 }
 
@@ -32,6 +33,10 @@ export class DartGenerator extends AbstractGenerator<DartOptions, DartRenderComp
     typeMapping: DartDefaultTypeMapping,
     constraints: DartDefaultConstraints
   };
+  
+  static defaultCompleteModelOptions: DartRenderCompleteModelOptions = {
+    packageName: 'AsyncapiModels'
+  };
 
   constructor(
     options?: DeepPartial<DartOptions>,
@@ -40,21 +45,44 @@ export class DartGenerator extends AbstractGenerator<DartOptions, DartRenderComp
     super('Dart', realizedOptions);
   }
 
+
+  /**
+   * Returns the Dart options by merging custom options with default ones.
+   */
+   static getDartOptions(options?: DeepPartial<DartOptions>): DartOptions {
+    const optionsToUse = mergePartialAndDefault(DartGenerator.defaultOptions, options) as DartOptions;
+    //Always overwrite the dependency manager unless user explicitly state they want it (ignore default temporary dependency manager)
+    if (options?.dependencyManager === undefined) {
+      optionsToUse.dependencyManager = () => { return new DartDependencyManager(optionsToUse); };
+    }
+    return optionsToUse;
+  }
+
+  /**
+   * Wrapper to get an instance of the dependency manager
+   */
+  getDartDependencyManager(options: DartOptions): DartDependencyManager {
+    return this.getDependencyManagerInstance(options) as DartDependencyManager;
+  }
+
   splitMetaModel(model: MetaModel): MetaModel[] {
     //These are the models that we have separate renderers for
-    const metaModelsToSplit = {
+    const metaModelsToSplit: SplitOptions = {
       splitEnum: true, 
       splitObject: true
     };
     return split(model, metaModelsToSplit);
   }
 
-  constrainToMetaModel(model: MetaModel): ConstrainedMetaModel {
-    return constrainMetaModel<DartOptions>(
+  constrainToMetaModel(model: MetaModel, options: DeepPartial<DartOptions>): ConstrainedMetaModel {
+    const optionsToUse = DartGenerator.getDartOptions({...this.options, ...options});
+    const dependencyManagerToUse = this.getDartDependencyManager(optionsToUse);
+    return constrainMetaModel<DartOptions, DartDependencyManager>(
       this.options.typeMapping, 
       this.options.constraints, 
       {
         metaModel: model,
+        dependencyManager: dependencyManagerToUse,
         options: this.options,
         constrainedName: '' //This is just a placeholder, it will be constrained within the function
       }
@@ -66,11 +94,12 @@ export class DartGenerator extends AbstractGenerator<DartOptions, DartRenderComp
    * @param model
    * @param inputModel
    */
-  render(model: ConstrainedMetaModel, inputModel: InputMetaModel): Promise<RenderOutput> {
+  render(model: ConstrainedMetaModel, inputModel: InputMetaModel, options?: DeepPartial<DartOptions>): Promise<RenderOutput> {
+    const optionsToUse = DartGenerator.getDartOptions({...this.options, ...options});
     if (model instanceof ConstrainedObjectModel) {
-      return this.renderClass(model, inputModel);
+      return this.renderClass(model, inputModel, optionsToUse);
     } else if (model instanceof ConstrainedEnumModel) {
-      return this.renderEnum(model, inputModel);
+      return this.renderEnum(model, inputModel, optionsToUse);
     } 
     Logger.warn(`Dart generator, cannot generate this type of model, ${model.name}`);
     return Promise.resolve(RenderOutput.toRenderOutput({result: '', renderedName: '', dependencies: []}));
@@ -85,14 +114,21 @@ export class DartGenerator extends AbstractGenerator<DartOptions, DartRenderComp
    * @param inputModel
    * @param options used to render the full output
    */
-  async renderCompleteModel(model: ConstrainedMetaModel, inputModel: InputMetaModel, options: DartRenderCompleteModelOptions): Promise<RenderOutput> {
-    if (isReservedDartKeyword(options.packageName)) {
-      throw new Error(`You cannot use reserved Dart keyword (${options.packageName}) as package name, please use another.`);
+  async renderCompleteModel(
+    model: ConstrainedMetaModel, 
+    inputModel: InputMetaModel, 
+    completeModelOptions: Partial<DartRenderCompleteModelOptions>,
+    options: DeepPartial<DartOptions>): Promise<RenderOutput> {
+    const completeModelOptionsToUse = mergePartialAndDefault(DartGenerator.defaultCompleteModelOptions, completeModelOptions) as DartRenderCompleteModelOptions;
+    const optionsToUse = DartGenerator.getDartOptions({...this.options, ...options});
+    const dependencyManagerToUse = this.getDartDependencyManager(optionsToUse);
+    if (isReservedDartKeyword(completeModelOptionsToUse.packageName)) {
+      throw new Error(`You cannot use reserved Dart keyword (${completeModelOptionsToUse.packageName}) as package name, please use another.`);
     }
 
-    const outputModel = await this.render(model, inputModel);
+    const outputModel = await this.render(model, inputModel, optionsToUse);
     const modelDependencies = model.getNearestDependencies().map((dependencyModelName) => {
-      return `import 'package:${options.packageName}/${FormatHelpers.snakeCase(dependencyModelName.name)}.dart';`;
+      return `import 'package:${completeModelOptionsToUse.packageName}/${FormatHelpers.snakeCase(dependencyModelName.name)}.dart';`;
     });
     const outputContent = `${modelDependencies.join('\n')}
       ${outputModel.dependencies.join('\n')}
@@ -104,17 +140,21 @@ export class DartGenerator extends AbstractGenerator<DartOptions, DartRenderComp
     });
   }
 
-  async renderClass(model: ConstrainedObjectModel, inputModel: InputMetaModel): Promise<RenderOutput> {
+  async renderClass(model: ConstrainedObjectModel, inputModel: InputMetaModel, options?: DeepPartial<DartOptions>): Promise<RenderOutput> {
+    const optionsToUse = DartGenerator.getDartOptions({...this.options, ...options});
+    const dependencyManagerToUse = this.getDartDependencyManager(optionsToUse);
     const presets = this.getPresets('class');
-    const renderer = new ClassRenderer(this.options, this, presets, model, inputModel);
+    const renderer = new ClassRenderer(optionsToUse, this, presets, model, inputModel, dependencyManagerToUse);
     const result = await renderer.runSelfPreset();
-    return RenderOutput.toRenderOutput({result, renderedName: model.name, dependencies: renderer.dependencies});
+    return RenderOutput.toRenderOutput({result, renderedName: model.name, dependencies: dependencyManagerToUse.dependencies});
   }
 
-  async renderEnum(model: ConstrainedEnumModel, inputModel: InputMetaModel): Promise<RenderOutput> {
+  async renderEnum(model: ConstrainedEnumModel, inputModel: InputMetaModel, options?: DeepPartial<DartOptions>): Promise<RenderOutput> {
+    const optionsToUse = DartGenerator.getDartOptions({...this.options, ...options});
+    const dependencyManagerToUse = this.getDartDependencyManager(optionsToUse);
     const presets = this.getPresets('enum');
-    const renderer = new EnumRenderer(this.options, this, presets, model, inputModel);
+    const renderer = new EnumRenderer(optionsToUse, this, presets, model, inputModel, dependencyManagerToUse);
     const result = await renderer.runSelfPreset();
-    return RenderOutput.toRenderOutput({result, renderedName: model.name, dependencies: renderer.dependencies});
+    return RenderOutput.toRenderOutput({result, renderedName: model.name, dependencies: dependencyManagerToUse.dependencies});
   }
 }

--- a/src/generators/dart/DartRenderer.ts
+++ b/src/generators/dart/DartRenderer.ts
@@ -2,6 +2,7 @@ import { AbstractRenderer } from '../AbstractRenderer';
 import { DartGenerator, DartOptions } from './DartGenerator';
 import { Preset, ConstrainedMetaModel, InputMetaModel } from '../../models';
 import { FormatHelpers } from '../../helpers';
+import { DartDependencyManager } from './DartDependencyManager';
 
 /**
  * Common renderer for Dart types
@@ -15,6 +16,7 @@ export abstract class DartRenderer<RendererModelType extends ConstrainedMetaMode
     presets: Array<[Preset, unknown]>,
     model: RendererModelType, 
     inputModel: InputMetaModel,
+    public dependencyManager: DartDependencyManager
   ) {
     super(options, generator, presets, model, inputModel);
   }

--- a/src/generators/dart/presets/JsonSerializablePreset.ts
+++ b/src/generators/dart/presets/JsonSerializablePreset.ts
@@ -10,9 +10,9 @@ export const DART_JSON_PRESET: DartPreset = {
   class: {
     self({renderer, model, content}) {
       const snakeformattedModelName = FormatHelpers.snakeCase(model.name);
-      renderer.addDependency('import \'package:json_annotation/json_annotation.dart\';');
-      renderer.addDependency(`part '${snakeformattedModelName}.g.dart';`);
-      renderer.addDependency('@JsonSerializable()');
+      renderer.dependencyManager.addDependency('import \'package:json_annotation/json_annotation.dart\';');
+      renderer.dependencyManager.addDependency(`part '${snakeformattedModelName}.g.dart';`);
+      renderer.dependencyManager.addDependency('@JsonSerializable()');
       return content;
     },
     additionalContent({model}) {
@@ -23,9 +23,9 @@ Map<String, dynamic> toJson() => _$${model.name}ToJson(this);`;
   enum: {
     self({renderer, model, content}) {
       const snakeformattedModelName = FormatHelpers.snakeCase(model.name);
-      renderer.addDependency('import \'package:json_annotation/json_annotation.dart\';');
-      renderer.addDependency(`part '${snakeformattedModelName}.g.dart';`);
-      renderer.addDependency('@JsonEnum(alwaysCreate:true)');
+      renderer.dependencyManager.addDependency('import \'package:json_annotation/json_annotation.dart\';');
+      renderer.dependencyManager.addDependency(`part '${snakeformattedModelName}.g.dart';`);
+      renderer.dependencyManager.addDependency('@JsonEnum(alwaysCreate:true)');
       return content;
     },
   }

--- a/test/generators/dart/DartConstrainer.spec.ts
+++ b/test/generators/dart/DartConstrainer.spec.ts
@@ -1,12 +1,14 @@
-import { DartGenerator } from '../../../src/generators';
+import { DartGenerator, DartOptions } from '../../../src/generators';
 import { DartDefaultTypeMapping } from '../../../src/generators/dart/DartConstrainer';
+import { DartDependencyManager } from '../../../src/generators/dart/DartDependencyManager';
 import { ConstrainedAnyModel, ConstrainedArrayModel, ConstrainedBooleanModel, ConstrainedDictionaryModel, ConstrainedEnumModel, ConstrainedFloatModel, ConstrainedIntegerModel, ConstrainedObjectModel, ConstrainedReferenceModel, ConstrainedStringModel, ConstrainedTupleModel, ConstrainedUnionModel, InputMetaModel } from '../../../src/models';
 
-describe('DartRenderer', () => {
+describe('DartConstrainer', () => {
+  const defaultOptions = {options: DartGenerator.defaultOptions, dependencyManager: new DartDependencyManager(DartGenerator.defaultOptions)};
   describe('ObjectModel', () => { 
     test('should render the constrained name as type', () => {
       const model = new ConstrainedObjectModel('test', undefined, '', {});
-      const type = DartDefaultTypeMapping.Object({constrainedModel: model, options: DartGenerator.defaultOptions});
+      const type = DartDefaultTypeMapping.Object({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual(model.name);
     });
   });
@@ -14,42 +16,42 @@ describe('DartRenderer', () => {
     test('should render the constrained name as type', () => {
       const refModel = new ConstrainedAnyModel('test', undefined, '');
       const model = new ConstrainedReferenceModel('test', undefined, '', refModel);
-      const type = DartDefaultTypeMapping.Reference({constrainedModel: model, options: DartGenerator.defaultOptions});
+      const type = DartDefaultTypeMapping.Reference({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual(model.name);
     });
   });
   describe('Any', () => { 
     test('should render type', () => {
       const model = new ConstrainedAnyModel('test', undefined, '');
-      const type = DartDefaultTypeMapping.Any({constrainedModel: model, options: DartGenerator.defaultOptions});
+      const type = DartDefaultTypeMapping.Any({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('Object');
     });
   });
   describe('Float', () => { 
     test('should render type', () => {
       const model = new ConstrainedFloatModel('test', undefined, '');
-      const type = DartDefaultTypeMapping.Float({constrainedModel: model, options: DartGenerator.defaultOptions});
+      const type = DartDefaultTypeMapping.Float({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('double');
     });
   });
   describe('Integer', () => { 
     test('should render type', () => {
       const model = new ConstrainedIntegerModel('test', undefined, '');
-      const type = DartDefaultTypeMapping.Integer({constrainedModel: model, options: DartGenerator.defaultOptions});
+      const type = DartDefaultTypeMapping.Integer({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('int');
     });
   });
   describe('String', () => { 
     test('should render type', () => {
       const model = new ConstrainedStringModel('test', undefined, '');
-      const type = DartDefaultTypeMapping.String({constrainedModel: model, options: DartGenerator.defaultOptions});
+      const type = DartDefaultTypeMapping.String({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('String');
     });
   });
   describe('Boolean', () => { 
     test('should render type', () => {
       const model = new ConstrainedBooleanModel('test', undefined, '');
-      const type = DartDefaultTypeMapping.Boolean({constrainedModel: model, options: DartGenerator.defaultOptions});
+      const type = DartDefaultTypeMapping.Boolean({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('bool');
     });
   });
@@ -57,12 +59,14 @@ describe('DartRenderer', () => {
   describe('Tuple', () => { 
     test('should render default type', () => {
       const model = new ConstrainedTupleModel('test', undefined, '', []);
-      const type = DartDefaultTypeMapping.Tuple({constrainedModel: model, options: {...DartGenerator.defaultOptions}});
+      const optionsToUse: DartOptions = {...DartGenerator.defaultOptions};
+      const type = DartDefaultTypeMapping.Tuple({constrainedModel: model, options: optionsToUse, dependencyManager: new DartDependencyManager(optionsToUse)});
       expect(type).toEqual('List<Object>');
     });
     test('should render type with custom collection type', () => {
       const model = new ConstrainedTupleModel('test', undefined, '', []);
-      const type = DartDefaultTypeMapping.Tuple({constrainedModel: model, options: {...DartGenerator.defaultOptions, collectionType: 'List'}});
+      const optionsToUse: DartOptions = {...DartGenerator.defaultOptions, collectionType: 'List'};
+      const type = DartDefaultTypeMapping.Tuple({constrainedModel: model, options: optionsToUse, dependencyManager: new DartDependencyManager(optionsToUse)});
       expect(type).toEqual('List<Object>');
     });
   });
@@ -71,13 +75,14 @@ describe('DartRenderer', () => {
     test('should render default type', () => {
       const arrayModel = new ConstrainedStringModel('test', undefined, 'string');
       const model = new ConstrainedArrayModel('test', undefined, '', arrayModel);
-      const type = DartDefaultTypeMapping.Array({constrainedModel: model, options: DartGenerator.defaultOptions});
+      const type = DartDefaultTypeMapping.Array({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('List<string>');
     });
     test('should render type with custom collection type', () => {
       const arrayModel = new ConstrainedStringModel('test', undefined, 'string');
       const model = new ConstrainedArrayModel('test', undefined, '', arrayModel);
-      const type = DartDefaultTypeMapping.Array({constrainedModel: model, options: {...DartGenerator.defaultOptions, collectionType: 'List'}});
+      const optionsToUse: DartOptions = {...DartGenerator.defaultOptions, collectionType: 'List'};
+      const type = DartDefaultTypeMapping.Array({constrainedModel: model, options: optionsToUse, dependencyManager: new DartDependencyManager(optionsToUse)});
       expect(type).toEqual('List<string>');
     });
   });
@@ -85,7 +90,7 @@ describe('DartRenderer', () => {
   describe('Enum', () => { 
     test('should render the constrained name as type', () => {
       const model = new ConstrainedEnumModel('test', undefined, '', []);
-      const type = DartDefaultTypeMapping.Enum({constrainedModel: model, options: DartGenerator.defaultOptions});
+      const type = DartDefaultTypeMapping.Enum({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual(model.name);
     });
   });
@@ -93,7 +98,7 @@ describe('DartRenderer', () => {
   describe('Union', () => { 
     test('should render type', () => {
       const model = new ConstrainedUnionModel('test', undefined, '', []);
-      const type = DartDefaultTypeMapping.Union({constrainedModel: model, options: DartGenerator.defaultOptions});
+      const type = DartDefaultTypeMapping.Union({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('Object');
     });
   });
@@ -103,7 +108,7 @@ describe('DartRenderer', () => {
       const keyModel = new ConstrainedStringModel('test', undefined, 'string');
       const valueModel = new ConstrainedStringModel('test', undefined, 'string');
       const model = new ConstrainedDictionaryModel('test', undefined, '', keyModel, valueModel);
-      const type = DartDefaultTypeMapping.Dictionary({constrainedModel: model, options: DartGenerator.defaultOptions});
+      const type = DartDefaultTypeMapping.Dictionary({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('Map<string, string>');
     });
   });

--- a/test/generators/dart/DartRenderer.spec.ts
+++ b/test/generators/dart/DartRenderer.spec.ts
@@ -1,4 +1,5 @@
 import { defaultGeneratorOptions, DartGenerator } from '../../../src/generators';
+import { DartDependencyManager } from '../../../src/generators/dart/DartDependencyManager';
 import { DartRenderer } from '../../../src/generators/dart/DartRenderer';
 import { ConstrainedObjectModel, InputMetaModel } from '../../../src/models';
 class MockDartRenderer extends DartRenderer<ConstrainedObjectModel> {
@@ -7,7 +8,7 @@ class MockDartRenderer extends DartRenderer<ConstrainedObjectModel> {
 describe('DartRenderer', () => {
   let renderer: DartRenderer<any>;
   beforeEach(() => {
-    renderer = new MockDartRenderer(DartGenerator.defaultOptions, new DartGenerator(), [], new ConstrainedObjectModel('', undefined, '', {}), new InputMetaModel());
+    renderer = new MockDartRenderer(DartGenerator.defaultOptions, new DartGenerator(), [], new ConstrainedObjectModel('', undefined, '', {}), new InputMetaModel(), new DartDependencyManager(DartGenerator.defaultOptions));
   });
   describe('renderComments()', () => {
     test('Should be able to render comments', () => {


### PR DESCRIPTION
**Description**
This PR adds the new dependency manager alongside a few changes:
- Allow the user to add dependencies for each model in the constraint and presets phase.
- As a side effect of the implementation, this enables the user to selectively overwrite options so you do not have to create a new generator instance all the time. 

These changes currently live on the `dependency_-manager` (wups) branch and are a WIP until all generators are adapted, that is why the tests are failing. 

**Related issue(s)**
Read more about the change here: https://github.com/asyncapi/modelina/pull/947
Fixes: https://github.com/asyncapi/modelina/issues/851