### PR TITLE
feat: php generator - descriptions, rendering model vs rendering file, example of complete model

### DIFF
--- a/examples/php-generate-complete-models/README.md
+++ b/examples/php-generate-complete-models/README.md
@@ -1,0 +1,17 @@
+# PHP Generate Complete Models Example
+
+A basic example of how to use Modelina and output PHP model.
+
+## How to run this example
+
+Run this example using:
+
+```sh
+npm i && npm run start
+```
+
+If you are on Windows, use the `start:windows` script instead:
+
+```sh
+npm i && npm run start:windows
+```

--- a/examples/php-generate-complete-models/__snapshots__/index.spec.ts.snap
+++ b/examples/php-generate-complete-models/__snapshots__/index.spec.ts.snap
@@ -3,6 +3,13 @@
 exports[`Should be able to render PHP and should log expected output to console 1`] = `
 Array [
   "
+<?php
+declare(strict_types=1);
+
+namespace Asyncapi;
+
+
+
 final class Root
 {
   private ?string $email;

--- a/examples/php-generate-complete-models/index.spec.ts
+++ b/examples/php-generate-complete-models/index.spec.ts
@@ -1,0 +1,15 @@
+const spy = jest.spyOn(global.console, 'log').mockImplementation(() => {
+  return;
+});
+import { generate } from './index';
+
+describe('Should be able to render PHP', () => {
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+  test('and should log expected output to console', async () => {
+    await generate();
+    expect(spy.mock.calls.length).toEqual(1);
+    expect(spy.mock.calls[0]).toMatchSnapshot();
+  });
+});

--- a/examples/php-generate-complete-models/index.ts
+++ b/examples/php-generate-complete-models/index.ts
@@ -14,7 +14,10 @@ const jsonSchemaDraft7 = {
 };
 
 export async function generate(): Promise<void> {
-  const models: OutputModel[] = await generator.generateCompleteModels(jsonSchemaDraft7, {});
+  const models: OutputModel[] = await generator.generateCompleteModels(
+    jsonSchemaDraft7,
+    {}
+  );
   for (const model of models) {
     console.log(model.result);
   }

--- a/examples/php-generate-complete-models/index.ts
+++ b/examples/php-generate-complete-models/index.ts
@@ -1,0 +1,24 @@
+import { OutputModel, PhpGenerator } from '../../src';
+
+const generator: PhpGenerator = new PhpGenerator();
+const jsonSchemaDraft7 = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    email: {
+      type: 'string',
+      format: 'email'
+    }
+  }
+};
+
+export async function generate(): Promise<void> {
+  const models: OutputModel[] = await generator.generateCompleteModels(jsonSchemaDraft7, {});
+  for (const model of models) {
+    console.log(model.result);
+  }
+}
+if (require.main === module) {
+  generate();
+}

--- a/examples/php-generate-complete-models/package-lock.json
+++ b/examples/php-generate-complete-models/package-lock.json
@@ -1,0 +1,10 @@
+{
+  "name": "php-generate-complete-models",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "hasInstallScript": true
+    }
+  }
+}

--- a/examples/php-generate-complete-models/package.json
+++ b/examples/php-generate-complete-models/package.json
@@ -1,0 +1,10 @@
+{
+  "config" : { "example_name" : "php-generate-complete-models" },
+  "scripts": {
+    "install": "cd ../.. && npm i",
+    "start": "../../node_modules/.bin/ts-node --cwd ../../ ./examples/$npm_package_config_example_name/index.ts",
+    "start:windows": "..\\..\\node_modules\\.bin\\ts-node --cwd ..\\..\\ .\\examples\\%npm_package_config_example_name%\\index.ts",
+    "test": "../../node_modules/.bin/jest --config=../../jest.config.js ./examples/$npm_package_config_example_name/index.spec.ts",
+    "test:windows": "..\\..\\node_modules\\.bin\\jest --config=..\\..\\jest.config.js examples/%npm_package_config_example_name%/index.spec.ts"
+  }
+}

--- a/src/generators/php/PhpGenerator.ts
+++ b/src/generators/php/PhpGenerator.ts
@@ -150,11 +150,10 @@ export class PhpGenerator extends AbstractGenerator<
     inputModel: InputMetaModel,
     options: PhpRenderCompleteModelOptions
   ): Promise<RenderOutput> {
-
     const completeModelOptionsToUse = mergePartialAndDefault(
-        PhpGenerator.defaultCompleteModelOptions,
-        options
-    )
+      PhpGenerator.defaultCompleteModelOptions,
+      options
+    );
 
     if (isReservedPhpKeyword(completeModelOptionsToUse.packageName)) {
       throw new Error(
@@ -162,7 +161,9 @@ export class PhpGenerator extends AbstractGenerator<
       );
     }
 
-    const declares = completeModelOptionsToUse.declareStrictTypes ? 'declare(strict_types=1);' : '';
+    const declares = completeModelOptionsToUse.declareStrictTypes
+      ? 'declare(strict_types=1);'
+      : '';
     const outputModel = await this.render(model, inputModel);
     const modelDependencies = model
       .getNearestDependencies()

--- a/src/generators/php/PhpRenderer.ts
+++ b/src/generators/php/PhpRenderer.ts
@@ -25,6 +25,6 @@ export abstract class PhpRenderer<
 
   renderComments(lines: string | string[]): string {
     lines = FormatHelpers.breakLines(lines);
-    return lines.map((line) => `// ${line}`).join('\n');
+    return lines.map((line) => `* ${line}`).join('\n');
   }
 }

