### PR TITLE
feat: make MetaModel's nullable

### DIFF
--- a/docs/migrations/version-1-to-2.md
+++ b/docs/migrations/version-1-to-2.md
@@ -49,3 +49,17 @@ components:
 ```
 
 The _type_ property in the _CloudEvent_ schema will in this case have an _anonymous_schema_ id. If another schema in the _allOf_ list has the same property and an id other than _anonymous_schema_, it will now use that id. Meaning, in this example, it will be _DogType_ and _CatType_.
+
+# Nullable models
+
+Each [meta model](../internal-model.md) up until now where not able to be marked as nullable, but now they can be through `isNullable`. Here are the different outputs and how they now apply nullable types:
+
+### TypeScript
+### C#
+### Java
+### Kotlin
+### Rust 
+### Python
+### Go
+### Dart
+

--- a/src/models/MetaModel.ts
+++ b/src/models/MetaModel.ts
@@ -1,5 +1,9 @@
 export class MetaModel {
-  constructor(public name: string, public originalInput: any) {}
+  constructor(
+    public name: string,
+    public originalInput: any,
+    public isNullable: boolean = false
+  ) {}
 }
 
 export class ReferenceModel extends MetaModel {
@@ -19,7 +23,13 @@ export class TupleModel extends MetaModel {
   constructor(
     name: string,
     originalInput: any,
-    public tuple: TupleValueModel[]
+    public tuple: TupleValueModel[],
+    /**
+     * Mark the tuple as as being able to contain additional values.
+     *
+     * In some outputs they would generate simple arrays.
+     */
+    public additionalValue: MetaModel | undefined = undefined
   ) {
     super(name, originalInput);
   }

--- a/test/helpers/CommonModelToMetaModel.spec.ts
+++ b/test/helpers/CommonModelToMetaModel.spec.ts
@@ -17,6 +17,17 @@ describe('CommonModelToMetaModel', () => {
   afterEach(() => {
     jest.restoreAllMocks();
   });
+  test('should apply null type', () => {
+    const cm = new CommonModel();
+    cm.$id = 'test';
+    cm.type = ['string', 'null'];
+
+    const model = convertToMetaModel(cm);
+
+    expect(model).not.toBeUndefined();
+    expect(model instanceof StringModel).toEqual(true);
+    expect(model.isNullable).toEqual(true);
+  });
   test('should default to any model', () => {
     const cm = new CommonModel();
     cm.$id = 'test';
@@ -28,15 +39,7 @@ describe('CommonModelToMetaModel', () => {
   });
   test('should convert to any model', () => {
     const cm = new CommonModel();
-    cm.type = [
-      'string',
-      'number',
-      'integer',
-      'boolean',
-      'object',
-      'array',
-      'null'
-    ];
+    cm.type = ['string', 'number', 'integer', 'boolean', 'object', 'array'];
     cm.$id = 'test';
 
     const model = convertToMetaModel(cm);


### PR DESCRIPTION
**Description**
This PR adds `isNullable` property to the MetaModel and adapts the conversion of CommonModel to MetaModel.

**Related issue(s)**
Fixes https://github.com/asyncapi/modelina/issues/754
Fixes https://github.com/asyncapi/modelina/issues/749