### PR TITLE
fix!: additionalItems being applied for regular arrays

### DIFF
--- a/docs/migrations/version-1-to-2.md
+++ b/docs/migrations/version-1-to-2.md
@@ -49,3 +49,28 @@ components:
 ```
 
 The _type_ property in the _CloudEvent_ schema will in this case have an _anonymous_schema_ id. If another schema in the _allOf_ list has the same property and an id other than _anonymous_schema_, it will now use that id. Meaning, in this example, it will be _DogType_ and _CatType_.
+
+## Accurate array types
+
+For JSON Schema inputs (indirectly for AsyncAPI and OpenAPI), `additionalItems` was applied to regular array types, when it should only be applied for tuples.
+
+This means that a schema such as:
+```
+    "tags": {
+      "type": "array",
+      "items": {
+        "$ref": "http://asyncapi.com/definitions/2.6.0/tag.json"
+      },
+      "additionalItems": true
+    },
+```
+
+Would generate a type such as, in TypeScript:
+```
+private _tags?: (Tag | any)[];
+```
+
+Where it now generates:
+```
+private _tags?: Tag[];
+```

--- a/examples/csharp-auto-implemented-properties/__snapshots__/index.spec.ts.snap
+++ b/examples/csharp-auto-implemented-properties/__snapshots__/index.spec.ts.snap
@@ -4,7 +4,7 @@ exports[`Should be able to render auto-implemented properties in CSharp and shou
 Array [
   "public class Root
 {
-  public dynamic[]? Emails { get; set; }
+  public string[]? Emails { get; set; }
   public string? StringProp { get; set; }
   public double? NumberProp { get; set; }
 }",

--- a/examples/csharp-change-collection-type/__snapshots__/index.spec.ts.snap
+++ b/examples/csharp-change-collection-type/__snapshots__/index.spec.ts.snap
@@ -4,9 +4,9 @@ exports[`Should be able to render collections in C# as IEnumerable and should lo
 Array [
   "public class Root
 {
-  private IEnumerable<dynamic>? email;
+  private IEnumerable<string>? email;
 
-  public IEnumerable<dynamic>? Email 
+  public IEnumerable<string>? Email 
   {
     get { return email; }
     set { email = value; }

--- a/src/helpers/CommonModelToMetaModel.ts
+++ b/src/helpers/CommonModelToMetaModel.ts
@@ -445,15 +445,9 @@ export function convertToArrayModel(
     return undefined;
   }
 
-  const isNormalArray =
-    !Array.isArray(jsonSchemaModel.items) &&
-    jsonSchemaModel.additionalItems === undefined &&
-    jsonSchemaModel.items !== undefined;
-  //item multiple types + additionalItems sat = both count, as normal array
-  //item single type + additionalItems sat = contradicting, only items count, as normal array
-  //item not sat + additionalItems sat = anything is allowed, as normal array
-  //item single type + additionalItems not sat = normal array
-  //item not sat + additionalItems not sat = normal array, any type
+  const isNormalArray = !Array.isArray(jsonSchemaModel.items);
+  //items single type = normal array
+  //items not sat = normal array, any type
   if (isNormalArray) {
     const placeholderModel = new AnyModel('', undefined);
     const metaModel = new ArrayModel(
@@ -462,12 +456,13 @@ export function convertToArrayModel(
       placeholderModel
     );
     alreadySeenModels.set(jsonSchemaModel, metaModel);
-
-    const valueModel = convertToMetaModel(
-      jsonSchemaModel.items as CommonModel,
-      alreadySeenModels
-    );
-    metaModel.valueModel = valueModel;
+    if (jsonSchemaModel.items !== undefined) {
+      const valueModel = convertToMetaModel(
+        jsonSchemaModel.items as CommonModel,
+        alreadySeenModels
+      );
+      metaModel.valueModel = valueModel;
+    }
     return metaModel;
   }
 

--- a/test/generators/csharp/__snapshots__/CSharpGenerator.spec.ts.snap
+++ b/test/generators/csharp/__snapshots__/CSharpGenerator.spec.ts.snap
@@ -42,7 +42,7 @@ exports[`CSharpGenerator should render \`class\` type 1`] = `
   private bool? marriage;
   private dynamic? members;
   private dynamic[]? tupleType;
-  private dynamic[] arrayType;
+  private string[] arrayType;
   private Dictionary<string, dynamic>? additionalProperties;
 
   public string StreetName 
@@ -87,7 +87,7 @@ exports[`CSharpGenerator should render \`class\` type 1`] = `
     set { tupleType = value; }
   }
 
-  public dynamic[] ArrayType 
+  public string[] ArrayType 
   {
     get { return arrayType; }
     set { arrayType = value; }

--- a/test/generators/go/__snapshots__/GoGenerator.spec.ts.snap
+++ b/test/generators/go/__snapshots__/GoGenerator.spec.ts.snap
@@ -103,7 +103,7 @@ type Address struct {
   Marriage bool
   Members interface{}
   TupleType []interface{}
-  ArrayType []interface{}
+  ArrayType []string
   AdditionalProperties map[string]interface{}
 }"
 `;