--- a/src/generators/php/presets/DescriptionPreset.ts
+++ b/src/generators/php/presets/DescriptionPreset.ts
@@ -1,4 +1,25 @@
 import { PhpPreset } from '../PhpPreset';
+import { ConstrainedEnumModel, ConstrainedObjectModel } from "../../../models";
+
+function renderDescription({
+  content,
+  model
+}: {
+  content: string;
+  model: ConstrainedObjectModel | ConstrainedEnumModel;
+}): string {
+
+  if (!model.originalInput['description']) {
+    return content;
+  }
+
+  const description = model.originalInput['description'];
+
+  return `
+/**
+ * ${description}
+ */${content}`;
+}
 
 /**
  * Preset which adds description to rendered model.
@@ -6,20 +27,15 @@ import { PhpPreset } from '../PhpPreset';
  * @implements {PhpPreset}
  */
 
-const DESC = 'my description';
-
 export const PHP_DESCRIPTION_PRESET: PhpPreset = {
   class: {
-    self({ content }) {
-      return `//${DESC}\n${content}`;
+    self({ content, model }) {
+      return renderDescription({content, model});
     },
-    getter({ content }) {
-      return `//${DESC}\n${content}`;
-    }
   },
   enum: {
-    self({ content }) {
-      return `//${DESC}\n${content}`;
+    self({ content, model }) {
+      return renderDescription({content, model});
     }
   }
 };

--- a/src/generators/php/presets/DescriptionPreset.ts
+++ b/src/generators/php/presets/DescriptionPreset.ts
@@ -1,5 +1,5 @@
 import { PhpPreset } from '../PhpPreset';
-import { ConstrainedEnumModel, ConstrainedObjectModel } from "../../../models";
+import { ConstrainedEnumModel, ConstrainedObjectModel } from '../../../models';
 
 function renderDescription({
   content,
@@ -8,7 +8,6 @@ function renderDescription({
   content: string;
   model: ConstrainedObjectModel | ConstrainedEnumModel;
 }): string {
-
   if (!model.originalInput['description']) {
     return content;
   }
@@ -30,12 +29,12 @@ function renderDescription({
 export const PHP_DESCRIPTION_PRESET: PhpPreset = {
   class: {
     self({ content, model }) {
-      return renderDescription({content, model});
-    },
+      return renderDescription({ content, model });
+    }
   },
   enum: {
     self({ content, model }) {
-      return renderDescription({content, model});
+      return renderDescription({ content, model });
     }
   }
 };

--- a/src/generators/php/renderers/ClassRenderer.ts
+++ b/src/generators/php/renderers/ClassRenderer.ts
@@ -21,10 +21,12 @@ export class ClassRenderer extends PhpRenderer<ConstrainedObjectModel> {
       await this.runAdditionalContentPreset()
     ];
 
-    return `final class ${this.model.name}
+    return `
+final class ${this.model.name}
 {
 ${this.indent(this.renderBlock(content, 2))}
-}`;
+}
+`;
   }
 
   runCtorPreset(): Promise<string> {

--- a/src/generators/php/renderers/EnumRenderer.ts
+++ b/src/generators/php/renderers/EnumRenderer.ts
@@ -14,10 +14,12 @@ import { PhpOptions } from '../PhpGenerator';
 export class EnumRenderer extends PhpRenderer<ConstrainedEnumModel> {
   async defaultSelf(): Promise<string> {
     const content = [await this.renderItems()];
-    return `enum ${this.model.name}
+    return `
+enum ${this.model.name}
 {
 ${this.indent(this.renderBlock(content, 2))}
-}`;
+}
+`;
   }
 
   async renderItems(): Promise<string> {

--- a/test/generators/php/PhpGenerator.spec.ts
+++ b/test/generators/php/PhpGenerator.spec.ts
@@ -139,7 +139,7 @@ describe('PhpGenerator', () => {
       expect(models[0].dependencies).toEqual(expectedDependencies);
     });
 
-    test('custom', async () => {
+    test('should render complete model', async () => {
       const doc = {
         $id: 'CustomClass',
         type: 'object',
@@ -148,10 +148,7 @@ describe('PhpGenerator', () => {
         }
       };
 
-      const models = await generator.generateCompleteModels(doc, {
-        packageName: 'Asyncapi',
-        declareStrictTypes: true,
-      });
+      const models = await generator.generateCompleteModels(doc, {});
       expect(models).toHaveLength(1);
       expect(models[0].result).toMatchSnapshot();
     });

--- a/test/generators/php/PhpGenerator.spec.ts
+++ b/test/generators/php/PhpGenerator.spec.ts
@@ -139,6 +139,23 @@ describe('PhpGenerator', () => {
       expect(models[0].dependencies).toEqual(expectedDependencies);
     });
 
+    test('custom', async () => {
+      const doc = {
+        $id: 'CustomClass',
+        type: 'object',
+        properties: {
+          property: { type: 'string' }
+        }
+      };
+
+      const models = await generator.generateCompleteModels(doc, {
+        packageName: 'Asyncapi',
+        declareStrictTypes: true,
+      });
+      expect(models).toHaveLength(1);
+      expect(models[0].result).toMatchSnapshot();
+    });
+
     test('should render optional/nullable properties', async () => {
       const doc = {
         $id: 'Address',

--- a/test/generators/php/PhpRenderer.spec.ts
+++ b/test/generators/php/PhpRenderer.spec.ts
@@ -19,7 +19,7 @@ describe('PhpRenderer', () => {
 
   describe('renderComments()', () => {
     test('Should be able to render comments', () => {
-      expect(renderer.renderComments('someComment')).toEqual('// someComment');
+      expect(renderer.renderComments('someComment')).toEqual('* someComment');
     });
   });
 });

--- a/test/generators/php/__snapshots__/PhpGenerator.spec.ts.snap
+++ b/test/generators/php/__snapshots__/PhpGenerator.spec.ts.snap
@@ -1,7 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`PhpGenerator Class should not render reserved keyword 1`] = `
-"final class Address
+"
+final class Address
 {
   private ?string $enum;
   private ?string $reservedEnum;
@@ -11,11 +12,13 @@ exports[`PhpGenerator Class should not render reserved keyword 1`] = `
 
   public function getReservedEnum(): ?string { return $this->reservedEnum; }
   public function setReservedEnum(?string $reservedEnum): void { $this->reservedEnum = $reservedEnum; }
-}"
+}
+"
 `;
 
 exports[`PhpGenerator Class should render \`class\` type 1`] = `
-"final class Address
+"
+final class Address
 {
   private string $streetName;
   private string $city;
@@ -49,11 +52,13 @@ exports[`PhpGenerator Class should render \`class\` type 1`] = `
 
   public function getAdditionalProperties(): mixed { return $this->additionalProperties; }
   public function setAdditionalProperties(mixed $additionalProperties): void { $this->additionalProperties = $additionalProperties; }
-}"
+}
+"
 `;
 
 exports[`PhpGenerator Class should render optional/nullable properties 1`] = `
-"final class Address
+"
+final class Address
 {
   private string $streetName;
   private string $city;
@@ -71,11 +76,13 @@ exports[`PhpGenerator Class should render optional/nullable properties 1`] = `
 
   public function getHouseNumber(): ?float { return $this->houseNumber; }
   public function setHouseNumber(?float $houseNumber): void { $this->houseNumber = $houseNumber; }
-}"
+}
+"
 `;
 
 exports[`PhpGenerator Class should work with custom preset for \`class\` type 1`] = `
-"final class CustomClass
+"
+final class CustomClass
 {
   test1
   private ?string $property;
@@ -91,36 +98,66 @@ exports[`PhpGenerator Class should work with custom preset for \`class\` type 1`
   public function getAdditionalProperties(): mixed { return $this->additionalProperties; }
   test3
   public function setAdditionalProperties(mixed $additionalProperties): void { $this->additionalProperties = $additionalProperties; }
-}"
+}
+"
+`;
+
+exports[`PhpGenerator Class custom 1`] = `
+"
+<?php
+declare(strict_types=1);
+
+namespace Asyncapi;
+
+
+
+final class CustomClass
+{
+  private ?string $property;
+  private mixed $additionalProperties;
+
+  public function getProperty(): ?string { return $this->property; }
+  public function setProperty(?string $property): void { $this->property = $property; }
+
+  public function getAdditionalProperties(): mixed { return $this->additionalProperties; }
+  public function setAdditionalProperties(mixed $additionalProperties): void { $this->additionalProperties = $additionalProperties; }
+}
+"
 `;
 
 exports[`PhpGenerator Enum should render \`enum\` with mixed types (union type) 1`] = `
-"enum Things
+"
+enum Things
 {
   case TEXAS;
   case NUMBER_1;
   case RESERVED_NUMBER_1;
   case FALSE;
   case CURLYLEFT_QUOTATION_TEST_QUOTATION_COLON_QUOTATION_TEST_QUOTATION_CURLYRIGHT;
-}"
+}
+"
 `;
 
 exports[`PhpGenerator Enum should render enums with translated special characters 1`] = `
-"enum States
+"
+enum States
 {
   case TEST_PLUS;
   case DOLLAR_TEST;
   case TEST_MINUS;
   case TEST_QUESTION_EXCLAMATION;
   case ASTERISK_TEST;
-}"
+}
+"
 `;
 
 exports[`PhpGenerator Enum should work custom preset for \`enum\` type 1`] = `
-"enum CustomEnum
+"
+enum CustomEnum
 {
   case TEXAS;
   case ALABAMA;
   case CALIFORNIA;
-}"
+}
+"
 `;

--- a/test/generators/php/__snapshots__/PhpGenerator.spec.ts.snap
+++ b/test/generators/php/__snapshots__/PhpGenerator.spec.ts.snap
@@ -102,7 +102,7 @@ final class CustomClass
 "
 `;
 
-exports[`PhpGenerator Class custom 1`] = `
+exports[`PhpGenerator Class should render complete model 1`] = `
 "
 <?php
 declare(strict_types=1);

--- a/test/generators/php/presets/__snapshots__/DescriptionPreset.spec.ts.snap
+++ b/test/generators/php/presets/__snapshots__/DescriptionPreset.spec.ts.snap
@@ -1,27 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`PHP_DESCRIPTION_PRESET should render description and examples for class 1`] = `
-"//my description
+"
+/**
+ * Description for class
+ */
 final class Clazz
 {
   private ?string $prop;
   private mixed $additionalProperties;
 
-  //my description
   public function getProp(): ?string { return $this->prop; }
   public function setProp(?string $prop): void { $this->prop = $prop; }
 
-  //my description
   public function getAdditionalProperties(): mixed { return $this->additionalProperties; }
   public function setAdditionalProperties(mixed $additionalProperties): void { $this->additionalProperties = $additionalProperties; }
-}"
+}
+"
 `;
 
 exports[`PHP_DESCRIPTION_PRESET should render description and examples for enum 1`] = `
-"//my description
+"
+/**
+ * Description for enum
+ */
 enum Enum
 {
   case ON;
   case OFF;
-}"
+}
+"
 `;


### PR DESCRIPTION
1. Added the Generate Complete Models Example
2. Moved the rendering `<?php` tag to rendering complete model
3. Rendering class descriptions
4. Rendering Strict Types declaration as default