### PR TITLE
feat: add option to Csharp generator allowing user to generate records instead of classes

### DIFF
--- a/docs/languages/Csharp.md
+++ b/docs/languages/Csharp.md
@@ -85,7 +85,12 @@ Check out this [example for a live demonstration](../../examples/csharp-overwrit
 
 If you want the generated models to inherit from a custom class, you can overwrite the existing rendering behavior and create your own class setup.
 
-Check out this [example for a live demonstration](../../examples/csharp-use-inheritance).
+## Generate models as records 
+
+Since C# 9 the language now supports records as an alternative to classes suitable for roles like DTO's. Modelina can generate records by setting the `modelType: record` option. Note that this renderer does not support the `autoImplementedProperties` option as this is default with records. 
+
+Check out this [example for a live demonstration](../../examples/csharp-generate-records).
+
 # FAQ
 This is the most asked questions and answers which should be your GOTO list to check before asking anywhere else. Cause it might already have been answered!
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -100,6 +100,7 @@ These are all specific examples only relevant to the C# generator:
 - [csharp-generate-newtonsoft-serializer](./csharp-generate-newtonsoft-serializer) - A basic example on how to generate models that include function to serialize the data models to and form JSON with Newtonsoft.
 - [csharp-overwrite-enum-naming](./csharp-overwrite-enum-naming) - A basic example on how to generate enum value names.
 - [csharp-use-inheritance](./csharp-use-inheritance) - A basic example that shows how to introduce inheritance to classes 
+- [csharp-generate-records](./csharp-generate-records) - A basic example that shows how to change C# model type from class to record.
 
 ## TypeScript
 These are all specific examples only relevant to the TypeScript generator:

--- a/examples/csharp-generate-records/README.md
+++ b/examples/csharp-generate-records/README.md
@@ -1,0 +1,17 @@
+# TODO: Your example title
+
+TODO: Your example description
+
+## How to run this example
+
+Run this example using:
+
+```sh
+npm i && npm run start
+```
+
+If you are on Windows, use the `start:windows` script instead:
+
+```sh
+npm i && npm run start:windows
+```

--- a/examples/csharp-generate-records/__snapshots__/index.spec.ts.snap
+++ b/examples/csharp-generate-records/__snapshots__/index.spec.ts.snap
@@ -4,7 +4,8 @@ exports[`Should be able to render a C# record instead of a class using the model
 Array [
   "public record Root
 {
-  public string? Email { get; init; }
+  public IEnumerable<dynamic>? Email { get; init; }
+  public required string Name { get; init; }
 }",
 ]
 `;

--- a/examples/csharp-generate-records/__snapshots__/index.spec.ts.snap
+++ b/examples/csharp-generate-records/__snapshots__/index.spec.ts.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Should be able to render a C# record instead of a class using the modelType option and should log expected output to console 1`] = `
+Array [
+  "public record Root
+{
+  public string? Email { get; init; }
+}",
+]
+`;

--- a/examples/csharp-generate-records/index.spec.ts
+++ b/examples/csharp-generate-records/index.spec.ts
@@ -1,0 +1,15 @@
+const spy = jest.spyOn(global.console, 'log').mockImplementation(() => {
+  return;
+});
+import { generate } from './index';
+
+describe('Should be able to render a C# record instead of a class using the modelType option', () => {
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+  test('and should log expected output to console', async () => {
+    await generate();
+    expect(spy.mock.calls.length).toEqual(1);
+    expect(spy.mock.calls[0]).toMatchSnapshot();
+  });
+});

--- a/examples/csharp-generate-records/index.ts
+++ b/examples/csharp-generate-records/index.ts
@@ -1,14 +1,26 @@
-import { CSharpGenerator } from '../../src';
+import {CSHARP_COMMON_PRESET, CSHARP_JSON_SERIALIZER_PRESET, CSharpGenerator} from '../../src';
 
-const generator = new CSharpGenerator({ modelType: 'record' });
+const generator = new CSharpGenerator({ 
+  modelType: 'record',
+  collectionType: 'List',
+});
 const jsonSchemaDraft7 = {
   $schema: 'http://json-schema.org/draft-07/schema#',
   type: 'object',
   additionalProperties: false,
+  required: [
+      "name"
+  ],
   properties: {
     email: {
-      type: 'string',
-      format: 'email'
+      type: 'array',
+      items: {
+        type: 'string',
+        format: 'email'
+      }
+    },
+    name: {
+      type: 'string'
     }
   }
 };

--- a/examples/csharp-generate-records/index.ts
+++ b/examples/csharp-generate-records/index.ts
@@ -1,0 +1,24 @@
+import { CSharpGenerator } from '../../src';
+
+const generator = new CSharpGenerator({ modelType: 'record' });
+const jsonSchemaDraft7 = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    email: {
+      type: 'string',
+      format: 'email'
+    }
+  }
+};
+
+export async function generate(): Promise<void> {
+  const models = await generator.generate(jsonSchemaDraft7);
+  for (const model of models) {
+    console.log(model.result);
+  }
+}
+if (require.main === module) {
+  generate();
+}

--- a/examples/csharp-generate-records/index.ts
+++ b/examples/csharp-generate-records/index.ts
@@ -1,16 +1,14 @@
-import {CSHARP_COMMON_PRESET, CSHARP_JSON_SERIALIZER_PRESET, CSharpGenerator} from '../../src';
+import { CSharpGenerator } from '../../src';
 
-const generator = new CSharpGenerator({ 
+const generator = new CSharpGenerator({
   modelType: 'record',
-  collectionType: 'List',
+  collectionType: 'List'
 });
 const jsonSchemaDraft7 = {
   $schema: 'http://json-schema.org/draft-07/schema#',
   type: 'object',
   additionalProperties: false,
-  required: [
-      "name"
-  ],
+  required: ['name'],
   properties: {
     email: {
       type: 'array',

--- a/examples/csharp-generate-records/package-lock.json
+++ b/examples/csharp-generate-records/package-lock.json
@@ -1,0 +1,10 @@
+{
+  "name": "csharp-generate-records",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "hasInstallScript": true
+    }
+  }
+}

--- a/examples/csharp-generate-records/package.json
+++ b/examples/csharp-generate-records/package.json
@@ -1,0 +1,10 @@
+{
+  "config" : { "example_name" : "csharp-generate-records" },
+  "scripts": {
+    "install": "cd ../.. && npm i",
+    "start": "../../node_modules/.bin/ts-node --cwd ../../ ./examples/$npm_package_config_example_name/index.ts",
+    "start:windows": "..\\..\\node_modules\\.bin\\ts-node --cwd ..\\..\\ .\\examples\\%npm_package_config_example_name%\\index.ts",
+    "test": "../../node_modules/.bin/jest --config=../../jest.config.js ./examples/$npm_package_config_example_name/index.spec.ts",
+    "test:windows": "..\\..\\node_modules\\.bin\\jest --config=..\\..\\jest.config.js examples/%npm_package_config_example_name%/index.spec.ts"
+  }
+}

--- a/src/generators/csharp/CSharpGenerator.ts
+++ b/src/generators/csharp/CSharpGenerator.ts
@@ -22,7 +22,7 @@ import {
 import { CSharpPreset, CSHARP_DEFAULT_PRESET } from './CSharpPreset';
 import { EnumRenderer } from './renderers/EnumRenderer';
 import { ClassRenderer } from './renderers/ClassRenderer';
-import { RecordRenderer } from "./renderers/RecordRenderer";
+import { RecordRenderer } from './renderers/RecordRenderer';
 import { isReservedCSharpKeyword } from './Constants';
 import { Logger } from '../../index';
 import {

--- a/src/generators/csharp/CSharpGenerator.ts
+++ b/src/generators/csharp/CSharpGenerator.ts
@@ -22,6 +22,7 @@ import {
 import { CSharpPreset, CSHARP_DEFAULT_PRESET } from './CSharpPreset';
 import { EnumRenderer } from './renderers/EnumRenderer';
 import { ClassRenderer } from './renderers/ClassRenderer';
+import { RecordRenderer } from "./renderers/RecordRenderer";
 import { isReservedCSharpKeyword } from './Constants';
 import { Logger } from '../../index';
 import {
@@ -36,6 +37,7 @@ export interface CSharpOptions extends CommonGeneratorOptions<CSharpPreset> {
   typeMapping: TypeMapping<CSharpOptions, CSharpDependencyManager>;
   constraints: Constraints;
   autoImplementedProperties: boolean;
+  modelType: 'class' | 'record';
 }
 export type CSharpTypeMapping = TypeMapping<
   CSharpOptions,
@@ -60,6 +62,7 @@ export class CSharpGenerator extends AbstractGenerator<
     typeMapping: CSharpDefaultTypeMapping,
     constraints: CSharpDefaultConstraints,
     autoImplementedProperties: false,
+    modelType: 'class',
     // Temporarily set
     dependencyManager: () => {
       return {} as CSharpDependencyManager;
@@ -193,6 +196,9 @@ ${FormatHelpers.indent(
       ...options
     });
     if (model instanceof ConstrainedObjectModel) {
+      if (this.options.modelType === 'record') {
+        return this.renderRecord(model, inputModel, optionsToUse);
+      }
       return this.renderClass(model, inputModel, optionsToUse);
     } else if (model instanceof ConstrainedEnumModel) {
       return this.renderEnum(model, inputModel, optionsToUse);
@@ -248,6 +254,33 @@ ${FormatHelpers.indent(
     const dependencyManagerToUse = this.getDependencyManager(optionsToUse);
     const presets = this.getPresets('class');
     const renderer = new ClassRenderer(
+      this.options,
+      this,
+      presets,
+      model,
+      inputModel,
+      dependencyManagerToUse
+    );
+    const result = await renderer.runSelfPreset();
+    return RenderOutput.toRenderOutput({
+      result,
+      renderedName: model.name,
+      dependencies: dependencyManagerToUse.dependencies
+    });
+  }
+
+  async renderRecord(
+    model: ConstrainedObjectModel,
+    inputModel: InputMetaModel,
+    options?: Partial<CSharpOptions>
+  ): Promise<RenderOutput> {
+    const optionsToUse = CSharpGenerator.getCSharpOptions({
+      ...this.options,
+      ...options
+    });
+    const dependencyManagerToUse = this.getDependencyManager(optionsToUse);
+    const presets = this.getPresets('record');
+    const renderer = new RecordRenderer(
       this.options,
       this,
       presets,

--- a/src/generators/csharp/CSharpPreset.ts
+++ b/src/generators/csharp/CSharpPreset.ts
@@ -17,9 +17,9 @@ import {
   EnumRenderer
 } from './renderers/EnumRenderer';
 import {
-  RecordRenderer, 
+  RecordRenderer,
   CSHARP_DEFAULT_RECORD_PRESET
-} from "./renderers/RecordRenderer";
+} from './renderers/RecordRenderer';
 
 // Our class preset uses custom `accessor` hook to craft getter and setters.
 export interface CsharpClassPreset<O> extends ClassPreset<ClassRenderer, O> {
@@ -28,12 +28,13 @@ export interface CsharpClassPreset<O> extends ClassPreset<ClassRenderer, O> {
   ) => Promise<string> | string;
 }
 
-export interface CsharpRecordPreset<O> extends InterfacePreset<RecordRenderer, O> {
+export interface CsharpRecordPreset<O>
+  extends InterfacePreset<RecordRenderer, O> {
   getter?: (
-      args: PresetArgs<RecordRenderer, O, ConstrainedObjectModel> & PropertyArgs
+    args: PresetArgs<RecordRenderer, O, ConstrainedObjectModel> & PropertyArgs
   ) => Promise<string> | string;
   setter?: (
-      args: PresetArgs<RecordRenderer, O, ConstrainedObjectModel> & PropertyArgs
+    args: PresetArgs<RecordRenderer, O, ConstrainedObjectModel> & PropertyArgs
   ) => Promise<string> | string;
 }
 

--- a/src/generators/csharp/CSharpPreset.ts
+++ b/src/generators/csharp/CSharpPreset.ts
@@ -15,6 +15,10 @@ import {
   CSHARP_DEFAULT_ENUM_PRESET,
   EnumRenderer
 } from './renderers/EnumRenderer';
+import {
+  RecordRenderer, 
+  CSHARP_DEFAULT_RECORD_PRESET
+} from "./renderers/RecordRenderer";
 
 // Our class preset uses custom `accessor` hook to craft getter and setters.
 export interface CsharpClassPreset<O> extends ClassPreset<ClassRenderer, O> {
@@ -23,15 +27,20 @@ export interface CsharpClassPreset<O> extends ClassPreset<ClassRenderer, O> {
   ) => Promise<string> | string;
 }
 
+export interface CsharpRecordPreset<O> extends ClassPreset<RecordRenderer, O> {
+}
+
 export type ClassPresetType<O> = CsharpClassPreset<O>;
 export type EnumPresetType<O> = EnumPreset<EnumRenderer, O>;
 
 export type CSharpPreset<O = any> = Preset<{
   class: CsharpClassPreset<O>;
+  record: CsharpRecordPreset<0>;
   enum: EnumPreset<EnumRenderer, O>;
 }>;
 
 export const CSHARP_DEFAULT_PRESET: CSharpPreset<CSharpOptions> = {
   class: CSHARP_DEFAULT_CLASS_PRESET,
+  record: CSHARP_DEFAULT_RECORD_PRESET,
   enum: CSHARP_DEFAULT_ENUM_PRESET
 };

--- a/src/generators/csharp/CSharpPreset.ts
+++ b/src/generators/csharp/CSharpPreset.ts
@@ -4,7 +4,8 @@ import {
   ClassPreset,
   PresetArgs,
   PropertyArgs,
-  ConstrainedObjectModel
+  ConstrainedObjectModel,
+  InterfacePreset
 } from '../../models';
 import { CSharpOptions } from './CSharpGenerator';
 import {
@@ -27,7 +28,13 @@ export interface CsharpClassPreset<O> extends ClassPreset<ClassRenderer, O> {
   ) => Promise<string> | string;
 }
 
-export interface CsharpRecordPreset<O> extends ClassPreset<RecordRenderer, O> {
+export interface CsharpRecordPreset<O> extends InterfacePreset<RecordRenderer, O> {
+  getter?: (
+      args: PresetArgs<RecordRenderer, O, ConstrainedObjectModel> & PropertyArgs
+  ) => Promise<string> | string;
+  setter?: (
+      args: PresetArgs<RecordRenderer, O, ConstrainedObjectModel> & PropertyArgs
+  ) => Promise<string> | string;
 }
 
 export type ClassPresetType<O> = CsharpClassPreset<O>;

--- a/src/generators/csharp/CSharpPreset.ts
+++ b/src/generators/csharp/CSharpPreset.ts
@@ -31,11 +31,12 @@ export interface CsharpRecordPreset<O> extends ClassPreset<RecordRenderer, O> {
 }
 
 export type ClassPresetType<O> = CsharpClassPreset<O>;
+export type RecordPresetType<O> = CsharpRecordPreset<O>;
 export type EnumPresetType<O> = EnumPreset<EnumRenderer, O>;
 
 export type CSharpPreset<O = any> = Preset<{
   class: CsharpClassPreset<O>;
-  record: CsharpRecordPreset<0>;
+  record: CsharpRecordPreset<O>;
   enum: EnumPreset<EnumRenderer, O>;
 }>;
 

--- a/src/generators/csharp/Constants.ts
+++ b/src/generators/csharp/Constants.ts
@@ -52,6 +52,7 @@ export const RESERVED_CSHARP_KEYWORDS = [
   'protected',
   'public',
   'readonly',
+  'record',
   'ref',
   'return',
   'sbyte',

--- a/src/generators/csharp/renderers/RecordRenderer.ts
+++ b/src/generators/csharp/renderers/RecordRenderer.ts
@@ -17,8 +17,6 @@ export class RecordRenderer extends CSharpRenderer<ConstrainedObjectModel> {
   public async defaultSelf(): Promise<string> {
     const content = [
       await this.renderProperties(),
-      await this.runCtorPreset(),
-      await this.renderAccessors(),
       await this.runAdditionalContentPreset()
     ];
 
@@ -45,29 +43,6 @@ ${this.indent(this.renderBlock(content, 2))}
     }
 
     return this.renderBlock(content);
-  }
-
-  async renderAccessors(): Promise<string> {
-    const properties = this.model.properties || {};
-    const content: string[] = [];
-
-    for (const property of Object.values(properties)) {
-      content.push(await this.runAccessorPreset(property));
-    }
-
-    return this.renderBlock(content, 2);
-  }
-
-  runCtorPreset(): Promise<string> {
-    return this.runPreset('ctor');
-  }
-
-  runAccessorPreset(property: ConstrainedObjectPropertyModel): Promise<string> {
-    return this.runPreset('accessor', {
-      property,
-      options: this.options,
-      renderer: this
-    });
   }
 
   runPropertyPreset(property: ConstrainedObjectPropertyModel): Promise<string> {
@@ -99,17 +74,20 @@ export const CSHARP_DEFAULT_RECORD_PRESET: CsharpRecordPreset<CSharpOptions> = {
   self({ renderer }) {
     return renderer.defaultSelf();
   },
-  async property({renderer, property, options}) {
+  async property({ renderer, property }) {
     const getter = await renderer.runGetterPreset(property);
     const setter = await renderer.runSetterPreset(property);
     return `public ${property.required ? 'required ' : ''}${property.property.type} ${pascalCase(
         property.propertyName
     )} { ${getter} ${setter} }`;
   },
-  getter({ options, property }) {
+  getter() {
     return 'get;';
   },
-  setter({ options, property }) {
+  setter() {
     return 'init;';
+  }, 
+  additionalContent() {
+    return '';
   }
 };

--- a/src/generators/csharp/renderers/RecordRenderer.ts
+++ b/src/generators/csharp/renderers/RecordRenderer.ts
@@ -5,7 +5,7 @@ import {
   ConstrainedObjectPropertyModel
 } from '../../../models';
 import { pascalCase } from 'change-case';
-import { CsharpClassPreset } from '../CSharpPreset';
+import { CsharpRecordPreset } from '../CSharpPreset';
 import { CSharpOptions } from '../CSharpGenerator';
 
 /**
@@ -95,7 +95,7 @@ ${this.indent(this.renderBlock(content, 2))}
   }
 }
 
-export const CSHARP_DEFAULT_RECORD_PRESET: CsharpClassPreset<CSharpOptions> = {
+export const CSHARP_DEFAULT_RECORD_PRESET: CsharpRecordPreset<CSharpOptions> = {
   self({ renderer }) {
     return renderer.defaultSelf();
   },

--- a/src/generators/csharp/renderers/RecordRenderer.ts
+++ b/src/generators/csharp/renderers/RecordRenderer.ts
@@ -1,0 +1,115 @@
+import { CSharpRenderer } from '../CSharpRenderer';
+import {
+  ConstrainedDictionaryModel,
+  ConstrainedObjectModel,
+  ConstrainedObjectPropertyModel
+} from '../../../models';
+import { pascalCase } from 'change-case';
+import { CsharpClassPreset } from '../CSharpPreset';
+import { CSharpOptions } from '../CSharpGenerator';
+
+/**
+ * Renderer for CSharp's `struct` type
+ *
+ * @extends CSharpRenderer
+ */
+export class RecordRenderer extends CSharpRenderer<ConstrainedObjectModel> {
+  public async defaultSelf(): Promise<string> {
+    const content = [
+      await this.renderProperties(),
+      await this.runCtorPreset(),
+      await this.renderAccessors(),
+      await this.runAdditionalContentPreset()
+    ];
+
+    if (
+      this.options?.collectionType === 'List' ||
+      this.model.containsPropertyType(ConstrainedDictionaryModel)
+    ) {
+      this.dependencyManager.addDependency('using System.Collections.Generic;');
+    }
+
+    return `public record ${this.model.name}
+{
+${this.indent(this.renderBlock(content, 2))}
+}`;
+  }
+
+  async renderProperties(): Promise<string> {
+    const properties = this.model.properties || {};
+    const content: string[] = [];
+
+    for (const property of Object.values(properties)) {
+      const rendererProperty = await this.runPropertyPreset(property);
+      content.push(rendererProperty);
+    }
+
+    return this.renderBlock(content);
+  }
+
+  async renderAccessors(): Promise<string> {
+    const properties = this.model.properties || {};
+    const content: string[] = [];
+
+    for (const property of Object.values(properties)) {
+      content.push(await this.runAccessorPreset(property));
+    }
+
+    return this.renderBlock(content, 2);
+  }
+
+  runCtorPreset(): Promise<string> {
+    return this.runPreset('ctor');
+  }
+
+  runAccessorPreset(property: ConstrainedObjectPropertyModel): Promise<string> {
+    return this.runPreset('accessor', {
+      property,
+      options: this.options,
+      renderer: this
+    });
+  }
+
+  runPropertyPreset(property: ConstrainedObjectPropertyModel): Promise<string> {
+    return this.runPreset('property', {
+      property,
+      options: this.options,
+      renderer: this
+    });
+  }
+
+  runGetterPreset(property: ConstrainedObjectPropertyModel): Promise<string> {
+    return this.runPreset('getter', {
+      property,
+      options: this.options,
+      renderer: this
+    });
+  }
+
+  runSetterPreset(property: ConstrainedObjectPropertyModel): Promise<string> {
+    return this.runPreset('setter', {
+      property,
+      options: this.options,
+      renderer: this
+    });
+  }
+}
+
+export const CSHARP_DEFAULT_RECORD_PRESET: CsharpClassPreset<CSharpOptions> = {
+  self({ renderer }) {
+    return renderer.defaultSelf();
+  },
+  async property({renderer, property, options}) {
+    const getter = await renderer.runGetterPreset(property);
+    const setter = await renderer.runSetterPreset(property);
+    return `public ${property.required ? 'required ' : ''}${property.property.type} ${pascalCase(
+        property.propertyName
+    )} { ${getter} ${setter} }`;
+  },
+  getter({ options, property }) {
+    return 'get;';
+  },
+  setter({ options, property }) {
+    return 'init;';
+  }
+};

--- a/src/generators/csharp/renderers/RecordRenderer.ts
+++ b/src/generators/csharp/renderers/RecordRenderer.ts
@@ -77,16 +77,16 @@ export const CSHARP_DEFAULT_RECORD_PRESET: CsharpRecordPreset<CSharpOptions> = {
   async property({ renderer, property }) {
     const getter = await renderer.runGetterPreset(property);
     const setter = await renderer.runSetterPreset(property);
-    return `public ${property.required ? 'required ' : ''}${property.property.type} ${pascalCase(
-        property.propertyName
-    )} { ${getter} ${setter} }`;
+    return `public ${property.required ? 'required ' : ''}${
+      property.property.type
+    } ${pascalCase(property.propertyName)} { ${getter} ${setter} }`;
   },
   getter() {
     return 'get;';
   },
   setter() {
     return 'init;';
-  }, 
+  },
   additionalContent() {
     return '';
   }

--- a/test/generators/csharp/CSharpGenerator.spec.ts
+++ b/test/generators/csharp/CSharpGenerator.spec.ts
@@ -3,7 +3,7 @@ import { CSharpGenerator } from '../../../src/generators';
 describe('CSharpGenerator', () => {
   let generator: CSharpGenerator;
   beforeEach(() => {
-    generator = new CSharpGenerator({ modelType: "class"});
+    generator = new CSharpGenerator({ modelType: 'class' });
   });
 
   test('should render `class` type', async () => {
@@ -46,7 +46,7 @@ describe('CSharpGenerator', () => {
       'using System.Collections.Generic;'
     ]);
   });
-  
+
   test('should render `record` type if chosen', async () => {
     const doc = {
       $id: '_address',
@@ -80,7 +80,7 @@ describe('CSharpGenerator', () => {
       }
     };
 
-    generator.options.modelType = "record";
+    generator.options.modelType = 'record';
     const models = await generator.generate(doc);
     expect(models).toHaveLength(1);
     expect(models[0].result).toMatchSnapshot();

--- a/test/generators/csharp/CSharpGenerator.spec.ts
+++ b/test/generators/csharp/CSharpGenerator.spec.ts
@@ -46,6 +46,48 @@ describe('CSharpGenerator', () => {
       'using System.Collections.Generic;'
     ]);
   });
+  
+  test('should render `record` type if chosen', async () => {
+    const doc = {
+      $id: '_address',
+      type: 'object',
+      properties: {
+        street_name: { type: 'string' },
+        city: { type: 'string', description: 'City description' },
+        state: { type: 'string' },
+        house_number: { type: 'number' },
+        marriage: {
+          type: 'boolean',
+          description: 'Status if marriage live in given house'
+        },
+        members: {
+          oneOf: [{ type: 'string' }, { type: 'number' }, { type: 'boolean' }]
+        },
+        tuple_type: {
+          type: 'array',
+          items: [{ type: 'string' }, { type: 'number' }]
+        },
+        array_type: { type: 'array', items: { type: 'string' } }
+      },
+      required: ['street_name', 'city', 'state', 'house_number', 'array_type'],
+      additionalProperties: {
+        type: 'string'
+      },
+      patternProperties: {
+        '^S(.?*)test&': {
+          type: 'string'
+        }
+      }
+    };
+
+    generator.options.modelType = "record";
+    const models = await generator.generate(doc);
+    expect(models).toHaveLength(1);
+    expect(models[0].result).toMatchSnapshot();
+    expect(models[0].dependencies).toEqual([
+      'using System.Collections.Generic;'
+    ]);
+  });
 
   test('should render `enum` type', async () => {
     const doc = {

--- a/test/generators/csharp/CSharpGenerator.spec.ts
+++ b/test/generators/csharp/CSharpGenerator.spec.ts
@@ -3,7 +3,7 @@ import { CSharpGenerator } from '../../../src/generators';
 describe('CSharpGenerator', () => {
   let generator: CSharpGenerator;
   beforeEach(() => {
-    generator = new CSharpGenerator();
+    generator = new CSharpGenerator({ modelType: "class"});
   });
 
   test('should render `class` type', async () => {

--- a/test/generators/csharp/__snapshots__/CSharpGenerator.spec.ts.snap
+++ b/test/generators/csharp/__snapshots__/CSharpGenerator.spec.ts.snap
@@ -142,6 +142,21 @@ public static class ThingsExtensions
 "
 `;
 
+exports[`CSharpGenerator should render \`record\` type if chosen 1`] = `
+"public record Address
+{
+  public required string StreetName { get; init; }
+  public required string City { get; init; }
+  public required string State { get; init; }
+  public required double HouseNumber { get; init; }
+  public bool? Marriage { get; init; }
+  public dynamic? Members { get; init; }
+  public dynamic[]? TupleType { get; init; }
+  public required dynamic[] ArrayType { get; init; }
+  public Dictionary<string, dynamic>? AdditionalProperties { get; init; }
+}"
+`;
+
 exports[`CSharpGenerator should render enums with translated special characters 1`] = `
 "public enum States
 {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
This PR adds an option to the C# generator allowing it to render records instead of classes. This is done using a new renderer that implements `self`, `property` and `additionalContent` hooks. It does not support using the `autoimplementedProperties` as option as this is instead a default when generating records.

**Related issue(s)**
Resolves #1153