### PR TITLE
fix: csharp simplification for newtonsoft serialization

### DIFF
--- a/examples/csharp-generate-newtonsoft-serializer/__snapshots__/index.spec.ts.snap
+++ b/examples/csharp-generate-newtonsoft-serializer/__snapshots__/index.spec.ts.snap
@@ -1,9 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Should be able to generate a model with functions to serialize the data model into JSON  and should log expected output to console 1`] = `
+exports[`Should be able to generate a model  and should log expected output to console 1`] = `
 Array [
-  "[JsonConverter(typeof(RootConverter))]
-public class Root
+  "public class Root
 {
   private string email;
 
@@ -12,37 +11,6 @@ public class Root
     get { return email; }
     set { email = value; }
   }
-}
-
-public class RootConverter : JsonConverter<Root>
-{
-  public override Root ReadJson(JsonReader reader, System.Type objectType, Root existingValue, bool hasExistingValue, JsonSerializer serializer)
-{
-  JObject jo = JObject.Load(reader);
-  Root value = new Root();
-
-  if(jo[\\"email\\"] != null) {
-  value.Email = jo[\\"email\\"].ToObject<string>(serializer);
-}
-
-  
-  return value;
-}
-  public override void WriteJson(JsonWriter writer, Root value, JsonSerializer serializer)
-{
-  JObject jo = new JObject();
-
-  if (value.Email != null)
-{
-  jo.Add(\\"email\\", JToken.FromObject(value.Email, serializer));
-}
-  
-
-  jo.WriteTo(writer);
-}
-
-  public override bool CanRead => true;
-  public override bool CanWrite => true;
 }",
 ]
 `;

--- a/examples/csharp-generate-newtonsoft-serializer/index.spec.ts
+++ b/examples/csharp-generate-newtonsoft-serializer/index.spec.ts
@@ -1,7 +1,7 @@
 const spy = jest.spyOn(global.console, 'log').mockImplementation(() => { return; });
 import {generate} from './index';
 
-describe('Should be able to generate a model with functions to serialize the data model into JSON ', () => {
+describe('Should be able to generate a model ', () => {
   afterAll(() => {
     jest.restoreAllMocks();
   });

--- a/src/generators/csharp/presets/NewtonsoftSerializerPreset.ts
+++ b/src/generators/csharp/presets/NewtonsoftSerializerPreset.ts
@@ -22,7 +22,10 @@ ${renderer.indent(enumItems)}
 ${renderer.indent('}')}`;
     },
     item: ({content, item, renderer}): string => {
-      return `${renderer.indent(`[EnumMember(Value="${item.value.toString().replace(/(^")|("$)/g, '')}")]`)}
+      const stringValue = item.value.toString();
+      const sanitizedValue = stringValue.replace(/(^")|("$)/g, '');
+
+      return `${renderer.indent(`[EnumMember(Value="${sanitizedValue}")]`)}
 ${renderer.indent(content)}`;
     }
   },

--- a/src/generators/csharp/presets/NewtonsoftSerializerPreset.ts
+++ b/src/generators/csharp/presets/NewtonsoftSerializerPreset.ts
@@ -22,7 +22,7 @@ ${renderer.indent(enumItems)}
 ${renderer.indent('}')}`;
     },
     item: ({content, item, renderer}): string => {
-      return `${renderer.indent(`[EnumMember(Value="${item.value.toString().replaceAll(/(^")|("$)/g, '')}")]`)}
+      return `${renderer.indent(`[EnumMember(Value="${item.value.toString().replace(/(^")|("$)/g, '')}")]`)}
 ${renderer.indent(content)}`;
     }
   },

--- a/src/generators/csharp/presets/NewtonsoftSerializerPreset.ts
+++ b/src/generators/csharp/presets/NewtonsoftSerializerPreset.ts
@@ -15,18 +15,22 @@ export const CSHARP_NEWTONSOFT_SERIALIZER_PRESET: CSharpPreset<CSharpOptions> = 
 
       const enumItems = await renderer.renderItems();
 
-      return `${renderer.indent('[JsonConverter(typeof(StringEnumConverter))]')}
-${renderer.indent(`public enum ${model.name}`)}
-${renderer.indent('{')}
-${renderer.indent(enumItems)}
-${renderer.indent('}')}`;
+      return [
+        renderer.indent('[JsonConverter(typeof(StringEnumConverter))]'),
+        renderer.indent(`public enum ${model.name}`),
+        renderer.indent('{'),
+        renderer.indent(enumItems),
+        renderer.indent('}')
+      ].join('\n');
     },
     item: ({content, item, renderer}): string => {
       const stringValue = item.value.toString();
       const sanitizedValue = stringValue.replace(/(^")|("$)/g, '');
 
-      return `${renderer.indent(`[EnumMember(Value="${sanitizedValue}")]`)}
-${renderer.indent(content)}`;
+      return [
+        renderer.indent(`[EnumMember(Value="${sanitizedValue}")]`),
+        renderer.indent(content)
+      ].join('\n');
     }
   },
 };

