### PR TITLE
feat: php generator - rename packageName to namespace

### DIFF
--- a/docs/languages/Php.md
+++ b/docs/languages/Php.md
@@ -1,0 +1,4 @@
+# PHP
+There are special use-cases that each language supports; this document pertains to **PHP models**.
+
+At the moment, PHP models have no specific features.

--- a/examples/README.md
+++ b/examples/README.md
@@ -125,6 +125,7 @@ These are all specific examples only relevant to the Kotlin generator:
 ## PHP
 These are all specific examples only relevant to the PHP generator:
 - [php-generate-models](./php-generate-models) - A basic example of how to use Modelina and output a PHP class.
+- [php-generate-complete-models](./php-generate-complete-models) - An example that will output PHP complete class with dependencies and headers.
 
 ## Other examples
 Miscellaneous examples that do not fit into the otherwise grouping.

--- a/src/generators/php/PhpGenerator.ts
+++ b/src/generators/php/PhpGenerator.ts
@@ -30,7 +30,7 @@ export interface PhpOptions extends CommonGeneratorOptions<PhpPreset> {
   constraints: Constraints;
 }
 export interface PhpRenderCompleteModelOptions {
-  packageName: string;
+  namespace: string;
   declareStrictTypes: boolean;
 }
 export class PhpGenerator extends AbstractGenerator<
@@ -45,7 +45,7 @@ export class PhpGenerator extends AbstractGenerator<
   };
 
   static defaultCompleteModelOptions: PhpRenderCompleteModelOptions = {
-    packageName: 'Asyncapi',
+    namespace: 'Asyncapi',
     declareStrictTypes: true
   };
 
@@ -155,9 +155,9 @@ export class PhpGenerator extends AbstractGenerator<
       options
     );
 
-    if (isReservedPhpKeyword(completeModelOptionsToUse.packageName)) {
+    if (isReservedPhpKeyword(completeModelOptionsToUse.namespace)) {
       throw new Error(
-        `You cannot use reserved PHP keyword (${options.packageName}) as package name, please use another.`
+        `You cannot use reserved PHP keyword (${options.namespace}) as package name, please use another.`
       );
     }
 
@@ -168,13 +168,13 @@ export class PhpGenerator extends AbstractGenerator<
     const modelDependencies = model
       .getNearestDependencies()
       .map((dependencyModel) => {
-        return `use ${completeModelOptionsToUse.packageName}\\${dependencyModel.name};`;
+        return `use ${completeModelOptionsToUse.namespace}\\${dependencyModel.name};`;
       });
     const outputContent = `
 <?php
 ${declares}
 
-namespace ${completeModelOptionsToUse.packageName};
+namespace ${completeModelOptionsToUse.namespace};
 ${modelDependencies.join('\n')}
 ${outputModel.dependencies.join('\n')}
 ${outputModel.result}`;


### PR DESCRIPTION
PHP has the concept of namespaces (like C#) instead of packages (like Java) so to have it coherent I renamed it