### PR TITLE
fix: dart model naming should ignore `_` 

### DIFF
--- a/src/generators/dart/constrainer/ModelNameConstrainer.ts
+++ b/src/generators/dart/constrainer/ModelNameConstrainer.ts
@@ -13,7 +13,7 @@ export type ModelNameConstraints = {
 
 export const DefaultModelNameConstraints: ModelNameConstraints = {
   NO_SPECIAL_CHAR: (value: string) => {
-    return FormatHelpers.replaceSpecialCharacters(value, { exclude: [], separator: '_' });
+    return FormatHelpers.replaceSpecialCharacters(value, { exclude: ['_'], separator: '_' });
   },
   NO_NUMBER_START_CHAR,
   NO_EMPTY_VALUE,

--- a/src/generators/dart/constrainer/ModelNameConstrainer.ts
+++ b/src/generators/dart/constrainer/ModelNameConstrainer.ts
@@ -18,7 +18,7 @@ export const DefaultModelNameConstraints: ModelNameConstraints = {
   NO_NUMBER_START_CHAR,
   NO_EMPTY_VALUE,
   NAMING_FORMATTER: (value: string) => {
-    return FormatHelpers.toPascalCase(value);
+    return FormatHelpers.toPascalCaseMergingNumbers(value);
   },
   NO_RESERVED_KEYWORDS: (value: string) => {
     return NO_RESERVED_KEYWORDS(value, isReservedDartKeyword); 

--- a/test/generators/dart/constrainer/ModelNameConstrainer.spec.ts
+++ b/test/generators/dart/constrainer/ModelNameConstrainer.spec.ts
@@ -7,7 +7,7 @@ describe('ModelNameConstrainer', () => {
   });
   test('should never render number as start char', () => {
     const constrainedKey = DartDefaultConstraints.modelName({modelName: '1'});
-    expect(constrainedKey).toEqual('Number_1');
+    expect(constrainedKey).toEqual('Number1');
   });
   test('should never contain empty name', () => {
     const constrainedKey = DartDefaultConstraints.modelName({modelName: ''});
@@ -15,7 +15,7 @@ describe('ModelNameConstrainer', () => {
   });
   test('should use constant naming format', () => {
     const constrainedKey = DartDefaultConstraints.modelName({modelName: 'some weird_value!"#2'});
-    expect(constrainedKey).toEqual('SomeSpaceWeird_ValueExclamationQuotationHash_2');
+    expect(constrainedKey).toEqual('SomeSpaceWeirdValueExclamationQuotationHash2');
   });
   test('should never render reserved keywords', () => {
     const constrainedKey = DartDefaultConstraints.modelName({modelName: 'return'});

--- a/test/generators/dart/constrainer/ModelNameConstrainer.spec.ts
+++ b/test/generators/dart/constrainer/ModelNameConstrainer.spec.ts
@@ -15,7 +15,7 @@ describe('ModelNameConstrainer', () => {
   });
   test('should use constant naming format', () => {
     const constrainedKey = DartDefaultConstraints.modelName({modelName: 'some weird_value!"#2'});
-    expect(constrainedKey).toEqual('SomeSpaceWeirdUnderscoreValueExclamationQuotationHash_2');
+    expect(constrainedKey).toEqual('SomeSpaceWeird_ValueExclamationQuotationHash_2');
   });
   test('should never render reserved keywords', () => {
     const constrainedKey = DartDefaultConstraints.modelName({modelName: 'return'});


### PR DESCRIPTION
**Description**
This PR fixes the dart model naming constrainer to ignore `_` characters which we had before the constrainer functionality.