### PR TITLE
fix: typescript serialization using wrong typings

### DIFF
--- a/src/generators/typescript/presets/CommonPreset.ts
+++ b/src/generators/typescript/presets/CommonPreset.ts
@@ -61,7 +61,7 @@ function renderUnionSerializationArray(
       ${propName}.push(typeof unionItem === 'number' || typeof unionItem === 'boolean' ? unionItem : JSON.stringify(unionItem))
     }`;
   }
-  return `let ${propName}: string[] = [];
+  return `let ${propName}: any[] = [];
   for (const unionItem of ${modelInstanceVariable}) {
     ${unionSerialization}
   }
@@ -74,7 +74,7 @@ function renderArraySerialization(
   arrayModel: ConstrainedArrayModel
 ) {
   const propName = `${prop}JsonValues`;
-  return `let ${propName}: string[] = [];
+  return `let ${propName}: any[] = [];
   for (const unionItem of ${modelInstanceVariable}) {
     ${propName}.push(\`${renderMarshalProperty(
     'unionItem',

--- a/test/generators/typescript/preset/__snapshots__/MarshallingPreset.spec.ts.snap
+++ b/test/generators/typescript/preset/__snapshots__/MarshallingPreset.spec.ts.snap
@@ -77,7 +77,7 @@ exports[`Marshalling preset should render un/marshal code 1`] = `
       } 
     }
     if(this.unionArrayTest !== undefined) {
-      let unionArrayTestJsonValues: string[] = [];
+      let unionArrayTestJsonValues: any[] = [];
       for (const unionItem of this.unionArrayTest) {
         if(unionItem instanceof NestedTest) {
           unionArrayTestJsonValues.push(unionItem.marshal());
@@ -88,7 +88,7 @@ exports[`Marshalling preset should render un/marshal code 1`] = `
       json += \`\\"unionArrayTest\\": [\${unionArrayTestJsonValues.join(',')}],\`; 
     }
     if(this.arrayTest !== undefined) {
-      let arrayTestJsonValues: string[] = [];
+      let arrayTestJsonValues: any[] = [];
       for (const unionItem of this.arrayTest) {
         arrayTestJsonValues.push(\`\${unionItem.marshal()}\`);
       }


### PR DESCRIPTION
**Description**
For the arrays used to store union and array values, it can be more than just string type, and this is being complained about when transpiling the files.