### PR TITLE
fix: do not honor ignoreAdditionalProperties and ignoreAddtionalItems if properties exist

### DIFF
--- a/src/interpreter/InterpretAdditionalItems.ts
+++ b/src/interpreter/InterpretAdditionalItems.ts
@@ -19,14 +19,13 @@ export default function interpretAdditionalItems(
   interpreter: Interpreter,
   interpreterOptions: InterpreterOptions = Interpreter.defaultInterpreterOptions
 ): void {
-  if (interpreterOptions.ignoreAdditionalItems === true) {
-    return;
-  }
   if (typeof schema === 'boolean' || model.type?.includes('array') === false) {
     return;
   }
   const additionalItemsModel = interpreter.interpret(
-    schema.additionalItems === undefined ? true : schema.additionalItems,
+    schema.additionalItems === undefined
+      ? !interpreterOptions.ignoreAdditionalItems
+      : schema.additionalItems,
     interpreterOptions
   );
   if (additionalItemsModel !== undefined) {

--- a/src/interpreter/InterpretAdditionalProperties.ts
+++ b/src/interpreter/InterpretAdditionalProperties.ts
@@ -20,15 +20,12 @@ export default function interpretAdditionalProperties(
   interpreter: Interpreter,
   interpreterOptions: InterpreterOptions = Interpreter.defaultInterpreterOptions
 ): void {
-  if (interpreterOptions.ignoreAdditionalProperties === true) {
-    return;
-  }
   if (typeof schema === 'boolean' || isModelObject(model) === false) {
     return;
   }
   const additionalPropertiesModel = interpreter.interpret(
     schema.additionalProperties === undefined
-      ? true
+      ? !interpreterOptions.ignoreAdditionalProperties
       : schema.additionalProperties,
     interpreterOptions
   );


### PR DESCRIPTION
**Description**
Recently we have introduced the ability to handle the default behavior of `additionalProperties` and `additionalItems`. However we might have introduced an unintended side effect. For example for a schema like:
```
{
  $schema: 'http://json-schema.org/draft-07/schema#',
  type: 'object',
  properties: {
    email: {
      type: 'string',
      format: 'email'
    }
  }
}
```
If we use `ignoreAdditionalProperties` then for TypeScript generator we would get something like:
```
class Root {
  private _email?: string;

  constructor(input: {
    email?: string,
  }) {
    this._email = input.email;
  }

  get email(): string | undefined { return this._email; }
  set email(email: string | undefined) { this._email = email; }
}
```
For a schema like this:
```
{
  $schema: 'http://json-schema.org/draft-07/schema#',
  type: 'object',
  properties: {
    email: {
      type: 'string',
      format: 'email'
    }
  },
  additionalProperties: {
     type: 'string'
  }
}
```
We would get the same TypeScript output.

My proposal is to fix this and ensure that the output is something like:
```
class Root {
  private _email?: string;
  private _additionalProperties?: Map<string, string>;

  constructor(input: {
    email?: string,
    additionalProperties?: Map<string, string>,
  }) {
    this._email = input.email;
    this._additionalProperties = input.additionalProperties;
  }

  get email(): string | undefined { return this._email; }
  set email(email: string | undefined) { this._email = email; }

  get additionalProperties(): Map<string, string> | undefined { return this._additionalProperties; }
  set additionalProperties(additionalProperties: Map<string, string> | undefined) { this._additionalProperties = additionalProperties; }
}
```

The reasoning being that `ignoreAdditionalProperties` should affect ONLY the default JSON schema behavior, however if user explicitly sets it to some other value `ignoreAdditionalProperties` should have no effect.