### PR TITLE
feat: adding interpreter options override

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -15,6 +15,7 @@ This document contains many of the advanced use-cases that you may stumble upon 
 - [Change the generated indentation type and size](#change-the-generated-indentation-type-and-size)
 - [Change the type mapping](#change-the-type-mapping)
 - [Changing the constrain rules](#changing-the-constrain-rules)
+- [Changing the interpreter options](#changing-the-interpreter-options)
 
 <!-- tocstop -->
 
@@ -98,3 +99,11 @@ There can be multiple reasons why you want to change the default constrain rules
 Check out this [example out for a live demonstration](../examples/overwrite-default-constraint/) for how to overwrite the default constraints.
 
 Check out this [example out for a live demonstration](../examples/overwrite-naming-formatting/) for how to overwrite the naming formatting for models.
+
+## Changing the interpreter options
+
+Sometimes it is desirable to change the default behavior of the `Interpreter`. While most of the default behavior of the `Interpreter` is fine, there are areas that would be nice to customize. Some of these are:
+- `additionalProperties` - according to JSON schema spec, by default, `additionalProperties` is set to `true`
+- `additionalItems` - according to JSON schema spec, by default, `additionalItems` is set to `true`
+
+Check out this [example out for a live demonstration](../examples/overwrite-interpreter-options/) for how to overwrite the interpreter options.

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -106,4 +106,4 @@ Sometimes it is desirable to change the default behavior of the `Interpreter`. W
 - `additionalProperties` - according to JSON schema spec, by default, `additionalProperties` is set to `true`
 - `additionalItems` - according to JSON schema spec, by default, `additionalItems` is set to `true`
 
-Check out this [example out for a live demonstration](../examples/overwrite-interpreter-options/) for how to overwrite the interpreter options.
+Check out this [example out for a live demonstration](../examples/overwrite-interpreter-options/) for how to customize the behavior of `additionalItems` and `additionalProperties`.

--- a/examples/overwrite-interpreter-options/README.md
+++ b/examples/overwrite-interpreter-options/README.md
@@ -1,0 +1,17 @@
+# Overwrite interpreter options
+
+This example shows how to overwrite the interpreter options.
+
+## How to run this example
+
+Run this example using:
+
+```sh
+npm i && npm run start
+```
+
+If you are on Windows, use the `start:windows` script instead:
+
+```sh
+npm i && npm run start:windows
+```

--- a/examples/overwrite-interpreter-options/__snapshots__/index.spec.ts.snap
+++ b/examples/overwrite-interpreter-options/__snapshots__/index.spec.ts.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Should be able to render models with overridden additionalProperties and should log expected output to console 1`] = `
+Array [
+  "class Root {
+  private _email?: string;
+
+  constructor(input: {
+    email?: string,
+  }) {
+    this._email = input.email;
+  }
+
+  get email(): string | undefined { return this._email; }
+  set email(email: string | undefined) { this._email = email; }
+}",
+]
+`;

--- a/examples/overwrite-interpreter-options/index.spec.ts
+++ b/examples/overwrite-interpreter-options/index.spec.ts
@@ -1,0 +1,15 @@
+const spy = jest.spyOn(global.console, 'log').mockImplementation(() => {
+  return;
+});
+import { generate } from './index';
+
+describe('Should be able to render models with overridden additionalProperties', () => {
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+  test('and should log expected output to console', async () => {
+    await generate();
+    expect(spy.mock.calls.length).toEqual(1);
+    expect(spy.mock.calls[0]).toMatchSnapshot();
+  });
+});

--- a/examples/overwrite-interpreter-options/index.ts
+++ b/examples/overwrite-interpreter-options/index.ts
@@ -1,0 +1,58 @@
+import { TypeScriptGenerator } from '../../src';
+import { CommonModel } from '../../src';
+import {
+  InterpreterSchemaType,
+  Interpreter,
+  InterpreterOptions
+} from '../../src/interpreter/Interpreter';
+import { isModelObject } from '../../src/interpreter/Utils';
+
+const generator = new TypeScriptGenerator({
+  processorOptions: {
+    interpreter: {
+      additionalProperties: (
+        schema: InterpreterSchemaType,
+        model: CommonModel,
+        interpreter: Interpreter,
+        options?: InterpreterOptions
+      ) => {
+        if (typeof schema === 'boolean' || isModelObject(model) === false) {
+          return;
+        }
+
+        // Here we ensure that if additionalProperties are missing
+        // then schema schema.additionalProperties will set to false
+        const additionalPropertiesModel = interpreter.interpret(
+          schema.additionalProperties === undefined
+            ? false
+            : schema.additionalProperties,
+          options
+        );
+        if (additionalPropertiesModel !== undefined) {
+          model.addAdditionalProperty(additionalPropertiesModel, schema);
+        }
+      }
+    }
+  }
+});
+
+const jsonSchemaDraft7 = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  type: 'object',
+  properties: {
+    email: {
+      type: 'string',
+      format: 'email'
+    }
+  }
+};
+
+export async function generate(): Promise<void> {
+  const models = await generator.generate(jsonSchemaDraft7);
+  for (const model of models) {
+    console.log(model.result);
+  }
+}
+if (require.main === module) {
+  generate();
+}

--- a/examples/overwrite-interpreter-options/index.ts
+++ b/examples/overwrite-interpreter-options/index.ts
@@ -10,28 +10,7 @@ import { isModelObject } from '../../src/interpreter/Utils';
 const generator = new TypeScriptGenerator({
   processorOptions: {
     interpreter: {
-      additionalProperties: (
-        schema: InterpreterSchemaType,
-        model: CommonModel,
-        interpreter: Interpreter,
-        options?: InterpreterOptions
-      ) => {
-        if (typeof schema === 'boolean' || isModelObject(model) === false) {
-          return;
-        }
-
-        // Here we ensure that if additionalProperties are missing
-        // then schema schema.additionalProperties will set to false
-        const additionalPropertiesModel = interpreter.interpret(
-          schema.additionalProperties === undefined
-            ? false
-            : schema.additionalProperties,
-          options
-        );
-        if (additionalPropertiesModel !== undefined) {
-          model.addAdditionalProperty(additionalPropertiesModel, schema);
-        }
-      }
+      ignoreAdditionalProperties: true
     }
   }
 });

--- a/examples/overwrite-interpreter-options/package-lock.json
+++ b/examples/overwrite-interpreter-options/package-lock.json
@@ -1,0 +1,10 @@
+{
+  "name": "overwrite-interpreter-options",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "hasInstallScript": true
+    }
+  }
+}

--- a/examples/overwrite-interpreter-options/package.json
+++ b/examples/overwrite-interpreter-options/package.json
@@ -1,0 +1,10 @@
+{
+  "config" : { "example_name" : "overwrite-interpreter-options" },
+  "scripts": {
+    "install": "cd ../.. && npm i",
+    "start": "../../node_modules/.bin/ts-node --cwd ../../ ./examples/$npm_package_config_example_name/index.ts",
+    "start:windows": "..\\..\\node_modules\\.bin\\ts-node --cwd ..\\..\\ .\\examples\\%npm_package_config_example_name%\\index.ts",
+    "test": "../../node_modules/.bin/jest --config=../../jest.config.js ./examples/$npm_package_config_example_name/index.spec.ts",
+    "test:windows": "..\\..\\node_modules\\.bin\\jest --config=..\\..\\jest.config.js examples/%npm_package_config_example_name%/index.spec.ts"
+  }
+}

--- a/src/interpreter/InterpretAdditionalItems.ts
+++ b/src/interpreter/InterpretAdditionalItems.ts
@@ -22,8 +22,12 @@ export default function interpretAdditionalItems(
   if (typeof schema === 'boolean' || model.type?.includes('array') === false) {
     return;
   }
+  const ignoreAdditionalItems =
+    interpreterOptions.ignoreAdditionalItems || false;
   const additionalItemsModel = interpreter.interpret(
-    schema.additionalItems === undefined ? true : schema.additionalItems,
+    schema.additionalItems === undefined
+      ? !ignoreAdditionalItems
+      : schema.additionalItems,
     interpreterOptions
   );
   if (additionalItemsModel !== undefined) {

--- a/src/interpreter/InterpretAdditionalProperties.ts
+++ b/src/interpreter/InterpretAdditionalProperties.ts
@@ -23,9 +23,11 @@ export default function interpretAdditionalProperties(
   if (typeof schema === 'boolean' || isModelObject(model) === false) {
     return;
   }
+  const ignoreAdditionalProperties =
+    interpreterOptions.ignoreAdditionalProperties || false;
   const additionalPropertiesModel = interpreter.interpret(
     schema.additionalProperties === undefined
-      ? true
+      ? !ignoreAdditionalProperties
       : schema.additionalProperties,
     interpreterOptions
   );

--- a/src/interpreter/Interpreter.ts
+++ b/src/interpreter/Interpreter.ts
@@ -64,7 +64,6 @@ export class Interpreter {
     const: interpretConst,
     enum: interpretEnum
   };
-  static NOOP_FUNC = (): void => { return; };
 
   private anonymCounter = 1;
   private seenSchemas: Map<InterpreterSchemaType, CommonModel> = new Map();
@@ -123,11 +122,7 @@ export class Interpreter {
     }
   }
 
-  private interpretSchemaObject(
-    model: CommonModel,
-    schema: InterpreterSchemas,
-    interpreterOptions: InterpreterOptions = Interpreter.defaultInterpreterOptions
-  ) {
+  private interpretSchemaObject(model: CommonModel, schema: InterpreterSchemas, interpreterOptions: InterpreterOptions = Interpreter.defaultInterpreterOptions) {
     if (schema.type !== undefined) {
       model.addTypes(schema.type);
     }
@@ -188,6 +183,7 @@ export class Interpreter {
     //All schemas MUST have ids as we do not know how it will be generated and when it will be needed
     model.$id = interpretName(schema) || `anonymSchema${this.anonymCounter++}`;
   }
+  /* eslint-enable sonarjs/cognitive-complexity */
 
   /**
    * Go through a schema and combine the interpreted models together.

--- a/src/interpreter/Interpreter.ts
+++ b/src/interpreter/Interpreter.ts
@@ -22,21 +22,49 @@ import interpretAnyOf from './InterpretAnyOf';
 import interpretOneOfWithAllOf from './InterpretOneOfWithAllOf';
 import interpretOneOfWithProperties from './InterpretOneOfWithProperties';
 
+/* eslint-disable no-use-before-define */
+export type InterpreterComplexFunc = (schema: InterpreterSchemaType, model: CommonModel, interpreter : Interpreter, options?: InterpreterOptions) => void;
+export type InterpreterFunc = (schema: InterpreterSchemaType, model: CommonModel) => void;
 export type InterpreterOptions = {
-  allowInheritance?: boolean;
+  allowInheritance?: boolean,
+  patternProperties?: InterpreterComplexFunc,
+  additionalProperties?: InterpreterComplexFunc,
+  additionalItems?: InterpreterComplexFunc,
+  items?: InterpreterComplexFunc,
+  properties?: InterpreterComplexFunc,
+  allOf?: InterpreterComplexFunc,
+  oneOf?: InterpreterComplexFunc,
+  oneOfWithAllOf?: InterpreterComplexFunc,
+  oneOfWithProperties?: InterpreterComplexFunc,
+  anyOf?: InterpreterComplexFunc,
+  dependencies?: InterpreterComplexFunc,
+  not?: InterpreterComplexFunc,
+  const?: InterpreterFunc,
+  enum?: InterpreterFunc
 };
-export type InterpreterSchemas =
-  | Draft6Schema
-  | Draft4Schema
-  | Draft7Schema
-  | SwaggerV2Schema
-  | AsyncapiV2Schema;
+/* eslint-enable no-use-before-define */
+export type InterpreterSchemas = Draft6Schema | Draft4Schema | Draft7Schema | SwaggerV2Schema | AsyncapiV2Schema;
 export type InterpreterSchemaType = InterpreterSchemas | boolean;
 
 export class Interpreter {
   static defaultInterpreterOptions: InterpreterOptions = {
-    allowInheritance: false
+    allowInheritance: false,
+    patternProperties: interpretPatternProperties,
+    additionalProperties: interpretAdditionalProperties,
+    additionalItems: interpretAdditionalItems,
+    items: interpretItems,
+    properties: interpretProperties,
+    allOf: interpretAllOf,
+    oneOf: interpretOneOf,
+    oneOfWithAllOf: interpretOneOfWithAllOf,
+    oneOfWithProperties: interpretOneOfWithProperties,
+    anyOf: interpretAnyOf,
+    dependencies: interpretDependencies,
+    not: interpretNot,
+    const: interpretConst,
+    enum: interpretEnum
   };
+  static NOOP_FUNC = (): void => { return; };
 
   private anonymCounter = 1;
   private seenSchemas: Map<InterpreterSchemaType, CommonModel> = new Map();
@@ -107,19 +135,35 @@ export class Interpreter {
       model.required = schema.required;
     }
 
-    interpretPatternProperties(schema, model, this, interpreterOptions);
-    interpretAdditionalProperties(schema, model, this, interpreterOptions);
-    interpretAdditionalItems(schema, model, this, interpreterOptions);
-    interpretItems(schema, model, this, interpreterOptions);
-    interpretProperties(schema, model, this, interpreterOptions);
-    interpretAllOf(schema, model, this, interpreterOptions);
-    interpretOneOf(schema, model, this, interpreterOptions);
-    interpretOneOfWithAllOf(schema, model, this, interpreterOptions);
-    interpretOneOfWithProperties(schema, model, this, interpreterOptions);
-    interpretAnyOf(schema, model, this, interpreterOptions);
-    interpretDependencies(schema, model, this, interpreterOptions);
-    interpretConst(schema, model);
-    interpretEnum(schema, model);
+    const defaultInterpreterOptions = Interpreter.defaultInterpreterOptions;
+    const patternPropertiesFunc = (interpreterOptions.patternProperties || defaultInterpreterOptions.patternProperties) as InterpreterComplexFunc;
+    const additionalPropertiesFunc = (interpreterOptions.additionalProperties || defaultInterpreterOptions.additionalProperties) as InterpreterComplexFunc;
+    const additionalItemsFunc = (interpreterOptions.additionalItems || defaultInterpreterOptions.additionalItems) as InterpreterComplexFunc;
+    const itemsFunc = (interpreterOptions.items || defaultInterpreterOptions.items) as InterpreterComplexFunc;
+    const propertiesFunc = (interpreterOptions.properties || defaultInterpreterOptions.properties) as InterpreterComplexFunc;
+    const allOfFunc = (interpreterOptions.allOf || defaultInterpreterOptions.allOf) as InterpreterComplexFunc;
+    const oneOfFunc = (interpreterOptions.oneOf || defaultInterpreterOptions.oneOf) as InterpreterComplexFunc;
+    const oneOfWithAllOfFunc = (interpreterOptions.oneOfWithAllOf || defaultInterpreterOptions.oneOfWithAllOf) as InterpreterComplexFunc;
+    const oneOfWithPropertiesFunc = (interpreterOptions.oneOfWithProperties || defaultInterpreterOptions.oneOfWithProperties) as InterpreterComplexFunc;
+    const anyOfFunc = (interpreterOptions.anyOf || defaultInterpreterOptions.anyOf) as InterpreterComplexFunc;
+    const dependenciesFunc = (interpreterOptions.dependencies || defaultInterpreterOptions.dependencies) as InterpreterComplexFunc;
+    const constFunc = (interpreterOptions.const || defaultInterpreterOptions.const) as InterpreterFunc;
+    const enumFunc = (interpreterOptions.enum || defaultInterpreterOptions.enum) as InterpreterFunc;
+    const notFunc = (interpreterOptions.not || defaultInterpreterOptions.not) as InterpreterComplexFunc;
+
+    patternPropertiesFunc(schema, model, this, interpreterOptions);
+    additionalPropertiesFunc(schema, model, this, interpreterOptions);
+    additionalItemsFunc(schema, model, this, interpreterOptions);
+    itemsFunc(schema, model, this, interpreterOptions);
+    propertiesFunc(schema, model, this, interpreterOptions);
+    allOfFunc(schema, model, this, interpreterOptions);
+    oneOfFunc(schema, model, this, interpreterOptions);
+    oneOfWithAllOfFunc(schema, model, this, interpreterOptions);
+    oneOfWithPropertiesFunc(schema, model, this, interpreterOptions);
+    anyOfFunc(schema, model, this, interpreterOptions);
+    dependenciesFunc(schema, model, this, interpreterOptions);
+    constFunc(schema, model);
+    enumFunc(schema, model);
 
     if (
       !(schema instanceof Draft4Schema) &&
@@ -139,7 +183,7 @@ export class Interpreter {
       );
     }
 
-    interpretNot(schema, model, this, interpreterOptions);
+    notFunc(schema, model, this, interpreterOptions);
 
     //All schemas MUST have ids as we do not know how it will be generated and when it will be needed
     model.$id = interpretName(schema) || `anonymSchema${this.anonymCounter++}`;

--- a/src/interpreter/Interpreter.ts
+++ b/src/interpreter/Interpreter.ts
@@ -23,27 +23,40 @@ import interpretOneOfWithAllOf from './InterpretOneOfWithAllOf';
 import interpretOneOfWithProperties from './InterpretOneOfWithProperties';
 
 /* eslint-disable no-use-before-define */
-export type InterpreterComplexFunc = (schema: InterpreterSchemaType, model: CommonModel, interpreter : Interpreter, options?: InterpreterOptions) => void;
-export type InterpreterFunc = (schema: InterpreterSchemaType, model: CommonModel) => void;
+export type InterpreterComplexFunc = (
+  schema: InterpreterSchemaType,
+  model: CommonModel,
+  interpreter: Interpreter,
+  options?: InterpreterOptions
+) => void;
+export type InterpreterFunc = (
+  schema: InterpreterSchemaType,
+  model: CommonModel
+) => void;
 export type InterpreterOptions = {
-  allowInheritance?: boolean,
-  patternProperties?: InterpreterComplexFunc,
-  additionalProperties?: InterpreterComplexFunc,
-  additionalItems?: InterpreterComplexFunc,
-  items?: InterpreterComplexFunc,
-  properties?: InterpreterComplexFunc,
-  allOf?: InterpreterComplexFunc,
-  oneOf?: InterpreterComplexFunc,
-  oneOfWithAllOf?: InterpreterComplexFunc,
-  oneOfWithProperties?: InterpreterComplexFunc,
-  anyOf?: InterpreterComplexFunc,
-  dependencies?: InterpreterComplexFunc,
-  not?: InterpreterComplexFunc,
-  const?: InterpreterFunc,
-  enum?: InterpreterFunc
+  allowInheritance?: boolean;
+  patternProperties?: InterpreterComplexFunc;
+  additionalProperties?: InterpreterComplexFunc;
+  additionalItems?: InterpreterComplexFunc;
+  items?: InterpreterComplexFunc;
+  properties?: InterpreterComplexFunc;
+  allOf?: InterpreterComplexFunc;
+  oneOf?: InterpreterComplexFunc;
+  oneOfWithAllOf?: InterpreterComplexFunc;
+  oneOfWithProperties?: InterpreterComplexFunc;
+  anyOf?: InterpreterComplexFunc;
+  dependencies?: InterpreterComplexFunc;
+  not?: InterpreterComplexFunc;
+  const?: InterpreterFunc;
+  enum?: InterpreterFunc;
 };
 /* eslint-enable no-use-before-define */
-export type InterpreterSchemas = Draft6Schema | Draft4Schema | Draft7Schema | SwaggerV2Schema | AsyncapiV2Schema;
+export type InterpreterSchemas =
+  | Draft6Schema
+  | Draft4Schema
+  | Draft7Schema
+  | SwaggerV2Schema
+  | AsyncapiV2Schema;
 export type InterpreterSchemaType = InterpreterSchemas | boolean;
 
 export class Interpreter {
@@ -122,7 +135,12 @@ export class Interpreter {
     }
   }
 
-  private interpretSchemaObject(model: CommonModel, schema: InterpreterSchemas, interpreterOptions: InterpreterOptions = Interpreter.defaultInterpreterOptions) {
+  // eslint-disable-next-line sonarjs/cognitive-complexity
+  private interpretSchemaObject(
+    model: CommonModel,
+    schema: InterpreterSchemas,
+    interpreterOptions: InterpreterOptions = Interpreter.defaultInterpreterOptions
+  ) {
     if (schema.type !== undefined) {
       model.addTypes(schema.type);
     }
@@ -131,20 +149,34 @@ export class Interpreter {
     }
 
     const defaultInterpreterOptions = Interpreter.defaultInterpreterOptions;
-    const patternPropertiesFunc = (interpreterOptions.patternProperties || defaultInterpreterOptions.patternProperties) as InterpreterComplexFunc;
-    const additionalPropertiesFunc = (interpreterOptions.additionalProperties || defaultInterpreterOptions.additionalProperties) as InterpreterComplexFunc;
-    const additionalItemsFunc = (interpreterOptions.additionalItems || defaultInterpreterOptions.additionalItems) as InterpreterComplexFunc;
-    const itemsFunc = (interpreterOptions.items || defaultInterpreterOptions.items) as InterpreterComplexFunc;
-    const propertiesFunc = (interpreterOptions.properties || defaultInterpreterOptions.properties) as InterpreterComplexFunc;
-    const allOfFunc = (interpreterOptions.allOf || defaultInterpreterOptions.allOf) as InterpreterComplexFunc;
-    const oneOfFunc = (interpreterOptions.oneOf || defaultInterpreterOptions.oneOf) as InterpreterComplexFunc;
-    const oneOfWithAllOfFunc = (interpreterOptions.oneOfWithAllOf || defaultInterpreterOptions.oneOfWithAllOf) as InterpreterComplexFunc;
-    const oneOfWithPropertiesFunc = (interpreterOptions.oneOfWithProperties || defaultInterpreterOptions.oneOfWithProperties) as InterpreterComplexFunc;
-    const anyOfFunc = (interpreterOptions.anyOf || defaultInterpreterOptions.anyOf) as InterpreterComplexFunc;
-    const dependenciesFunc = (interpreterOptions.dependencies || defaultInterpreterOptions.dependencies) as InterpreterComplexFunc;
-    const constFunc = (interpreterOptions.const || defaultInterpreterOptions.const) as InterpreterFunc;
-    const enumFunc = (interpreterOptions.enum || defaultInterpreterOptions.enum) as InterpreterFunc;
-    const notFunc = (interpreterOptions.not || defaultInterpreterOptions.not) as InterpreterComplexFunc;
+    const patternPropertiesFunc = (interpreterOptions.patternProperties ||
+      defaultInterpreterOptions.patternProperties) as InterpreterComplexFunc;
+    const additionalPropertiesFunc = (interpreterOptions.additionalProperties ||
+      defaultInterpreterOptions.additionalProperties) as InterpreterComplexFunc;
+    const additionalItemsFunc = (interpreterOptions.additionalItems ||
+      defaultInterpreterOptions.additionalItems) as InterpreterComplexFunc;
+    const itemsFunc = (interpreterOptions.items ||
+      defaultInterpreterOptions.items) as InterpreterComplexFunc;
+    const propertiesFunc = (interpreterOptions.properties ||
+      defaultInterpreterOptions.properties) as InterpreterComplexFunc;
+    const allOfFunc = (interpreterOptions.allOf ||
+      defaultInterpreterOptions.allOf) as InterpreterComplexFunc;
+    const oneOfFunc = (interpreterOptions.oneOf ||
+      defaultInterpreterOptions.oneOf) as InterpreterComplexFunc;
+    const oneOfWithAllOfFunc = (interpreterOptions.oneOfWithAllOf ||
+      defaultInterpreterOptions.oneOfWithAllOf) as InterpreterComplexFunc;
+    const oneOfWithPropertiesFunc = (interpreterOptions.oneOfWithProperties ||
+      defaultInterpreterOptions.oneOfWithProperties) as InterpreterComplexFunc;
+    const anyOfFunc = (interpreterOptions.anyOf ||
+      defaultInterpreterOptions.anyOf) as InterpreterComplexFunc;
+    const dependenciesFunc = (interpreterOptions.dependencies ||
+      defaultInterpreterOptions.dependencies) as InterpreterComplexFunc;
+    const constFunc = (interpreterOptions.const ||
+      defaultInterpreterOptions.const) as InterpreterFunc;
+    const enumFunc = (interpreterOptions.enum ||
+      defaultInterpreterOptions.enum) as InterpreterFunc;
+    const notFunc = (interpreterOptions.not ||
+      defaultInterpreterOptions.not) as InterpreterComplexFunc;
 
     patternPropertiesFunc(schema, model, this, interpreterOptions);
     additionalPropertiesFunc(schema, model, this, interpreterOptions);


### PR DESCRIPTION
**Description**
This is an enhancement that would allow anyone to override default interpreter behavior. Some of use cases are overriding default behavior of `additionalProperties`, `additionalItems` that would allow anyone to customize how these schema properties are handled. For example by default these properties are treated as `true`, however we might want to treat them as `false` during code gen.

A typical example using interpreter options would look like this:
```
const generator = new JavaGenerator({
  processorOptions: {
    interpreter: {
      allOf: (schema, model, interpreter, interpreterOptions) => {
        // some custom logic for interpreting "allOf"
      }
    }
  }
});
```

**Related issue(s)**
https://github.com/asyncapi/modelina/issues/916