--- a/test/generators/java/presets/__snapshots__/CommonPreset.spec.ts.snap
+++ b/test/generators/java/presets/__snapshots__/CommonPreset.spec.ts.snap
@@ -6,7 +6,7 @@ exports[`JAVA_COMMON_PRESET should render accurately when there is no additional
   private String stringProp;
   private Double numberProp;
   private Boolean booleanProp;
-  private Object[] arrayProp;
+  private String[] arrayProp;
 
   public Boolean getRequiredProp() { return this.requiredProp; }
   public void setRequiredProp(Boolean requiredProp) { this.requiredProp = requiredProp; }
@@ -20,8 +20,8 @@ exports[`JAVA_COMMON_PRESET should render accurately when there is no additional
   public Boolean getBooleanProp() { return this.booleanProp; }
   public void setBooleanProp(Boolean booleanProp) { this.booleanProp = booleanProp; }
 
-  public Object[] getArrayProp() { return this.arrayProp; }
-  public void setArrayProp(Object[] arrayProp) { this.arrayProp = arrayProp; }
+  public String[] getArrayProp() { return this.arrayProp; }
+  public void setArrayProp(String[] arrayProp) { this.arrayProp = arrayProp; }
 
   @Override
   public boolean equals(Object o) {
@@ -75,7 +75,7 @@ exports[`JAVA_COMMON_PRESET should render common function in class by common pre
   private String stringProp;
   private Double numberProp;
   private Boolean booleanProp;
-  private Object[] arrayProp;
+  private String[] arrayProp;
   private Map<String, Object> additionalProperties;
 
   public Boolean getRequiredProp() { return this.requiredProp; }
@@ -90,8 +90,8 @@ exports[`JAVA_COMMON_PRESET should render common function in class by common pre
   public Boolean getBooleanProp() { return this.booleanProp; }
   public void setBooleanProp(Boolean booleanProp) { this.booleanProp = booleanProp; }
 
-  public Object[] getArrayProp() { return this.arrayProp; }
-  public void setArrayProp(Object[] arrayProp) { this.arrayProp = arrayProp; }
+  public String[] getArrayProp() { return this.arrayProp; }
+  public void setArrayProp(String[] arrayProp) { this.arrayProp = arrayProp; }
 
   public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
   public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
@@ -150,7 +150,7 @@ exports[`JAVA_COMMON_PRESET with option should not render any functions when all
   private String stringProp;
   private Double numberProp;
   private Boolean booleanProp;
-  private Object[] arrayProp;
+  private String[] arrayProp;
   private Map<String, Object> additionalProperties;
 
   public Boolean getRequiredProp() { return this.requiredProp; }
@@ -165,8 +165,8 @@ exports[`JAVA_COMMON_PRESET with option should not render any functions when all
   public Boolean getBooleanProp() { return this.booleanProp; }
   public void setBooleanProp(Boolean booleanProp) { this.booleanProp = booleanProp; }
 
-  public Object[] getArrayProp() { return this.arrayProp; }
-  public void setArrayProp(Object[] arrayProp) { this.arrayProp = arrayProp; }
+  public String[] getArrayProp() { return this.arrayProp; }
+  public void setArrayProp(String[] arrayProp) { this.arrayProp = arrayProp; }
 
   public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
   public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
@@ -179,7 +179,7 @@ exports[`JAVA_COMMON_PRESET with option should render all functions 1`] = `
   private String stringProp;
   private Double numberProp;
   private Boolean booleanProp;
-  private Object[] arrayProp;
+  private String[] arrayProp;
   private Map<String, Object> additionalProperties;
 
   public Boolean getRequiredProp() { return this.requiredProp; }
@@ -194,8 +194,8 @@ exports[`JAVA_COMMON_PRESET with option should render all functions 1`] = `
   public Boolean getBooleanProp() { return this.booleanProp; }
   public void setBooleanProp(Boolean booleanProp) { this.booleanProp = booleanProp; }
 
-  public Object[] getArrayProp() { return this.arrayProp; }
-  public void setArrayProp(Object[] arrayProp) { this.arrayProp = arrayProp; }
+  public String[] getArrayProp() { return this.arrayProp; }
+  public void setArrayProp(String[] arrayProp) { this.arrayProp = arrayProp; }
 
   public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
   public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
@@ -254,7 +254,7 @@ exports[`JAVA_COMMON_PRESET with option should render classToString 1`] = `
   private String stringProp;
   private Double numberProp;
   private Boolean booleanProp;
-  private Object[] arrayProp;
+  private String[] arrayProp;
   private Map<String, Object> additionalProperties;
 
   public Boolean getRequiredProp() { return this.requiredProp; }
@@ -269,8 +269,8 @@ exports[`JAVA_COMMON_PRESET with option should render classToString 1`] = `
   public Boolean getBooleanProp() { return this.booleanProp; }
   public void setBooleanProp(Boolean booleanProp) { this.booleanProp = booleanProp; }
 
-  public Object[] getArrayProp() { return this.arrayProp; }
-  public void setArrayProp(Object[] arrayProp) { this.arrayProp = arrayProp; }
+  public String[] getArrayProp() { return this.arrayProp; }
+  public void setArrayProp(String[] arrayProp) { this.arrayProp = arrayProp; }
 
   public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
   public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
@@ -306,7 +306,7 @@ exports[`JAVA_COMMON_PRESET with option should render equals 1`] = `
   private String stringProp;
   private Double numberProp;
   private Boolean booleanProp;
-  private Object[] arrayProp;
+  private String[] arrayProp;
   private Map<String, Object> additionalProperties;
 
   public Boolean getRequiredProp() { return this.requiredProp; }
@@ -321,8 +321,8 @@ exports[`JAVA_COMMON_PRESET with option should render equals 1`] = `
   public Boolean getBooleanProp() { return this.booleanProp; }
   public void setBooleanProp(Boolean booleanProp) { this.booleanProp = booleanProp; }
 
-  public Object[] getArrayProp() { return this.arrayProp; }
-  public void setArrayProp(Object[] arrayProp) { this.arrayProp = arrayProp; }
+  public String[] getArrayProp() { return this.arrayProp; }
+  public void setArrayProp(String[] arrayProp) { this.arrayProp = arrayProp; }
 
   public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
   public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
@@ -353,7 +353,7 @@ exports[`JAVA_COMMON_PRESET with option should render hashCode 1`] = `
   private String stringProp;
   private Double numberProp;
   private Boolean booleanProp;
-  private Object[] arrayProp;
+  private String[] arrayProp;
   private Map<String, Object> additionalProperties;
 
   public Boolean getRequiredProp() { return this.requiredProp; }
@@ -368,8 +368,8 @@ exports[`JAVA_COMMON_PRESET with option should render hashCode 1`] = `
   public Boolean getBooleanProp() { return this.booleanProp; }
   public void setBooleanProp(Boolean booleanProp) { this.booleanProp = booleanProp; }
 
-  public Object[] getArrayProp() { return this.arrayProp; }
-  public void setArrayProp(Object[] arrayProp) { this.arrayProp = arrayProp; }
+  public String[] getArrayProp() { return this.arrayProp; }
+  public void setArrayProp(String[] arrayProp) { this.arrayProp = arrayProp; }
 
   public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
   public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
@@ -387,7 +387,7 @@ exports[`JAVA_COMMON_PRESET with option should render un/marshal 1`] = `
   private String stringProp;
   private Double numberProp;
   private Boolean booleanProp;
-  private Object[] arrayProp;
+  private String[] arrayProp;
   private Map<String, Object> additionalProperties;
 
   public Boolean getRequiredProp() { return this.requiredProp; }
@@ -402,8 +402,8 @@ exports[`JAVA_COMMON_PRESET with option should render un/marshal 1`] = `
   public Boolean getBooleanProp() { return this.booleanProp; }
   public void setBooleanProp(Boolean booleanProp) { this.booleanProp = booleanProp; }
 
-  public Object[] getArrayProp() { return this.arrayProp; }
-  public void setArrayProp(Object[] arrayProp) { this.arrayProp = arrayProp; }
+  public String[] getArrayProp() { return this.arrayProp; }
+  public void setArrayProp(String[] arrayProp) { this.arrayProp = arrayProp; }
 
   public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
   public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
@@ -447,7 +447,7 @@ exports[`JAVA_COMMON_PRESET with option should render un/marshal 1`] = `
             result.setBooleanProp(jsonObject.getBoolean(\\"booleanProp\\"));
           }
     if(jsonObject.has(\\"arrayProp\\")) {
-            result.setArrayProp(jsonObject.getObject[](\\"arrayProp\\"));
+            result.setArrayProp(jsonObject.getString[](\\"arrayProp\\"));
           }
     if(jsonObject.has(\\"additionalProperties\\")) {
             result.setAdditionalProperties(jsonObject.getMap<String, Object>(\\"additionalProperties\\"));

--- a/test/generators/rust/presets/CommonPreset.spec.ts
+++ b/test/generators/rust/presets/CommonPreset.spec.ts
@@ -143,10 +143,9 @@ describe('RUST_COMMON_PRESET', () => {
       };
 
       const models = await generator.generate(doc);
-      expect(models).toHaveLength(3);
+      expect(models).toHaveLength(2);
       expect(models[0].result).toMatchSnapshot();
       expect(models[1].result).toMatchSnapshot();
-      expect(models[2].result).toMatchSnapshot();
     });
   });
 

--- a/test/generators/rust/presets/__snapshots__/CommonPreset.spec.ts.snap
+++ b/test/generators/rust/presets/__snapshots__/CommonPreset.spec.ts.snap
@@ -197,13 +197,13 @@ exports[`RUST_COMMON_PRESET Enum should render reserved union for dict array 1`]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Class {
     #[serde(rename=\\"students\\")]
-    pub students: Vec<crate::Union>,
+    pub students: Vec<crate::Student>,
     #[serde(rename=\\"additionalProperties\\", skip_serializing_if = \\"Option::is_none\\")]
     pub additional_properties: Option<std::collections::HashMap<String, serde_json::Value>>,
 }
 
 impl Class {
-    pub fn new(students: Vec<crate::Union>, additional_properties: Option<std::collections::HashMap<String, serde_json::Value>>) -> Class {
+    pub fn new(students: Vec<crate::Student>, additional_properties: Option<std::collections::HashMap<String, serde_json::Value>>) -> Class {
         Class {
             students,
             additional_properties,
@@ -214,20 +214,6 @@ impl Class {
 `;
 
 exports[`RUST_COMMON_PRESET Enum should render reserved union for dict array 2`] = `
-"// Union represents a union of types: Student, serde_json::Value
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged)]
-pub enum Union {
-    #[serde(rename=\\"Student\\")]
-    Student(crate::Student),
-    #[serde(rename=\\"Undefined\\")]
-    Undefined(serde_json::Value),
-}
-
-"
-`;
-
-exports[`RUST_COMMON_PRESET Enum should render reserved union for dict array 3`] = `
 "// Student represents a Student model.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Student {

--- a/test/generators/typescript/__snapshots__/TypeScriptGenerator.spec.ts.snap
+++ b/test/generators/typescript/__snapshots__/TypeScriptGenerator.spec.ts.snap
@@ -367,7 +367,7 @@ exports[`TypeScriptGenerator should render \`class\` type 1`] = `
   private _members?: string | number | boolean;
   private _tupleType?: [string, number];
   private _tupleTypeWithAdditionalItems?: (string | number | any)[];
-  private _arrayType: (string | any)[];
+  private _arrayType: string[];
   private _additionalProperties?: Map<string, any | string>;
 
   constructor(input: {
@@ -379,7 +379,7 @@ exports[`TypeScriptGenerator should render \`class\` type 1`] = `
     members?: string | number | boolean,
     tupleType?: [string, number],
     tupleTypeWithAdditionalItems?: (string | number | any)[],
-    arrayType: (string | any)[],
+    arrayType: string[],
     additionalProperties?: Map<string, any | string>,
   }) {
     this._streetName = input.streetName;
@@ -418,8 +418,8 @@ exports[`TypeScriptGenerator should render \`class\` type 1`] = `
   get tupleTypeWithAdditionalItems(): (string | number | any)[] | undefined { return this._tupleTypeWithAdditionalItems; }
   set tupleTypeWithAdditionalItems(tupleTypeWithAdditionalItems: (string | number | any)[] | undefined) { this._tupleTypeWithAdditionalItems = tupleTypeWithAdditionalItems; }
 
-  get arrayType(): (string | any)[] { return this._arrayType; }
-  set arrayType(arrayType: (string | any)[]) { this._arrayType = arrayType; }
+  get arrayType(): string[] { return this._arrayType; }
+  set arrayType(arrayType: string[]) { this._arrayType = arrayType; }
 
   get additionalProperties(): Map<string, any | string> | undefined { return this._additionalProperties; }
   set additionalProperties(additionalProperties: Map<string, any | string> | undefined) { this._additionalProperties = additionalProperties; }
@@ -446,14 +446,14 @@ exports[`TypeScriptGenerator should render \`interface\` type 1`] = `
   members?: string | number | boolean;
   tupleType?: [string, number];
   tupleTypeWithAdditionalItems?: (string | number | any)[];
-  arrayType: (string | any)[];
+  arrayType: string[];
   additionalProperties?: Map<string, any | string>;
 }"
 `;
 