--- a/test/generators/csharp/presets/NewtonsoftSerializerPreset.spec.ts
+++ b/test/generators/csharp/presets/NewtonsoftSerializerPreset.spec.ts
@@ -17,7 +17,7 @@ const doc = {
   },
 };
 describe('Newtonsoft JSON serializer preset', () => {
-  test('should render serialize and deserialize converters', async () => {
+  test('should render enum with custom mapping of values', async () => {
     const generator = new CSharpGenerator({ 
       presets: [
         CSHARP_NEWTONSOFT_SERIALIZER_PRESET

--- a/test/generators/csharp/presets/__snapshots__/NewtonsoftSerializerPreset.spec.ts.snap
+++ b/test/generators/csharp/presets/__snapshots__/NewtonsoftSerializerPreset.spec.ts.snap
@@ -1,8 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Newtonsoft JSON serializer preset should render serialize and deserialize converters 1`] = `
-"[JsonConverter(typeof(TestConverter))]
-public class Test
+exports[`Newtonsoft JSON serializer preset should render enum with custom mapping of values 1`] = `
+"public class Test
 {
   private string stringProp;
   private double numberProp;
@@ -39,121 +38,26 @@ public class Test
     get { return additionalProperties; }
     set { additionalProperties = value; }
   }
-}
-
-public class TestConverter : JsonConverter<Test>
-{
-  public override Test ReadJson(JsonReader reader, System.Type objectType, Test existingValue, bool hasExistingValue, JsonSerializer serializer)
-{
-  JObject jo = JObject.Load(reader);
-  Test value = new Test();
-
-  if(jo[\\"string prop\\"] != null) {
-  value.StringProp = jo[\\"string prop\\"].ToObject<string>(serializer);
-}
-if(jo[\\"numberProp\\"] != null) {
-  value.NumberProp = jo[\\"numberProp\\"].ToObject<double>(serializer);
-}
-if(jo[\\"enumProp\\"] != null) {
-  value.EnumProp = EnumTestExtensions.ToEnumTest(jo[\\"enumProp\\"]);
-}
-if(jo[\\"objectProp\\"] != null) {
-  value.ObjectProp = jo[\\"objectProp\\"].ToObject<NestedTest>(serializer);
-}
-
-  var additionalProperties = jo.Properties().Where((prop) => prop.Name != \\"string prop\\" || prop.Name != \\"numberProp\\" || prop.Name != \\"enumProp\\" || prop.Name != \\"objectProp\\");
-  value.AdditionalProperties = new Dictionary<string, dynamic>();
-
-  foreach (var additionalProperty in additionalProperties)
-  {
-    value.AdditionalProperties[additionalProperty.Name] = additionalProperty.Value.ToObject<dynamic>(serializer);
-  }
-  return value;
-}
-  public override void WriteJson(JsonWriter writer, Test value, JsonSerializer serializer)
-{
-  JObject jo = new JObject();
-
-  if (value.StringProp != null)
-{
-  jo.Add(\\"string prop\\", JToken.FromObject(value.StringProp, serializer));
-}
-if (value.NumberProp != null)
-{
-  jo.Add(\\"numberProp\\", JToken.FromObject(value.NumberProp, serializer));
-}
-if (value.EnumProp != null)
-{
-  var enumValue = EnumTestExtensions.GetValue((EnumTest)value.EnumProp);
-var stringEnumValue = enumValue.ToString();
-// C# converts booleans to uppercase True and False, which newtonsoft cannot understand
-var jsonStringCompliant = stringEnumValue == \\"True\\" || stringEnumValue == \\"False\\" ? stringEnumValue.ToLower() : stringEnumValue;
-var jsonToken = JToken.Parse(jsonStringCompliant);
-jo.Add(\\"enumProp\\", jsonToken);
-}
-if (value.ObjectProp != null)
-{
-  jo.Add(\\"objectProp\\", JToken.FromObject(value.ObjectProp, serializer));
-}
-  if (value.AdditionalProperties != null)
-  {
-  foreach (var unwrapProperty in value.AdditionalProperties)
-  {
-    var hasProp = jo[unwrapProperty.Key]; 
-    if (hasProp != null) continue;
-    jo.Add(unwrapProperty.Key, JToken.FromObject(unwrapProperty.Value, serializer));
-  }
-}
-
-  jo.WriteTo(writer);
-}
-
-  public override bool CanRead => true;
-  public override bool CanWrite => true;
 }"
 `;
 
-exports[`Newtonsoft JSON serializer preset should render serialize and deserialize converters 2`] = `
-"public enum EnumTest
-{
-  SOME_SPACE_ENUM_SPACE_STRING,
-  RESERVED_TRUE,
-  CURLYLEFT_QUOTATION_TEST_QUOTATION_COLON_QUOTATION_TEST_QUOTATION_CURLYRIGHT,
-  NUMBER_2
-}
-
-public static class EnumTestExtensions
-{
-  public static dynamic? GetValue(this EnumTest enumValue)
+exports[`Newtonsoft JSON serializer preset should render enum with custom mapping of values 2`] = `
+"  [JsonConverter(typeof(StringEnumConverter))]
+  public enum EnumTest
   {
-    switch (enumValue)
-    {
-      case EnumTest.SOME_SPACE_ENUM_SPACE_STRING: return \\"Some enum String\\";
-      case EnumTest.RESERVED_TRUE: return true;
-      case EnumTest.CURLYLEFT_QUOTATION_TEST_QUOTATION_COLON_QUOTATION_TEST_QUOTATION_CURLYRIGHT: return \\"{\\\\\\"test\\\\\\":\\\\\\"test\\\\\\"}\\";
-      case EnumTest.NUMBER_2: return 2;
-    }
-    return null;
-  }
-
-  public static EnumTest? ToEnumTest(dynamic? value)
-  {
-    switch (value)
-    {
-      case \\"Some enum String\\": return EnumTest.SOME_SPACE_ENUM_SPACE_STRING;
-      case true: return EnumTest.RESERVED_TRUE;
-      case \\"{\\\\\\"test\\\\\\":\\\\\\"test\\\\\\"}\\": return EnumTest.CURLYLEFT_QUOTATION_TEST_QUOTATION_COLON_QUOTATION_TEST_QUOTATION_CURLYRIGHT;
-      case 2: return EnumTest.NUMBER_2;
-    }
-    return null;
-  }
-}
-"
+    [EnumMember(Value=\\"Some enum String\\")]
+    SOME_SPACE_ENUM_SPACE_STRING,
+    [EnumMember(Value=\\"true\\")]
+    RESERVED_TRUE,
+    [EnumMember(Value=\\"{\\\\\\"test\\\\\\":\\\\\\"test\\\\\\"}\\")]
+    CURLYLEFT_QUOTATION_TEST_QUOTATION_COLON_QUOTATION_TEST_QUOTATION_CURLYRIGHT,
+    [EnumMember(Value=\\"2\\")]
+    NUMBER_2
+  }"
 `;
 
-exports[`Newtonsoft JSON serializer preset should render serialize and deserialize converters 3`] = `
-"[JsonConverter(typeof(NestedTestConverter))]
-public class NestedTest
+exports[`Newtonsoft JSON serializer preset should render enum with custom mapping of values 3`] = `
+"public class NestedTest
 {
   private string stringProp;
   private Dictionary<string, dynamic> additionalProperties;
@@ -169,50 +73,5 @@ public class NestedTest
     get { return additionalProperties; }
     set { additionalProperties = value; }
   }
-}
-
-public class NestedTestConverter : JsonConverter<NestedTest>
-{
-  public override NestedTest ReadJson(JsonReader reader, System.Type objectType, NestedTest existingValue, bool hasExistingValue, JsonSerializer serializer)
-{
-  JObject jo = JObject.Load(reader);
-  NestedTest value = new NestedTest();
-
-  if(jo[\\"stringProp\\"] != null) {
-  value.StringProp = jo[\\"stringProp\\"].ToObject<string>(serializer);
-}
-
-  var additionalProperties = jo.Properties().Where((prop) => prop.Name != \\"stringProp\\");
-  value.AdditionalProperties = new Dictionary<string, dynamic>();
-
-  foreach (var additionalProperty in additionalProperties)
-  {
-    value.AdditionalProperties[additionalProperty.Name] = additionalProperty.Value.ToObject<dynamic>(serializer);
-  }
-  return value;
-}
-  public override void WriteJson(JsonWriter writer, NestedTest value, JsonSerializer serializer)
-{
-  JObject jo = new JObject();
-
-  if (value.StringProp != null)
-{
-  jo.Add(\\"stringProp\\", JToken.FromObject(value.StringProp, serializer));
-}
-  if (value.AdditionalProperties != null)
-  {
-  foreach (var unwrapProperty in value.AdditionalProperties)
-  {
-    var hasProp = jo[unwrapProperty.Key]; 
-    if (hasProp != null) continue;
-    jo.Add(unwrapProperty.Key, JToken.FromObject(unwrapProperty.Value, serializer));
-  }
-}
-
-  jo.WriteTo(writer);
-}
-
-  public override bool CanRead => true;
-  public override bool CanWrite => true;
 }"
 `;


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
- ⚠️ This is a breaking change:
   - enum fields in models can no longer be converted to dynamic (object) values. If an enum has mixed value types, it's no longer supported: values are always strings
   - Serializer and Deserializer classes are removed. If anyone previously used them directly, the code would fail to compile.
- Switching to declarative serialization & deserialization of enums
- Custom `*Serializer` and `*Deserializer` classes are removed from the generated code because they aren't required anymore
- Classes to map enum values to enum members are removed from the generated code
- All for the cause of reducing complexity: ![image](https://user-images.githubusercontent.com/5207748/207704525-b306b052-b482-44cf-b4de-f7dd85c14b5d.png)

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->
Resolves #1052 