### PR TITLE
fix: add Jackson annotations at the field level

### DIFF
--- a/examples/java-generate-jackson-annotation/__snapshots__/index.spec.ts.snap
+++ b/examples/java-generate-jackson-annotation/__snapshots__/index.spec.ts.snap
@@ -3,15 +3,15 @@
 exports[`Should be able to generate data models for jackson annotation and should log expected output to console 1`] = `
 Array [
   "public class Root {
+  @JsonProperty(\\"min_number_prop\\")
   private Double minNumberProp;
+  @JsonProperty(\\"max_number_prop\\")
   private Double maxNumberProp;
   private Map<String, Object> additionalProperties;
 
-  @JsonProperty(\\"min_number_prop\\")
   public Double getMinNumberProp() { return this.minNumberProp; }
   public void setMinNumberProp(Double minNumberProp) { this.minNumberProp = minNumberProp; }
 
-  @JsonProperty(\\"max_number_prop\\")
   public Double getMaxNumberProp() { return this.maxNumberProp; }
   public void setMaxNumberProp(Double maxNumberProp) { this.maxNumberProp = maxNumberProp; }
 

--- a/src/generators/java/presets/JacksonPreset.ts
+++ b/src/generators/java/presets/JacksonPreset.ts
@@ -12,7 +12,7 @@ export const JAVA_JACKSON_PRESET: JavaPreset = {
       renderer.addDependency('import com.fasterxml.jackson.annotation.*;');
       return content;
     },
-    getter({ renderer, property, content }) {
+    property({ renderer, property, content }) {
       //Properties that are dictionaries with unwrapped options, cannot get the annotation because it cannot be accurately unwrapped by the jackson library.
       const isDictionary = property.property instanceof ConstrainedDictionaryModel;
       const hasUnwrappedOptions = isDictionary && (property.property as ConstrainedDictionaryModel).serializationType === 'unwrap';

--- a/test/generators/java/presets/__snapshots__/JacksonPreset.spec.ts.snap
+++ b/test/generators/java/presets/__snapshots__/JacksonPreset.spec.ts.snap
@@ -2,15 +2,15 @@
 
 exports[`JAVA_JACKSON_PRESET should render Jackson annotations for class 1`] = `
 "public class Clazz {
+  @JsonProperty(\\"min_number_prop\\")
   private Double minNumberProp;
+  @JsonProperty(\\"max_number_prop\\")
   private Double maxNumberProp;
   private Map<String, Object> additionalProperties;
 
-  @JsonProperty(\\"min_number_prop\\")
   public Double getMinNumberProp() { return this.minNumberProp; }
   public void setMinNumberProp(Double minNumberProp) { this.minNumberProp = minNumberProp; }
 
-  @JsonProperty(\\"max_number_prop\\")
   public Double getMaxNumberProp() { return this.maxNumberProp; }
   public void setMaxNumberProp(Double maxNumberProp) { this.maxNumberProp = maxNumberProp; }
 


### PR DESCRIPTION
**Description**
This is a small fix for Java Jackson preset. To make sure that Jackson serialization works in all situations the recommended way is to add Jackson annotations at the field level.

**Related issue(s)**
https://github.com/asyncapi/modelina/issues/983