### PR TITLE
chore: add dependency manager for Kotlin

### DIFF
--- a/src/generators/kotlin/KotlinConstrainer.ts
+++ b/src/generators/kotlin/KotlinConstrainer.ts
@@ -1,9 +1,8 @@
 import { ConstrainedEnumValueModel } from '../../models';
-import { TypeMapping } from '../../helpers';
 import { defaultEnumKeyConstraints, defaultEnumValueConstraints } from './constrainer/EnumConstrainer';
 import { defaultModelNameConstraints } from './constrainer/ModelNameConstrainer';
 import { defaultPropertyKeyConstraints } from './constrainer/PropertyKeyConstrainer';
-import { KotlinOptions, KotlinTypeMapping } from './KotlinGenerator';
+import { KotlinTypeMapping } from './KotlinGenerator';
 
 function enumFormatToNumberType(enumValueModel: ConstrainedEnumValueModel, format: string): string {
   switch (format) {

--- a/src/generators/kotlin/KotlinConstrainer.ts
+++ b/src/generators/kotlin/KotlinConstrainer.ts
@@ -3,7 +3,7 @@ import { TypeMapping } from '../../helpers';
 import { defaultEnumKeyConstraints, defaultEnumValueConstraints } from './constrainer/EnumConstrainer';
 import { defaultModelNameConstraints } from './constrainer/ModelNameConstrainer';
 import { defaultPropertyKeyConstraints } from './constrainer/PropertyKeyConstrainer';
-import { KotlinOptions } from './KotlinGenerator';
+import { KotlinOptions, KotlinTypeMapping } from './KotlinGenerator';
 
 function enumFormatToNumberType(enumValueModel: ConstrainedEnumValueModel, format: string): string {
   switch (format) {
@@ -63,7 +63,7 @@ function interpretUnionValueType(types: string[]): string {
   return 'Any';
 }
 
-export const KotlinDefaultTypeMapping: TypeMapping<KotlinOptions> = {
+export const KotlinDefaultTypeMapping: KotlinTypeMapping = {
   Object ({constrainedModel}): string {
     return constrainedModel.name;
   },

--- a/src/generators/kotlin/KotlinDependencyManager.ts
+++ b/src/generators/kotlin/KotlinDependencyManager.ts
@@ -1,0 +1,21 @@
+import { ConstrainedMetaModel } from '../../models';
+import { AbstractDependencyManager } from '../AbstractDependencyManager';
+import { KotlinOptions } from './KotlinGenerator';
+
+export class KotlinDependencyManager extends AbstractDependencyManager {
+  constructor(
+    public options: KotlinOptions,
+    dependencies: string[] = []
+  ) {
+    super(dependencies);
+  }
+
+  /**
+   * Adds a dependency package ensuring correct syntax.
+   * 
+   * @param dependencyPackage package to import, for example `javax.validation.constraints.*`
+   */
+  addDependency(dependencyPackage: string): void {
+    super.addDependency(`import ${dependencyPackage}`);
+  }
+}

--- a/src/generators/kotlin/KotlinDependencyManager.ts
+++ b/src/generators/kotlin/KotlinDependencyManager.ts
@@ -1,4 +1,3 @@
-import { ConstrainedMetaModel } from '../../models';
 import { AbstractDependencyManager } from '../AbstractDependencyManager';
 import { KotlinOptions } from './KotlinGenerator';
 

--- a/src/generators/kotlin/KotlinGenerator.ts
+++ b/src/generators/kotlin/KotlinGenerator.ts
@@ -13,12 +13,14 @@ import { Logger } from '../..';
 import { constrainMetaModel, Constraints } from '../../helpers/ConstrainHelpers';
 import { KotlinDefaultConstraints, KotlinDefaultTypeMapping } from './KotlinConstrainer';
 import { DeepPartial, mergePartialAndDefault } from '../../utils/Partials';
+import { KotlinDependencyManager } from './KotlinDependencyManager';
 
 export interface KotlinOptions extends CommonGeneratorOptions<KotlinPreset> {
-  typeMapping: TypeMapping<KotlinOptions>;
+  typeMapping: TypeMapping<KotlinOptions, KotlinDependencyManager>;
   constraints: Constraints;
   collectionType: 'List' | 'Array';
 }
+export type KotlinTypeMapping = TypeMapping<KotlinOptions, KotlinDependencyManager>;
 export interface KotlinRenderCompleteModelOptions {
   packageName: string
 }
@@ -38,9 +40,30 @@ export class KotlinGenerator extends AbstractGenerator<KotlinOptions, KotlinRend
   constructor(
     options?: DeepPartial<KotlinOptions>,
   ) {
-    const realizedOptions = mergePartialAndDefault(KotlinGenerator.defaultOptions, options) as KotlinOptions;
+    const realizedOptions = KotlinGenerator.getKotlinOptions(options);
     super('Kotlin', realizedOptions);
   }
+
+
+  /**
+   * Returns the Kotlin options by merging custom options with default ones.
+   */
+  static getKotlinOptions(options?: DeepPartial<KotlinOptions>): KotlinOptions {
+    const optionsToUse = mergePartialAndDefault(KotlinGenerator.defaultOptions, options) as KotlinOptions;
+    //Always overwrite the dependency manager unless user explicitly state they want it (ignore default temporary dependency manager)
+    if (options?.dependencyManager === undefined) {
+      optionsToUse.dependencyManager = () => { return new KotlinDependencyManager(optionsToUse); };
+    }
+    return optionsToUse;
+  }
+
+  /**
+   * Wrapper to get an instance of the dependency manager
+   */
+  getDependencyManager(options: KotlinOptions): KotlinDependencyManager {
+    return this.getDependencyManagerInstance(options) as KotlinDependencyManager;
+  }
+
   /**
    * This function makes sure we split up the MetaModels accordingly to what we want to render as models.
    */
@@ -52,13 +75,16 @@ export class KotlinGenerator extends AbstractGenerator<KotlinOptions, KotlinRend
     return split(model, metaModelsToSplit);
   }
 
-  constrainToMetaModel(model: MetaModel): ConstrainedMetaModel {
-    return constrainMetaModel<KotlinOptions>(
-      this.options.typeMapping,
-      this.options.constraints,
+  constrainToMetaModel(model: MetaModel, options: DeepPartial<KotlinOptions>): ConstrainedMetaModel {
+    const optionsToUse = KotlinGenerator.getKotlinOptions({...this.options, ...options});
+    const dependencyManagerToUse = this.getDependencyManager(optionsToUse);
+    return constrainMetaModel<KotlinOptions, KotlinDependencyManager>(
+      optionsToUse.typeMapping,
+      optionsToUse.constraints,
       {
         metaModel: model,
-        options: this.options,
+        dependencyManager: dependencyManagerToUse,
+        options: optionsToUse,
         constrainedName: '' //This is just a placeholder, it will be constrained within the function
       }
     );
@@ -70,11 +96,12 @@ export class KotlinGenerator extends AbstractGenerator<KotlinOptions, KotlinRend
    * @param model
    * @param inputModel
    */
-  render(model: ConstrainedMetaModel, inputModel: InputMetaModel): Promise<RenderOutput> {
+  render(model: ConstrainedMetaModel, inputModel: InputMetaModel, options?: DeepPartial<KotlinOptions>): Promise<RenderOutput> {
+    const optionsToUse = KotlinGenerator.getKotlinOptions({...this.options, ...options});
     if (model instanceof ConstrainedObjectModel) {
-      return this.renderClass(model, inputModel);
+      return this.renderClass(model, inputModel, optionsToUse);
     } else if (model instanceof ConstrainedEnumModel) {
-      return this.renderEnum(model, inputModel);
+      return this.renderEnum(model, inputModel, optionsToUse);
     }
     Logger.warn(`Kotlin generator, cannot generate this type of model, ${model.name}`);
     return Promise.resolve(RenderOutput.toRenderOutput({ result: '', renderedName: '', dependencies: [] }));
@@ -90,8 +117,10 @@ export class KotlinGenerator extends AbstractGenerator<KotlinOptions, KotlinRend
    * @param options used to render the full output
    */
   async renderCompleteModel(model: ConstrainedMetaModel, inputModel: InputMetaModel, options: KotlinRenderCompleteModelOptions): Promise<RenderOutput> {
-    const outputModel = await this.render(model, inputModel);
+    const optionsToUse = KotlinGenerator.getKotlinOptions({...this.options, ...options});
+    const dependencyManagerToUse = this.getDependencyManager(optionsToUse);
 
+    const outputModel = await this.render(model, inputModel, optionsToUse);
     const packageName = this.sanitizePackageName(options.packageName);
     const outputContent = `package ${packageName}
 ${outputModel.dependencies.join('\n')}
@@ -107,17 +136,21 @@ ${outputModel.result}`;
       .join('.');
   }
 
-  async renderClass(model: ConstrainedObjectModel, inputModel: InputMetaModel): Promise<RenderOutput> {
+  async renderClass(model: ConstrainedObjectModel, inputModel: InputMetaModel, options?: DeepPartial<KotlinOptions>): Promise<RenderOutput> {
+    const optionsToUse = KotlinGenerator.getKotlinOptions({...this.options, ...options});
+    const dependencyManagerToUse = this.getDependencyManager(optionsToUse);
     const presets = this.getPresets('class');
-    const renderer = new ClassRenderer(this.options, this, presets, model, inputModel);
+    const renderer = new ClassRenderer(this.options, this, presets, model, inputModel, dependencyManagerToUse);
     const result = await renderer.runSelfPreset();
-    return RenderOutput.toRenderOutput({result, renderedName: model.name, dependencies: renderer.dependencies});
+    return RenderOutput.toRenderOutput({result, renderedName: model.name, dependencies: dependencyManagerToUse.dependencies});
   }
 
-  async renderEnum(model: ConstrainedEnumModel, inputModel: InputMetaModel): Promise<RenderOutput> {
+  async renderEnum(model: ConstrainedEnumModel, inputModel: InputMetaModel, options?: DeepPartial<KotlinOptions>): Promise<RenderOutput> {
+    const optionsToUse = KotlinGenerator.getKotlinOptions({...this.options, ...options});
+    const dependencyManagerToUse = this.getDependencyManager(optionsToUse);
     const presets = this.getPresets('enum');
-    const renderer = new EnumRenderer(this.options, this, presets, model, inputModel);
+    const renderer = new EnumRenderer(this.options, this, presets, model, inputModel, dependencyManagerToUse);
     const result = await renderer.runSelfPreset();
-    return RenderOutput.toRenderOutput({result, renderedName: model.name, dependencies: renderer.dependencies});
+    return RenderOutput.toRenderOutput({result, renderedName: model.name, dependencies: dependencyManagerToUse.dependencies});
   }
 }

--- a/src/generators/kotlin/KotlinGenerator.ts
+++ b/src/generators/kotlin/KotlinGenerator.ts
@@ -44,7 +44,6 @@ export class KotlinGenerator extends AbstractGenerator<KotlinOptions, KotlinRend
     super('Kotlin', realizedOptions);
   }
 
-
   /**
    * Returns the Kotlin options by merging custom options with default ones.
    */
@@ -118,8 +117,6 @@ export class KotlinGenerator extends AbstractGenerator<KotlinOptions, KotlinRend
    */
   async renderCompleteModel(model: ConstrainedMetaModel, inputModel: InputMetaModel, options: KotlinRenderCompleteModelOptions): Promise<RenderOutput> {
     const optionsToUse = KotlinGenerator.getKotlinOptions({...this.options, ...options});
-    const dependencyManagerToUse = this.getDependencyManager(optionsToUse);
-
     const outputModel = await this.render(model, inputModel, optionsToUse);
     const packageName = this.sanitizePackageName(options.packageName);
     const outputContent = `package ${packageName}

--- a/src/generators/kotlin/KotlinRenderer.ts
+++ b/src/generators/kotlin/KotlinRenderer.ts
@@ -2,6 +2,7 @@ import { AbstractRenderer } from '../AbstractRenderer';
 import { KotlinGenerator, KotlinOptions } from './KotlinGenerator';
 import { ConstrainedMetaModel, InputMetaModel, Preset } from '../../models';
 import { FormatHelpers } from '../../helpers';
+import { KotlinDependencyManager } from './KotlinDependencyManager';
 
 /**
  * Common renderer for Kotlin
@@ -15,6 +16,7 @@ export abstract class KotlinRenderer<RendererModelType extends ConstrainedMetaMo
     presets: Array<[Preset, unknown]>,
     model: RendererModelType,
     inputModel: InputMetaModel,
+    public dependencyManager: KotlinDependencyManager
   ) {
     super(options, generator, presets, model, inputModel);
   }

--- a/src/generators/kotlin/presets/ConstraintsPreset.ts
+++ b/src/generators/kotlin/presets/ConstraintsPreset.ts
@@ -11,7 +11,7 @@ import {ClassRenderer} from '../renderers/ClassRenderer';
 export const KOTLIN_CONSTRAINTS_PRESET: KotlinPreset = {
   class: {
     self({renderer, content}) {
-      renderer.addDependency('import javax.validation.constraints.*');
+      renderer.dependencyManager.addDependency('javax.validation.constraints.*');
       return content;
     },
     property({ renderer, property, content}) {

--- a/test/generators/kotlin/KotlinDependencyManager.spec.ts
+++ b/test/generators/kotlin/KotlinDependencyManager.spec.ts
@@ -1,0 +1,11 @@
+import { KotlinGenerator } from '../../../src/generators';
+import { KotlinDependencyManager } from '../../../src/generators/kotlin/KotlinDependencyManager';
+describe('KotlinDependencyManager', () => {
+  describe('addDependency()', () => {
+    test('Should be able to render dependency', () => {
+      const dependencyManager = new KotlinDependencyManager(KotlinGenerator.defaultOptions, []);
+      dependencyManager.addDependency('javax.validation.*');
+      expect(dependencyManager.dependencies).toEqual(['import javax.validation.*']);
+    });
+  });
+});


### PR DESCRIPTION
**Description**
This PR adds the final piece to the puzzle ([before releasing the feature](https://github.com/asyncapi/modelina/pull/1063)) and adds the dependency manager to Kotlin.

This is a core Modelina feature replicated across all generators that enables a few things.
1. It lets users add dependencies for models during the constraint phase, i.e. solving: https://github.com/asyncapi/modelina/issues/546#issuecomment-1209340325
2. It enables greater separation of logic for handling dependencies within one specific file instead of it being part of the renderer.
3. Subsequently the architecture enables greater precision of rendering models where we now have 3 different levels of options: https://github.com/asyncapi/modelina/pull/1063/files#diff-72376d0b487d7231cf31959bf266f6aea098e899743bae02e36d176cef4db476
 
@LouisXhaferi like the rest of the champions, it's up to you to decide how involved you want to be with the core Modelina changes, it's perfectly fine to say you don't want to invest the time into reviewing these types of changes, just let us know ASAP so another core champion can review it 🙂 Otherwise, by default I assume you want to review it 🙂 