### PR TITLE
chore: add dependency manager for Java

### DIFF
--- a/src/generators/java/JavaConstrainer.ts
+++ b/src/generators/java/JavaConstrainer.ts
@@ -1,9 +1,8 @@
 import { ConstrainedEnumValueModel } from '../../models';
-import { TypeMapping } from '../../helpers';
 import { defaultEnumKeyConstraints, defaultEnumValueConstraints } from './constrainer/EnumConstrainer';
 import { defaultModelNameConstraints } from './constrainer/ModelNameConstrainer';
 import { defaultPropertyKeyConstraints } from './constrainer/PropertyKeyConstrainer';
-import { JavaOptions } from './JavaGenerator';
+import { JavaTypeMapping } from './JavaGenerator';
 
 function enumFormatToNumberType(enumValueModel: ConstrainedEnumValueModel, format: string): string {
   switch (format) {
@@ -64,7 +63,7 @@ const interpretUnionValueType = (types: string[]): string => {
   return 'Object';
 };
 
-export const JavaDefaultTypeMapping: TypeMapping<JavaOptions> = {
+export const JavaDefaultTypeMapping: JavaTypeMapping = {
   Object({ constrainedModel }): string {
     return constrainedModel.name;
   },

--- a/src/generators/java/JavaDependencyManager.ts
+++ b/src/generators/java/JavaDependencyManager.ts
@@ -1,0 +1,11 @@
+import { AbstractDependencyManager } from '../AbstractDependencyManager';
+import { JavaOptions } from './JavaGenerator';
+
+export class JavaDependencyManager extends AbstractDependencyManager {
+  constructor(
+    public options: JavaOptions,
+    dependencies: string[] = []
+  ) {
+    super(dependencies);
+  }
+}

--- a/src/generators/java/JavaGenerator.ts
+++ b/src/generators/java/JavaGenerator.ts
@@ -4,7 +4,7 @@ import {
   defaultGeneratorOptions
 } from '../AbstractGenerator';
 import { ConstrainedEnumModel, ConstrainedMetaModel, ConstrainedObjectModel, InputMetaModel, MetaModel, RenderOutput } from '../../models';
-import { split, TypeMapping } from '../../helpers';
+import { split, SplitOptions, TypeMapping } from '../../helpers';
 import { JavaPreset, JAVA_DEFAULT_PRESET } from './JavaPreset';
 import { ClassRenderer } from './renderers/ClassRenderer';
 import { EnumRenderer } from './renderers/EnumRenderer';
@@ -13,10 +13,13 @@ import { Logger } from '../../';
 import { constrainMetaModel, Constraints } from '../../helpers/ConstrainHelpers';
 import { JavaDefaultConstraints, JavaDefaultTypeMapping } from './JavaConstrainer';
 import { DeepPartial, mergePartialAndDefault } from '../../utils/Partials';
+import { JavaDependencyManager } from './JavaDependencyManager';
+
+export type JavaTypeMapping = TypeMapping<JavaOptions, JavaDependencyManager>;
 
 export interface JavaOptions extends CommonGeneratorOptions<JavaPreset> {
   collectionType: 'List' | 'Array';
-  typeMapping: TypeMapping<JavaOptions>;
+  typeMapping: JavaTypeMapping;
   constraints: Constraints;
 }
 export interface JavaRenderCompleteModelOptions {
@@ -30,6 +33,10 @@ export class JavaGenerator extends AbstractGenerator<JavaOptions, JavaRenderComp
     typeMapping: JavaDefaultTypeMapping,
     constraints: JavaDefaultConstraints
   };
+  
+  static defaultCompleteModelOptions: JavaRenderCompleteModelOptions = {
+    packageName: 'Asyncapi.Models'
+  };
 
   constructor(
     options?: DeepPartial<JavaOptions>,
@@ -37,22 +44,44 @@ export class JavaGenerator extends AbstractGenerator<JavaOptions, JavaRenderComp
     const realizedOptions = mergePartialAndDefault(JavaGenerator.defaultOptions, options) as JavaOptions;
     super('Java', realizedOptions);
   }
-  
+
+  /**
+   * Returns the Java options by merging custom options with default ones.
+   */
+  static getJavaOptions(options?: DeepPartial<JavaOptions>): JavaOptions {
+    const optionsToUse = mergePartialAndDefault(JavaGenerator.defaultOptions, options) as JavaOptions;
+    //Always overwrite the dependency manager unless user explicitly state they want it (ignore default temporary dependency manager)
+    if (options?.dependencyManager === undefined) {
+      optionsToUse.dependencyManager = () => { return new JavaDependencyManager(optionsToUse); };
+    }
+    return optionsToUse;
+  }
+
+  /**
+   * Wrapper to get an instance of the dependency manager
+   */
+  getJavaDependencyManager(options: JavaOptions): JavaDependencyManager {
+    return this.getDependencyManagerInstance(options) as JavaDependencyManager;
+  }
+
   splitMetaModel(model: MetaModel): MetaModel[] {
     //These are the models that we have separate renderers for
-    const metaModelsToSplit = {
+    const metaModelsToSplit: SplitOptions = {
       splitEnum: true, 
       splitObject: true
     };
     return split(model, metaModelsToSplit);
   }
 
-  constrainToMetaModel(model: MetaModel): ConstrainedMetaModel {
-    return constrainMetaModel<JavaOptions>(
+  constrainToMetaModel(model: MetaModel, options: DeepPartial<JavaOptions>): ConstrainedMetaModel {
+    const optionsToUse = JavaGenerator.getJavaOptions({...this.options, ...options});
+    const dependencyManagerToUse = this.getJavaDependencyManager(optionsToUse);
+    return constrainMetaModel<JavaOptions, JavaDependencyManager>(
       this.options.typeMapping, 
       this.options.constraints, 
       {
         metaModel: model,
+        dependencyManager: dependencyManagerToUse,
         options: this.options,
         constrainedName: '' //This is just a placeholder, it will be constrained within the function
       }
@@ -65,11 +94,12 @@ export class JavaGenerator extends AbstractGenerator<JavaOptions, JavaRenderComp
    * @param model 
    * @param inputModel 
    */
-  render(model: ConstrainedMetaModel, inputModel: InputMetaModel): Promise<RenderOutput> {
+  render(model: ConstrainedMetaModel, inputModel: InputMetaModel, options?: DeepPartial<JavaOptions>): Promise<RenderOutput> {
+    const optionsToUse = JavaGenerator.getJavaOptions({...this.options, ...options});
     if (model instanceof ConstrainedObjectModel) {
-      return this.renderClass(model, inputModel);
+      return this.renderClass(model, inputModel, optionsToUse);
     } else if (model instanceof ConstrainedEnumModel) {
-      return this.renderEnum(model, inputModel);
+      return this.renderEnum(model, inputModel, optionsToUse);
     } 
     Logger.warn(`Java generator, cannot generate this type of model, ${model.name}`);
     return Promise.resolve(RenderOutput.toRenderOutput({ result: '', renderedName: '', dependencies: [] }));
@@ -84,33 +114,43 @@ export class JavaGenerator extends AbstractGenerator<JavaOptions, JavaRenderComp
    * @param inputModel 
    * @param options used to render the full output
    */
-  async renderCompleteModel(model: ConstrainedMetaModel, inputModel: InputMetaModel, options: JavaRenderCompleteModelOptions): Promise<RenderOutput> {
-    if (isReservedJavaKeyword(options.packageName)) {
-      throw new Error(`You cannot use reserved Java keyword (${options.packageName}) as package name, please use another.`);
+  async renderCompleteModel(model: ConstrainedMetaModel, inputModel: InputMetaModel, 
+    completeModelOptions: Partial<JavaRenderCompleteModelOptions>,
+    options: DeepPartial<JavaOptions>): Promise<RenderOutput> {
+    const completeModelOptionsToUse = mergePartialAndDefault(JavaGenerator.defaultCompleteModelOptions, completeModelOptions) as JavaRenderCompleteModelOptions;
+    const optionsToUse = JavaGenerator.getJavaOptions({...this.options, ...options});
+    const dependencyManagerToUse = this.getJavaDependencyManager(optionsToUse);
+
+    if (isReservedJavaKeyword(completeModelOptionsToUse.packageName)) {
+      throw new Error(`You cannot use reserved Java keyword (${completeModelOptionsToUse.packageName}) as package name, please use another.`);
     }
 
     const outputModel = await this.render(model, inputModel);
     const modelDependencies = model.getNearestDependencies().map((dependencyModel) => {
-      return `import ${options.packageName}.${dependencyModel.name};`;
+      return `import ${completeModelOptionsToUse.packageName}.${dependencyModel.name};`;
     });
-    const outputContent = `package ${options.packageName};
+    const outputContent = `package ${completeModelOptionsToUse.packageName};
 ${modelDependencies.join('\n')}
 ${outputModel.dependencies.join('\n')}
 ${outputModel.result}`; 
     return RenderOutput.toRenderOutput({result: outputContent, renderedName: outputModel.renderedName, dependencies: outputModel.dependencies});
   }
 
-  async renderClass(model: ConstrainedObjectModel, inputModel: InputMetaModel): Promise<RenderOutput> {
+  async renderClass(model: ConstrainedObjectModel, inputModel: InputMetaModel, options?: DeepPartial<JavaOptions>): Promise<RenderOutput> {
+    const optionsToUse = JavaGenerator.getJavaOptions({...this.options, ...options});
+    const dependencyManagerToUse = this.getJavaDependencyManager(optionsToUse);
     const presets = this.getPresets('class');
-    const renderer = new ClassRenderer(this.options, this, presets, model, inputModel);
+    const renderer = new ClassRenderer(optionsToUse, this, presets, model, inputModel, dependencyManagerToUse);
     const result = await renderer.runSelfPreset();
-    return RenderOutput.toRenderOutput({result, renderedName: model.name, dependencies: renderer.dependencies});
+    return RenderOutput.toRenderOutput({result, renderedName: model.name, dependencies: dependencyManagerToUse.dependencies});
   }
 
-  async renderEnum(model: ConstrainedEnumModel, inputModel: InputMetaModel): Promise<RenderOutput> {
+  async renderEnum(model: ConstrainedEnumModel, inputModel: InputMetaModel, options?: DeepPartial<JavaOptions>): Promise<RenderOutput> {
+    const optionsToUse = JavaGenerator.getJavaOptions({...this.options, ...options});
+    const dependencyManagerToUse = this.getJavaDependencyManager(optionsToUse);
     const presets = this.getPresets('enum'); 
-    const renderer = new EnumRenderer(this.options, this, presets, model, inputModel);
+    const renderer = new EnumRenderer(optionsToUse, this, presets, model, inputModel, dependencyManagerToUse);
     const result = await renderer.runSelfPreset();
-    return RenderOutput.toRenderOutput({result, renderedName: model.name, dependencies: renderer.dependencies});
+    return RenderOutput.toRenderOutput({result, renderedName: model.name, dependencies: dependencyManagerToUse.dependencies});
   }
 }

--- a/src/generators/java/JavaRenderer.ts
+++ b/src/generators/java/JavaRenderer.ts
@@ -2,6 +2,7 @@ import { AbstractRenderer } from '../AbstractRenderer';
 import { JavaGenerator, JavaOptions } from './JavaGenerator';
 import { ConstrainedMetaModel, InputMetaModel, Preset } from '../../models';
 import { FormatHelpers } from '../../helpers';
+import { JavaDependencyManager } from './JavaDependencyManager';
 
 /**
  * Common renderer for Java types
@@ -15,6 +16,7 @@ export abstract class JavaRenderer<RendererModelType extends ConstrainedMetaMode
     presets: Array<[Preset, unknown]>,
     model: RendererModelType, 
     inputModel: InputMetaModel,
+    public dependencyManager: JavaDependencyManager
   ) {
     super(options, generator, presets, model, inputModel);
   }

--- a/src/generators/java/presets/CommonPreset.ts
+++ b/src/generators/java/presets/CommonPreset.ts
@@ -166,13 +166,13 @@ export const JAVA_COMMON_PRESET: JavaPreset<JavaCommonPresetOptions> = {
       const shouldContainMarshal = options.marshalling === true;
 
       if (shouldContainEqual === true || shouldContainHashCode === true) {
-        renderer.addDependency('import java.util.Objects;');
+        renderer.dependencyManager.addDependency('import java.util.Objects;');
       }
 
       if (shouldContainMarshal === true) {
-        renderer.addDependency('import java.util.stream;');
-        renderer.addDependency('import org.json.JSONObject;');
-        renderer.addDependency('import java.util.Map;');
+        renderer.dependencyManager.addDependency('import java.util.stream;');
+        renderer.dependencyManager.addDependency('import org.json.JSONObject;');
+        renderer.dependencyManager.addDependency('import java.util.Map;');
       }
 
       if (shouldContainEqual) { blocks.push(renderEqual({ renderer, model })); }

--- a/src/generators/java/presets/ConstraintsPreset.ts
+++ b/src/generators/java/presets/ConstraintsPreset.ts
@@ -9,7 +9,7 @@ import { JavaPreset } from '../JavaPreset';
 export const JAVA_CONSTRAINTS_PRESET: JavaPreset = {
   class: {
     self({renderer, content}) {
-      renderer.addDependency('import javax.validation.constraints.*;');
+      renderer.dependencyManager.addDependency('import javax.validation.constraints.*;');
       return content;
     },
     // eslint-disable-next-line sonarjs/cognitive-complexity

--- a/src/generators/java/presets/JacksonPreset.ts
+++ b/src/generators/java/presets/JacksonPreset.ts
@@ -9,7 +9,7 @@ import { JavaPreset } from '../JavaPreset';
 export const JAVA_JACKSON_PRESET: JavaPreset = {
   class: {
     self({renderer, content}) {
-      renderer.addDependency('import com.fasterxml.jackson.annotation.*;');
+      renderer.dependencyManager.addDependency('import com.fasterxml.jackson.annotation.*;');
       return content;
     },
     getter({ renderer, property, content }) {
@@ -25,7 +25,7 @@ export const JAVA_JACKSON_PRESET: JavaPreset = {
   },
   enum: {
     self({renderer, content}) {
-      renderer.addDependency('import com.fasterxml.jackson.annotation.*;');
+      renderer.dependencyManager.addDependency('import com.fasterxml.jackson.annotation.*;');
       return content;
     },
     getValue({content}) {

--- a/src/generators/java/renderers/ClassRenderer.ts
+++ b/src/generators/java/renderers/ClassRenderer.ts
@@ -19,10 +19,10 @@ export class ClassRenderer extends JavaRenderer<ConstrainedObjectModel> {
     ];
 
     if (this.options?.collectionType === 'List') {
-      this.addDependency('import java.util.List;');
+      this.dependencyManager.addDependency('import java.util.List;');
     }
     if (this.model.containsPropertyType(ConstrainedDictionaryModel)) {
-      this.addDependency('import java.util.Map;');
+      this.dependencyManager.addDependency('import java.util.Map;');
     }
     
     return `public class ${this.model.name} {

--- a/test/generators/java/JavaConstrainer.spec.ts
+++ b/test/generators/java/JavaConstrainer.spec.ts
@@ -1,10 +1,12 @@
 import {JavaDefaultTypeMapping } from '../../../src/generators/java/JavaConstrainer';
 import { ConstrainedAnyModel, ConstrainedArrayModel, ConstrainedBooleanModel, ConstrainedDictionaryModel, ConstrainedEnumModel, ConstrainedEnumValueModel, ConstrainedFloatModel, ConstrainedIntegerModel, ConstrainedObjectModel, ConstrainedReferenceModel, ConstrainedStringModel, ConstrainedTupleModel, ConstrainedUnionModel, JavaGenerator, JavaOptions } from '../../../src';
+import { JavaDependencyManager } from '../../../src/generators/java/JavaDependencyManager';
 describe('JavaConstrainer', () => {
+  const defaultOptions = {options: JavaGenerator.defaultOptions, dependencyManager: new JavaDependencyManager(JavaGenerator.defaultOptions)};
   describe('ObjectModel', () => { 
     test('should render the constrained name as type', () => {
       const model = new ConstrainedObjectModel('test', undefined, '', {});
-      const type = JavaDefaultTypeMapping.Object({constrainedModel: model, options: JavaGenerator.defaultOptions});
+      const type = JavaDefaultTypeMapping.Object({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual(model.name);
     });
   });
@@ -12,92 +14,92 @@ describe('JavaConstrainer', () => {
     test('should render the constrained name as type', () => {
       const refModel = new ConstrainedAnyModel('test', undefined, '');
       const model = new ConstrainedReferenceModel('test', undefined, '', refModel);
-      const type = JavaDefaultTypeMapping.Reference({constrainedModel: model, options: JavaGenerator.defaultOptions});
+      const type = JavaDefaultTypeMapping.Reference({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual(model.name);
     });
   });
   describe('Any', () => { 
     test('should render type', () => {
       const model = new ConstrainedAnyModel('test', undefined, '');
-      const type = JavaDefaultTypeMapping.Any({constrainedModel: model, options: JavaGenerator.defaultOptions});
+      const type = JavaDefaultTypeMapping.Any({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('Object');
     });
   });
   describe('Float', () => { 
     test('should render type', () => {
       const model = new ConstrainedFloatModel('test', undefined, '');
-      const type = JavaDefaultTypeMapping.Float({constrainedModel: model, options: JavaGenerator.defaultOptions});
+      const type = JavaDefaultTypeMapping.Float({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('Double');
     });
     test('should render double when original input has number format', () => {
       const model = new ConstrainedFloatModel('test', {format: 'float'}, '');
-      const type = JavaDefaultTypeMapping.Float({constrainedModel: model, options: JavaGenerator.defaultOptions});
+      const type = JavaDefaultTypeMapping.Float({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('float');
     });
   });
   describe('Integer', () => { 
     test('should render type', () => {
       const model = new ConstrainedIntegerModel('test', undefined, '');
-      const type = JavaDefaultTypeMapping.Integer({constrainedModel: model, options: JavaGenerator.defaultOptions});
+      const type = JavaDefaultTypeMapping.Integer({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('Integer');
     });
     test('should render int when original input has integer format', () => {
       const model = new ConstrainedIntegerModel('test', {format: 'integer'}, '');
-      const type = JavaDefaultTypeMapping.Integer({constrainedModel: model, options: JavaGenerator.defaultOptions});
+      const type = JavaDefaultTypeMapping.Integer({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('int');
     });
     test('should render int when original input has int32 format', () => {
       const model = new ConstrainedIntegerModel('test', {format: 'int32'}, '');
-      const type = JavaDefaultTypeMapping.Integer({constrainedModel: model, options: JavaGenerator.defaultOptions});
+      const type = JavaDefaultTypeMapping.Integer({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('int');
     });
     test('should render long when original input has long format', () => {
       const model = new ConstrainedIntegerModel('test', {format: 'long'}, '');
-      const type = JavaDefaultTypeMapping.Integer({constrainedModel: model, options: JavaGenerator.defaultOptions});
+      const type = JavaDefaultTypeMapping.Integer({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('long');
     });
     test('should render long when original input has int64 format', () => {
       const model = new ConstrainedIntegerModel('test', {format: 'int64'}, '');
-      const type = JavaDefaultTypeMapping.Integer({constrainedModel: model, options: JavaGenerator.defaultOptions});
+      const type = JavaDefaultTypeMapping.Integer({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('long');
     });
   });
   describe('String', () => { 
     test('should render type', () => {
       const model = new ConstrainedStringModel('test', undefined, '');
-      const type = JavaDefaultTypeMapping.String({constrainedModel: model, options: JavaGenerator.defaultOptions});
+      const type = JavaDefaultTypeMapping.String({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('String');
     });
     test('should render LocalDate when original input has date format', () => {
       const model = new ConstrainedStringModel('test', {format: 'date'}, '');
-      const type = JavaDefaultTypeMapping.String({constrainedModel: model, options: JavaGenerator.defaultOptions});
+      const type = JavaDefaultTypeMapping.String({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('java.time.LocalDate');
     });
     test('should render OffsetTime when original input has time format', () => {
       const model = new ConstrainedStringModel('test', {format: 'time'}, '');
-      const type = JavaDefaultTypeMapping.String({constrainedModel: model, options: JavaGenerator.defaultOptions});
+      const type = JavaDefaultTypeMapping.String({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('java.time.OffsetTime');
     });
     test('should render OffsetDateTime when original input has dateTime format', () => {
       const model = new ConstrainedStringModel('test', {format: 'dateTime'}, '');
-      const type = JavaDefaultTypeMapping.String({constrainedModel: model, options: JavaGenerator.defaultOptions});
+      const type = JavaDefaultTypeMapping.String({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('java.time.OffsetDateTime');
     });
     test('should render OffsetDateTime when original input has date-time format', () => {
       const model = new ConstrainedStringModel('test', {format: 'date-time'}, '');
-      const type = JavaDefaultTypeMapping.String({constrainedModel: model, options: JavaGenerator.defaultOptions});
+      const type = JavaDefaultTypeMapping.String({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('java.time.OffsetDateTime');
     });
     test('should render byte when original input has binary format', () => {
       const model = new ConstrainedStringModel('test', {format: 'binary'}, '');
-      const type = JavaDefaultTypeMapping.String({constrainedModel: model, options: JavaGenerator.defaultOptions});
+      const type = JavaDefaultTypeMapping.String({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('byte[]');
     });
   });
   describe('Boolean', () => { 
     test('should render type', () => {
       const model = new ConstrainedBooleanModel('test', undefined, '');
-      const type = JavaDefaultTypeMapping.Boolean({constrainedModel: model, options: JavaGenerator.defaultOptions});
+      const type = JavaDefaultTypeMapping.Boolean({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('Boolean');
     });
   });
@@ -105,13 +107,13 @@ describe('JavaConstrainer', () => {
   describe('Tuple', () => { 
     test('should render type', () => {
       const model = new ConstrainedTupleModel('test', undefined, '', []);
-      const type = JavaDefaultTypeMapping.Tuple({constrainedModel: model, options: JavaGenerator.defaultOptions});
+      const type = JavaDefaultTypeMapping.Tuple({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('Object[]');
     });
     test('should render tuple as list', () => {
       const model = new ConstrainedTupleModel('test', undefined, '', []);
       const options: JavaOptions = {...JavaGenerator.defaultOptions, collectionType: 'List'};
-      const type = JavaDefaultTypeMapping.Tuple({constrainedModel: model, options});
+      const type = JavaDefaultTypeMapping.Tuple({constrainedModel: model, options, dependencyManager: new JavaDependencyManager(options)});
       expect(type).toEqual('List<Object>');
     });
   });
@@ -121,14 +123,14 @@ describe('JavaConstrainer', () => {
       const arrayModel = new ConstrainedStringModel('test', undefined, 'String');
       const model = new ConstrainedArrayModel('test', undefined, '', arrayModel);
       const options: JavaOptions = {...JavaGenerator.defaultOptions, collectionType: 'Array'};
-      const type = JavaDefaultTypeMapping.Array({constrainedModel: model, options});
+      const type = JavaDefaultTypeMapping.Array({constrainedModel: model, options, dependencyManager: new JavaDependencyManager(options)});
       expect(type).toEqual('String[]');
     });
     test('should render array as a list', () => {
       const arrayModel = new ConstrainedStringModel('test', undefined, 'String');
       const model = new ConstrainedArrayModel('test', undefined, '', arrayModel);
       const options: JavaOptions = {...JavaGenerator.defaultOptions, collectionType: 'List'};
-      const type = JavaDefaultTypeMapping.Array({constrainedModel: model, options});
+      const type = JavaDefaultTypeMapping.Array({constrainedModel: model, options, dependencyManager: new JavaDependencyManager(options)});
       expect(type).toEqual('List<String>');
     });
   });
@@ -137,58 +139,58 @@ describe('JavaConstrainer', () => {
     test('should render string enum values as String type', () => {
       const enumValue = new ConstrainedEnumValueModel('test', 'string type');
       const model = new ConstrainedEnumModel('test', undefined, '', [enumValue]);
-      const type = JavaDefaultTypeMapping.Enum({constrainedModel: model, options: JavaGenerator.defaultOptions});
+      const type = JavaDefaultTypeMapping.Enum({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('String');
     });
     test('should render boolean enum values as boolean type', () => {
       const enumValue = new ConstrainedEnumValueModel('test', true);
       const model = new ConstrainedEnumModel('test', undefined, '', [enumValue]);
-      const type = JavaDefaultTypeMapping.Enum({constrainedModel: model, options: JavaGenerator.defaultOptions});
+      const type = JavaDefaultTypeMapping.Enum({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('boolean');
     });
     test('should render generic number enum value with format  ', () => {
       const enumValue = new ConstrainedEnumValueModel('test', 123);
       const model = new ConstrainedEnumModel('test', undefined, '', [enumValue]);
-      const type = JavaDefaultTypeMapping.Enum({constrainedModel: model, options: JavaGenerator.defaultOptions});
+      const type = JavaDefaultTypeMapping.Enum({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('int');
     });
     test('should render generic number enum value with float format as float type', () => {
       const enumValue = new ConstrainedEnumValueModel('test', 12.0);
       const model = new ConstrainedEnumModel('test', {format: 'float'}, '', [enumValue]);
-      const type = JavaDefaultTypeMapping.Enum({constrainedModel: model, options: JavaGenerator.defaultOptions});
+      const type = JavaDefaultTypeMapping.Enum({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('float');
     });
     test('should render generic number enum value with double format as double type', () => {
       const enumValue = new ConstrainedEnumValueModel('test', 12.0);
       const model = new ConstrainedEnumModel('test', {format: 'double'}, '', [enumValue]);
-      const type = JavaDefaultTypeMapping.Enum({constrainedModel: model, options: JavaGenerator.defaultOptions});
+      const type = JavaDefaultTypeMapping.Enum({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('double');
     });
     test('should render object enum value as generic Object', () => {
       const enumValue = new ConstrainedEnumValueModel('test', {});
       const model = new ConstrainedEnumModel('test', undefined, '', [enumValue]);
-      const type = JavaDefaultTypeMapping.Enum({constrainedModel: model, options: JavaGenerator.defaultOptions});
+      const type = JavaDefaultTypeMapping.Enum({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('Object');
     });
     test('should render multiple value types as generic Object', () => {
       const enumValue2 = new ConstrainedEnumValueModel('test', true);
       const enumValue1 = new ConstrainedEnumValueModel('test', 'string type');
       const model = new ConstrainedEnumModel('test', undefined, '', [enumValue1, enumValue2]);
-      const type = JavaDefaultTypeMapping.Enum({constrainedModel: model, options: JavaGenerator.defaultOptions});
+      const type = JavaDefaultTypeMapping.Enum({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('Object');
     });
     test('should render double and integer as double type', () => {
       const enumValue2 = new ConstrainedEnumValueModel('test', 123);
       const enumValue1 = new ConstrainedEnumValueModel('test', 123.12);
       const model = new ConstrainedEnumModel('test', undefined, '', [enumValue1, enumValue2]);
-      const type = JavaDefaultTypeMapping.Enum({constrainedModel: model, options: JavaGenerator.defaultOptions});
+      const type = JavaDefaultTypeMapping.Enum({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('double');
     });
     test('should render int and long as long type', () => {
       const enumValue2 = new ConstrainedEnumValueModel('test', 123);
       const enumValue1 = new ConstrainedEnumValueModel('test', 123);
       const model = new ConstrainedEnumModel('test', {format: 'long'}, '', [enumValue1, enumValue2]);
-      const type = JavaDefaultTypeMapping.Enum({constrainedModel: model, options: JavaGenerator.defaultOptions});
+      const type = JavaDefaultTypeMapping.Enum({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('long');
     });
   });
@@ -196,7 +198,7 @@ describe('JavaConstrainer', () => {
   describe('Union', () => { 
     test('should render type', () => {
       const model = new ConstrainedUnionModel('test', undefined, '', []);
-      const type = JavaDefaultTypeMapping.Union({constrainedModel: model, options: JavaGenerator.defaultOptions});
+      const type = JavaDefaultTypeMapping.Union({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('Object');
     });
   });
@@ -206,14 +208,14 @@ describe('JavaConstrainer', () => {
       const keyModel = new ConstrainedStringModel('test', undefined, 'String');
       const valueModel = new ConstrainedStringModel('test', undefined, 'String');
       const model = new ConstrainedDictionaryModel('test', undefined, '', keyModel, valueModel);
-      const type = JavaDefaultTypeMapping.Dictionary({constrainedModel: model, options: JavaGenerator.defaultOptions});
+      const type = JavaDefaultTypeMapping.Dictionary({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('Map<String, String>');
     });
     test('should not render simple integer type', () => {
       const keyModel = new ConstrainedStringModel('test', undefined, 'String');
       const valueModel = new ConstrainedIntegerModel('test', undefined, 'int');
       const model = new ConstrainedDictionaryModel('test', undefined, '', keyModel, valueModel);
-      const type = JavaDefaultTypeMapping.Dictionary({constrainedModel: model, options: JavaGenerator.defaultOptions});
+      const type = JavaDefaultTypeMapping.Dictionary({constrainedModel: model, ...defaultOptions});
       expect(type).toEqual('Map<String, Integer>');
     });
   });

--- a/test/generators/java/JavaRenderer.spec.ts
+++ b/test/generators/java/JavaRenderer.spec.ts
@@ -1,4 +1,5 @@
 import { JavaGenerator } from '../../../src/generators';
+import { JavaDependencyManager } from '../../../src/generators/java/JavaDependencyManager';
 import { JavaRenderer } from '../../../src/generators/java/JavaRenderer';
 import { CommonModel, ConstrainedObjectModel, InputMetaModel } from '../../../src/models';
 import { MockJavaRenderer } from '../../TestUtils/TestRenderers';
@@ -6,7 +7,7 @@ import { MockJavaRenderer } from '../../TestUtils/TestRenderers';
 describe('JavaRenderer', () => {
   let renderer: JavaRenderer<any>;
   beforeEach(() => {
-    renderer = new MockJavaRenderer(JavaGenerator.defaultOptions, new JavaGenerator(), [], new ConstrainedObjectModel('', undefined, '', {}), new InputMetaModel());
+    renderer = new MockJavaRenderer(JavaGenerator.defaultOptions, new JavaGenerator(), [], new ConstrainedObjectModel('', undefined, '', {}), new InputMetaModel(), new JavaDependencyManager(JavaGenerator.defaultOptions));
   });
 
   describe('renderComments()', () => {


### PR DESCRIPTION
**Description**
This PR adds the new dependency manager alongside a few changes:
- Allow the user to add dependencies for each model in the constraint and presets phase.
- As a side effect of the implementation, this enables the user to selectively overwrite options so you do not have to create a new generator instance all the time. 

These changes currently live on the `dependency_-manager` (wups) branch and are a WIP until all generators are adapted, that is why the tests are failing. 

**Related issue(s)**
Read more about the change here: https://github.com/asyncapi/modelina/pull/947
Fixes: https://github.com/asyncapi/modelina/issues/851