### PR TITLE
fix: add conditions for when to ignore additionalProperties and additionalItems

### DIFF
--- a/src/interpreter/InterpretAdditionalItems.ts
+++ b/src/interpreter/InterpretAdditionalItems.ts
@@ -25,11 +25,15 @@ export default function interpretAdditionalItems(
   const hasArrayTypes = schema.items !== undefined;
   let defaultAdditionalItems = true;
   if (hasArrayTypes && interpreterOptions.ignoreAdditionalItems !== undefined) {
-    defaultAdditionalItems = interpreterOptions.ignoreAdditionalItems ? false : true;
+    defaultAdditionalItems = interpreterOptions.ignoreAdditionalItems
+      ? false
+      : true;
   }
 
   const additionalItemsModel = interpreter.interpret(
-    schema.additionalItems === undefined ? defaultAdditionalItems : schema.additionalItems,
+    schema.additionalItems === undefined
+      ? defaultAdditionalItems
+      : schema.additionalItems,
     interpreterOptions
   );
   if (additionalItemsModel !== undefined) {

--- a/src/interpreter/InterpretAdditionalItems.ts
+++ b/src/interpreter/InterpretAdditionalItems.ts
@@ -19,14 +19,17 @@ export default function interpretAdditionalItems(
   interpreter: Interpreter,
   interpreterOptions: InterpreterOptions = Interpreter.defaultInterpreterOptions
 ): void {
-  if (interpreterOptions.ignoreAdditionalItems === true) {
-    return;
-  }
   if (typeof schema === 'boolean' || model.type?.includes('array') === false) {
     return;
   }
+  const hasArrayTypes = schema.items !== undefined;
+  let defaultAdditionalItems = true;
+  if (hasArrayTypes && interpreterOptions.ignoreAdditionalItems !== undefined) {
+    defaultAdditionalItems = interpreterOptions.ignoreAdditionalItems ? false : true;
+  }
+
   const additionalItemsModel = interpreter.interpret(
-    schema.additionalItems === undefined ? true : schema.additionalItems,
+    schema.additionalItems === undefined ? defaultAdditionalItems : schema.additionalItems,
     interpreterOptions
   );
   if (additionalItemsModel !== undefined) {

--- a/src/interpreter/InterpretAdditionalProperties.ts
+++ b/src/interpreter/InterpretAdditionalProperties.ts
@@ -26,19 +26,20 @@ export default function interpretAdditionalProperties(
   let defaultAdditionalProperties = true;
   const hasProperties = Object.keys(schema.properties || {}).length > 0;
   //Only ignore additionalProperties if the schema already has properties defined, otherwise its gonna be interpreted as a map
-  if(hasProperties && interpreterOptions.ignoreAdditionalProperties === true) {
+  if (hasProperties && interpreterOptions.ignoreAdditionalProperties === true) {
     defaultAdditionalProperties = false;
   }
 
-  const additionalProperties = schema.additionalProperties === undefined
-    ? defaultAdditionalProperties
-    : schema.additionalProperties;
+  const additionalProperties =
+    schema.additionalProperties === undefined
+      ? defaultAdditionalProperties
+      : schema.additionalProperties;
 
   const additionalPropertiesModel = interpreter.interpret(
     additionalProperties,
     interpreterOptions
   );
-  
+
   if (additionalPropertiesModel !== undefined) {
     model.addAdditionalProperty(additionalPropertiesModel, schema);
   }

--- a/src/interpreter/InterpretAdditionalProperties.ts
+++ b/src/interpreter/InterpretAdditionalProperties.ts
@@ -20,18 +20,25 @@ export default function interpretAdditionalProperties(
   interpreter: Interpreter,
   interpreterOptions: InterpreterOptions = Interpreter.defaultInterpreterOptions
 ): void {
-  if (interpreterOptions.ignoreAdditionalProperties === true) {
-    return;
-  }
   if (typeof schema === 'boolean' || isModelObject(model) === false) {
     return;
   }
+  let defaultAdditionalProperties = true;
+  const hasProperties = Object.keys(schema.properties || {}).length > 0;
+  //Only ignore additionalProperties if the schema already has properties defined, otherwise its gonna be interpreted as a map
+  if(hasProperties && interpreterOptions.ignoreAdditionalProperties === true) {
+    defaultAdditionalProperties = false;
+  }
+
+  const additionalProperties = schema.additionalProperties === undefined
+    ? defaultAdditionalProperties
+    : schema.additionalProperties;
+
   const additionalPropertiesModel = interpreter.interpret(
-    schema.additionalProperties === undefined
-      ? true
-      : schema.additionalProperties,
+    additionalProperties,
     interpreterOptions
   );
+  
   if (additionalPropertiesModel !== undefined) {
     model.addAdditionalProperty(additionalPropertiesModel, schema);
   }

--- a/src/interpreter/Interpreter.ts
+++ b/src/interpreter/Interpreter.ts
@@ -25,19 +25,19 @@ import interpretOneOfWithProperties from './InterpretOneOfWithProperties';
 export type InterpreterOptions = {
   allowInheritance?: boolean;
   /**
-   * For JSON Schema draft 7, additionalProperties are by default true, but it might create an unintended property for the models. 
-   * 
+   * For JSON Schema draft 7, additionalProperties are by default true, but it might create an unintended property for the models.
+   *
    * Use this option to ignore default additionalProperties for models that has other properties with them.
-   * 
+   *
    * ONLY use this option if you do not have control over your schema files.
    * Instead adapt your schemas to be more strict by setting `additionalProperties: false`.
    */
   ignoreAdditionalProperties?: boolean;
   /**
    * For JSON Schema draft 7, additionalItems are by default true, but it might create an unintended types for arrays.
-   * 
+   *
    * Use this option to ignore default additionalItems for models, as long as there is other types sat for the array.
-   * 
+   *
    * ONLY use this option if you do not have control over the schema files you use to generate the models from.
    * Instead you should adapt your schemas to be more strict by setting `additionalItems: false`.
    */

--- a/src/interpreter/Interpreter.ts
+++ b/src/interpreter/Interpreter.ts
@@ -24,7 +24,23 @@ import interpretOneOfWithProperties from './InterpretOneOfWithProperties';
 
 export type InterpreterOptions = {
   allowInheritance?: boolean;
+  /**
+   * For JSON Schema draft 7, additionalProperties are by default true, but it might create an unintended property for the models. 
+   * 
+   * Use this option to ignore default additionalProperties for models that has other properties with them.
+   * 
+   * ONLY use this option if you do not have control over your schema files.
+   * Instead adapt your schemas to be more strict by setting `additionalProperties: false`.
+   */
   ignoreAdditionalProperties?: boolean;
+  /**
+   * For JSON Schema draft 7, additionalItems are by default true, but it might create an unintended types for arrays.
+   * 
+   * Use this option to ignore default additionalItems for models, as long as there is other types sat for the array.
+   * 
+   * ONLY use this option if you do not have control over the schema files you use to generate the models from.
+   * Instead you should adapt your schemas to be more strict by setting `additionalItems: false`.
+   */
   ignoreAdditionalItems?: boolean;
 };
 export type InterpreterSchemas =
@@ -112,8 +128,8 @@ export class Interpreter {
     }
 
     interpretPatternProperties(schema, model, this, interpreterOptions);
-    interpretAdditionalProperties(schema, model, this, interpreterOptions);
     interpretAdditionalItems(schema, model, this, interpreterOptions);
+    interpretAdditionalProperties(schema, model, this, interpreterOptions);
     interpretItems(schema, model, this, interpreterOptions);
     interpretProperties(schema, model, this, interpreterOptions);
     interpretAllOf(schema, model, this, interpreterOptions);

--- a/test/interpreter/unit/InterpretAdditionalItems.spec.ts
+++ b/test/interpreter/unit/InterpretAdditionalItems.spec.ts
@@ -94,21 +94,17 @@ describe('Interpretation of additionalItems', () => {
     );
   });
   test('should apply ignoreAdditionalItems for schemas with items', () => {
-    const schema: any = { items: {type: "string"}};
+    const schema: any = { items: { type: 'string' } };
     const model = new CommonModel();
     model.type = 'array';
     const interpreter = new Interpreter();
     const mockedReturnModel = new CommonModel();
-    const options = {ignoreAdditionalItems: true};
+    const options = { ignoreAdditionalItems: true };
     (interpreter.interpret as jest.Mock).mockReturnValue(mockedReturnModel);
 
     interpretAdditionalItems(schema, model, interpreter, options);
 
-    expect(interpreter.interpret).toHaveBeenNthCalledWith(
-      1,
-      false,
-      options
-    );
+    expect(interpreter.interpret).toHaveBeenNthCalledWith(1, false, options);
     expect(model.addAdditionalItems).toHaveBeenNthCalledWith(
       1,
       mockedReturnModel,
@@ -117,21 +113,17 @@ describe('Interpretation of additionalItems', () => {
   });
 
   test('should not apply ignoreAdditionalItems for schemas without items', () => {
-    const schema: any = { };
+    const schema: any = {};
     const model = new CommonModel();
     model.type = 'array';
     const interpreter = new Interpreter();
     const mockedReturnModel = new CommonModel();
-    const options = {ignoreAdditionalItems: true};
+    const options = { ignoreAdditionalItems: true };
     (interpreter.interpret as jest.Mock).mockReturnValue(mockedReturnModel);
 
     interpretAdditionalItems(schema, model, interpreter, options);
 
-    expect(interpreter.interpret).toHaveBeenNthCalledWith(
-      1,
-      true,
-      options
-    );
+    expect(interpreter.interpret).toHaveBeenNthCalledWith(1, true, options);
     expect(model.addAdditionalItems).toHaveBeenNthCalledWith(
       1,
       mockedReturnModel,
@@ -139,21 +131,17 @@ describe('Interpretation of additionalItems', () => {
     );
   });
   test('should not apply ignoreAdditionalItems for schemas with explicit additionalItems', () => {
-    const schema: any = { additionalItems: true};
+    const schema: any = { additionalItems: true };
     const model = new CommonModel();
     model.type = 'array';
     const interpreter = new Interpreter();
     const mockedReturnModel = new CommonModel();
-    const options = {ignoreAdditionalItems: true};
+    const options = { ignoreAdditionalItems: true };
     (interpreter.interpret as jest.Mock).mockReturnValue(mockedReturnModel);
 
     interpretAdditionalItems(schema, model, interpreter, options);
 
-    expect(interpreter.interpret).toHaveBeenNthCalledWith(
-      1,
-      true,
-      options
-    );
+    expect(interpreter.interpret).toHaveBeenNthCalledWith(1, true, options);
     expect(model.addAdditionalItems).toHaveBeenNthCalledWith(
       1,
       mockedReturnModel,

--- a/test/interpreter/unit/InterpretAdditionalItems.spec.ts
+++ b/test/interpreter/unit/InterpretAdditionalItems.spec.ts
@@ -93,4 +93,71 @@ describe('Interpretation of additionalItems', () => {
       schema
     );
   });
+  test('should apply ignoreAdditionalItems for schemas with items', () => {
+    const schema: any = { items: {type: "string"}};
+    const model = new CommonModel();
+    model.type = 'array';
+    const interpreter = new Interpreter();
+    const mockedReturnModel = new CommonModel();
+    const options = {ignoreAdditionalItems: true};
+    (interpreter.interpret as jest.Mock).mockReturnValue(mockedReturnModel);
+
+    interpretAdditionalItems(schema, model, interpreter, options);
+
+    expect(interpreter.interpret).toHaveBeenNthCalledWith(
+      1,
+      false,
+      options
+    );
+    expect(model.addAdditionalItems).toHaveBeenNthCalledWith(
+      1,
+      mockedReturnModel,
+      schema
+    );
+  });
+
+  test('should not apply ignoreAdditionalItems for schemas without items', () => {
+    const schema: any = { };
+    const model = new CommonModel();
+    model.type = 'array';
+    const interpreter = new Interpreter();
+    const mockedReturnModel = new CommonModel();
+    const options = {ignoreAdditionalItems: true};
+    (interpreter.interpret as jest.Mock).mockReturnValue(mockedReturnModel);
+
+    interpretAdditionalItems(schema, model, interpreter, options);
+
+    expect(interpreter.interpret).toHaveBeenNthCalledWith(
+      1,
+      true,
+      options
+    );
+    expect(model.addAdditionalItems).toHaveBeenNthCalledWith(
+      1,
+      mockedReturnModel,
+      schema
+    );
+  });
+  test('should not apply ignoreAdditionalItems for schemas with explicit additionalItems', () => {
+    const schema: any = { additionalItems: true};
+    const model = new CommonModel();
+    model.type = 'array';
+    const interpreter = new Interpreter();
+    const mockedReturnModel = new CommonModel();
+    const options = {ignoreAdditionalItems: true};
+    (interpreter.interpret as jest.Mock).mockReturnValue(mockedReturnModel);
+
+    interpretAdditionalItems(schema, model, interpreter, options);
+
+    expect(interpreter.interpret).toHaveBeenNthCalledWith(
+      1,
+      true,
+      options
+    );
+    expect(model.addAdditionalItems).toHaveBeenNthCalledWith(
+      1,
+      mockedReturnModel,
+      schema
+    );
+  });
 });

--- a/test/interpreter/unit/InterpretAdditionalProperties.spec.ts
+++ b/test/interpreter/unit/InterpretAdditionalProperties.spec.ts
@@ -93,4 +93,70 @@ describe('Interpretation of additionalProperties', () => {
       schema
     );
   });
+  test('should apply ignoreAdditionalProperties for schemas with properties', () => {
+    const schema: any = { properties: { property1: { type: 'string' } } };;
+    const model = new CommonModel();
+    model.type = 'object';
+    const interpreter = new Interpreter();
+    const options = {ignoreAdditionalProperties: true};
+    const mockedReturnModel = new CommonModel();
+    (interpreter.interpret as jest.Mock).mockReturnValue(mockedReturnModel);
+
+    interpretAdditionalProperties(schema, model, interpreter, options);
+
+    expect(interpreter.interpret).toHaveBeenNthCalledWith(
+      1,
+      false,
+      options
+    );
+    expect(model.addAdditionalProperty).toHaveBeenNthCalledWith(
+      1,
+      mockedReturnModel,
+      schema
+    );
+  });
+  test('should not apply ignoreAdditionalProperties for schemas explicit additionalProperties', () => {
+    const schema: any = { additionalProperties: true };;
+    const model = new CommonModel();
+    model.type = 'object';
+    const interpreter = new Interpreter();
+    const options = {ignoreAdditionalProperties: true};
+    const mockedReturnModel = new CommonModel();
+    (interpreter.interpret as jest.Mock).mockReturnValue(mockedReturnModel);
+
+    interpretAdditionalProperties(schema, model, interpreter, options);
+
+    expect(interpreter.interpret).toHaveBeenNthCalledWith(
+      1,
+      true,
+      options
+    );
+    expect(model.addAdditionalProperty).toHaveBeenNthCalledWith(
+      1,
+      mockedReturnModel,
+      schema
+    );
+  });
+  test('should not apply ignoreAdditionalProperties if no other properties defined', () => {
+    const schema: any = { };;
+    const model = new CommonModel();
+    model.type = 'object';
+    const interpreter = new Interpreter();
+    const options = {ignoreAdditionalProperties: true};
+    const mockedReturnModel = new CommonModel();
+    (interpreter.interpret as jest.Mock).mockReturnValue(mockedReturnModel);
+
+    interpretAdditionalProperties(schema, model, interpreter, options);
+
+    expect(interpreter.interpret).toHaveBeenNthCalledWith(
+      1,
+      true,
+      options
+    );
+    expect(model.addAdditionalProperty).toHaveBeenNthCalledWith(
+      1,
+      mockedReturnModel,
+      schema
+    );
+  });
 });

--- a/test/interpreter/unit/InterpretAdditionalProperties.spec.ts
+++ b/test/interpreter/unit/InterpretAdditionalProperties.spec.ts
@@ -94,21 +94,17 @@ describe('Interpretation of additionalProperties', () => {
     );
   });
   test('should apply ignoreAdditionalProperties for schemas with properties', () => {
-    const schema: any = { properties: { property1: { type: 'string' } } };;
+    const schema: any = { properties: { property1: { type: 'string' } } };
     const model = new CommonModel();
     model.type = 'object';
     const interpreter = new Interpreter();
-    const options = {ignoreAdditionalProperties: true};
+    const options = { ignoreAdditionalProperties: true };
     const mockedReturnModel = new CommonModel();
     (interpreter.interpret as jest.Mock).mockReturnValue(mockedReturnModel);
 
     interpretAdditionalProperties(schema, model, interpreter, options);
 
-    expect(interpreter.interpret).toHaveBeenNthCalledWith(
-      1,
-      false,
-      options
-    );
+    expect(interpreter.interpret).toHaveBeenNthCalledWith(1, false, options);
     expect(model.addAdditionalProperty).toHaveBeenNthCalledWith(
       1,
       mockedReturnModel,
@@ -116,21 +112,17 @@ describe('Interpretation of additionalProperties', () => {
     );
   });
   test('should not apply ignoreAdditionalProperties for schemas explicit additionalProperties', () => {
-    const schema: any = { additionalProperties: true };;
+    const schema: any = { additionalProperties: true };
     const model = new CommonModel();
     model.type = 'object';
     const interpreter = new Interpreter();
-    const options = {ignoreAdditionalProperties: true};
+    const options = { ignoreAdditionalProperties: true };
     const mockedReturnModel = new CommonModel();
     (interpreter.interpret as jest.Mock).mockReturnValue(mockedReturnModel);
 
     interpretAdditionalProperties(schema, model, interpreter, options);
 
-    expect(interpreter.interpret).toHaveBeenNthCalledWith(
-      1,
-      true,
-      options
-    );
+    expect(interpreter.interpret).toHaveBeenNthCalledWith(1, true, options);
     expect(model.addAdditionalProperty).toHaveBeenNthCalledWith(
       1,
       mockedReturnModel,
@@ -138,21 +130,17 @@ describe('Interpretation of additionalProperties', () => {
     );
   });
   test('should not apply ignoreAdditionalProperties if no other properties defined', () => {
-    const schema: any = { };;
+    const schema: any = {};
     const model = new CommonModel();
     model.type = 'object';
     const interpreter = new Interpreter();
-    const options = {ignoreAdditionalProperties: true};
+    const options = { ignoreAdditionalProperties: true };
     const mockedReturnModel = new CommonModel();
     (interpreter.interpret as jest.Mock).mockReturnValue(mockedReturnModel);
 
     interpretAdditionalProperties(schema, model, interpreter, options);
 
-    expect(interpreter.interpret).toHaveBeenNthCalledWith(
-      1,
-      true,
-      options
-    );
+    expect(interpreter.interpret).toHaveBeenNthCalledWith(1, true, options);
     expect(model.addAdditionalProperty).toHaveBeenNthCalledWith(
       1,
       mockedReturnModel,


### PR DESCRIPTION
**Description**
This PR fixes the two options always ignoring additionalProperties and additionalItems when it should be conditional on two things:

1. Should only apply on when defaulting, not when explicitly defined.
2. ignoreAdditionalProperties should only apply when the schema has properties, otherwise its normally later interpreted as a map type which is intended.
3. ignoreAdditionalProperties should only apply when the schema has explicit types defined, otherwise its the same as setting types explicitly.