-exports[`TypeScriptGenerator should render \`type\` type - array of primitive type 1`] = `"type TypeArray = (string | any)[];"`;
+exports[`TypeScriptGenerator should render \`type\` type - array of primitive type 1`] = `"type TypeArray = string[];"`;
 
-exports[`TypeScriptGenerator should render \`type\` type - array of union type 1`] = `"type TypeArray = (string | number | boolean | any)[];"`;
+exports[`TypeScriptGenerator should render \`type\` type - array of union type 1`] = `"type TypeArray = (string | number | boolean)[];"`;
 
 exports[`TypeScriptGenerator should render \`type\` type - enum 1`] = `
 "enum TypeEnum {

--- a/test/helpers/CommonModelToMetaModel.spec.ts
+++ b/test/helpers/CommonModelToMetaModel.spec.ts
@@ -134,6 +134,7 @@ describe('CommonModelToMetaModel', () => {
 
     expect(model).not.toBeUndefined();
     expect(model instanceof ArrayModel).toEqual(true);
+    expect((model as ArrayModel).valueModel instanceof AnyModel).toEqual(true);
   });
   test('should convert to object model', () => {
     const spm = new CommonModel();
@@ -273,8 +274,11 @@ describe('CommonModelToMetaModel', () => {
 
     expect(model).not.toBeUndefined();
     expect(model instanceof ArrayModel).toEqual(true);
+    expect((model as ArrayModel).valueModel instanceof StringModel).toEqual(
+      true
+    );
   });
-  test('should convert array with additional items to array model as union type', () => {
+  test('should not convert array with additional items to array model as union type', () => {
     const spm = new CommonModel();
     spm.type = 'string';
     const cm = new CommonModel();
@@ -287,7 +291,7 @@ describe('CommonModelToMetaModel', () => {
 
     expect(model).not.toBeUndefined();
     expect(model instanceof ArrayModel).toEqual(true);
-    expect((model as ArrayModel).valueModel instanceof UnionModel).toEqual(
+    expect((model as ArrayModel).valueModel instanceof StringModel).toEqual(
       true
     );
   });


### PR DESCRIPTION
**Description**
When I first created this logic I mistakenly thought `additionalItems` was applied to non-tuple array types i.e. when you use a single entry for `items`. This is not the case.

This PR:
- fixes that implementation and adapts the tests.
- add migration guidelines for how the models change.

**Related issue(s)**
Fixes https://github.com/asyncapi/modelina/issues/1138