### PR TITLE
feat!: java interfaced union generation for oneOf

### DIFF
--- a/examples/java-generate-union-deduction-jackson/README.md
+++ b/examples/java-generate-union-deduction-jackson/README.md
@@ -1,0 +1,17 @@
+# Java Generate Jackson Annotation
+
+A basic example on how to generate models for jackson annotation
+
+## How to run this example
+
+Run this example using:
+
+```sh
+npm i && npm run start
+```
+
+If you are on Windows, use the `start:windows` script instead:
+
+```sh
+npm i && npm run start:windows
+```

--- a/examples/java-generate-union-deduction-jackson/__snapshots__/index.spec.ts.snap
+++ b/examples/java-generate-union-deduction-jackson/__snapshots__/index.spec.ts.snap
@@ -1,0 +1,45 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Should be able to generate data models for jackson annotation and should log expected output to console 1`] = `
+Array [
+  Array [
+    "@JsonTypeInfo(use=JsonTypeInfo.Id.DEDUCTION)
+@JsonSubTypes({
+  @JsonSubTypes.Type(value = Car.class, name = \\"Car\\"),
+  @JsonSubTypes.Type(value = Truck.class, name = \\"Truck\\")
+})
+/**
+ * Vehicle represents a union of types: Car, Truck
+ */
+public interface Vehicle {
+  
+}",
+  ],
+  Array [
+    "public class Car implements Vehicle {
+  @JsonProperty(\\"passengers\\")
+  private String passengers;
+  private Map<String, Object> additionalProperties;
+
+  public String getPassengers() { return this.passengers; }
+  public void setPassengers(String passengers) { this.passengers = passengers; }
+
+  public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
+  public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
+}",
+  ],
+  Array [
+    "public class Truck implements Vehicle {
+  @JsonProperty(\\"cargo\\")
+  private String cargo;
+  private Map<String, Object> additionalProperties;
+
+  public String getCargo() { return this.cargo; }
+  public void setCargo(String cargo) { this.cargo = cargo; }
+
+  public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
+  public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
+}",
+  ],
+]
+`;

--- a/examples/java-generate-union-deduction-jackson/__snapshots__/index.spec.ts.snap
+++ b/examples/java-generate-union-deduction-jackson/__snapshots__/index.spec.ts.snap
@@ -12,7 +12,8 @@ Array [
  * Vehicle represents a union of types: Car, Truck
  */
 public interface Vehicle {
-  
+  Map<String, Object> getAdditionalProperties();
+  void setAdditionalProperties(Map<String, Object> additionalProperties);
 }",
   ],
   Array [

--- a/examples/java-generate-union-deduction-jackson/index.spec.ts
+++ b/examples/java-generate-union-deduction-jackson/index.spec.ts
@@ -1,0 +1,14 @@
+const spy = jest.spyOn(global.console, 'log').mockImplementation(() => {
+  return;
+});
+import { generate } from './index';
+
+describe('Should be able to generate data models for jackson annotation', () => {
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+  test('and should log expected output to console', async () => {
+    await generate();
+    expect(spy.mock.calls).toMatchSnapshot();
+  });
+});

--- a/examples/java-generate-union-deduction-jackson/index.ts
+++ b/examples/java-generate-union-deduction-jackson/index.ts
@@ -1,0 +1,37 @@
+import { JavaGenerator, JAVA_JACKSON_PRESET } from '../../src';
+
+const generator = new JavaGenerator({
+  presets: [JAVA_JACKSON_PRESET]
+});
+
+const jsonSchemaDraft7 = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  title: 'Vehicle',
+  type: 'object',
+  oneOf: [
+    {
+      title: 'Car',
+      type: 'object',
+      properties: {
+        passengers: { type: 'string' }
+      }
+    },
+    {
+      title: 'Truck',
+      type: 'object',
+      properties: {
+        cargo: { type: 'string' }
+      }
+    }
+  ]
+};
+
+export async function generate(): Promise<void> {
+  const models = await generator.generate(jsonSchemaDraft7);
+  for (const model of models) {
+    console.log(model.result);
+  }
+}
+if (require.main === module) {
+  generate();
+}

--- a/examples/java-generate-union-deduction-jackson/package.json
+++ b/examples/java-generate-union-deduction-jackson/package.json
@@ -1,0 +1,12 @@
+{
+  "config": {
+    "example_name": "java-generate-union-deduction-jackson"
+  },
+  "scripts": {
+    "install": "cd ../.. && npm i",
+    "start": "../../node_modules/.bin/ts-node --cwd ../../ ./examples/$npm_package_config_example_name/index.ts",
+    "start:windows": "..\\..\\node_modules\\.bin\\ts-node --cwd ..\\..\\ .\\examples\\%npm_package_config_example_name%\\index.ts",
+    "test": "../../node_modules/.bin/jest --config=../../jest.config.js ./examples/$npm_package_config_example_name/index.spec.ts",
+    "test:windows": "..\\..\\node_modules\\.bin\\jest --config=..\\..\\jest.config.js examples/%npm_package_config_example_name%/index.spec.ts"
+  }
+}

--- a/examples/java-generate-union-deduction/README.md
+++ b/examples/java-generate-union-deduction/README.md
@@ -1,0 +1,17 @@
+# Java Generate Jackson Annotation
+
+A basic example on how to generate models for jackson annotation
+
+## How to run this example
+
+Run this example using:
+
+```sh
+npm i && npm run start
+```
+
+If you are on Windows, use the `start:windows` script instead:
+
+```sh
+npm i && npm run start:windows
+```

--- a/examples/java-generate-union-deduction/__snapshots__/index.spec.ts.snap
+++ b/examples/java-generate-union-deduction/__snapshots__/index.spec.ts.snap
@@ -7,7 +7,8 @@ Array [
  * Vehicle represents a union of types: Car, Truck
  */
 public interface Vehicle {
-  
+  Map<String, Object> getAdditionalProperties();
+  void setAdditionalProperties(Map<String, Object> additionalProperties);
 }",
   ],
   Array [

--- a/examples/java-generate-union-deduction/__snapshots__/index.spec.ts.snap
+++ b/examples/java-generate-union-deduction/__snapshots__/index.spec.ts.snap
@@ -1,0 +1,38 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Should be able to generate data models for jackson annotation and should log expected output to console 1`] = `
+Array [
+  Array [
+    "/**
+ * Vehicle represents a union of types: Car, Truck
+ */
+public interface Vehicle {
+  
+}",
+  ],
+  Array [
+    "public class Car implements Vehicle {
+  private String passengers;
+  private Map<String, Object> additionalProperties;
+
+  public String getPassengers() { return this.passengers; }
+  public void setPassengers(String passengers) { this.passengers = passengers; }
+
+  public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
+  public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
+}",
+  ],
+  Array [
+    "public class Truck implements Vehicle {
+  private String cargo;
+  private Map<String, Object> additionalProperties;
+
+  public String getCargo() { return this.cargo; }
+  public void setCargo(String cargo) { this.cargo = cargo; }
+
+  public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
+  public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
+}",
+  ],
+]
+`;

--- a/examples/java-generate-union-deduction/index.spec.ts
+++ b/examples/java-generate-union-deduction/index.spec.ts
@@ -1,0 +1,14 @@
+const spy = jest.spyOn(global.console, 'log').mockImplementation(() => {
+  return;
+});
+import { generate } from './index';
+
+describe('Should be able to generate data models for jackson annotation', () => {
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+  test('and should log expected output to console', async () => {
+    await generate();
+    expect(spy.mock.calls).toMatchSnapshot();
+  });
+});

--- a/examples/java-generate-union-deduction/index.ts
+++ b/examples/java-generate-union-deduction/index.ts
@@ -1,0 +1,35 @@
+import { JavaGenerator } from '../../src';
+
+const generator = new JavaGenerator();
+
+const jsonSchemaDraft7 = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  title: 'Vehicle',
+  type: 'object',
+  oneOf: [
+    {
+      title: 'Car',
+      type: 'object',
+      properties: {
+        passengers: { type: 'string' }
+      }
+    },
+    {
+      title: 'Truck',
+      type: 'object',
+      properties: {
+        cargo: { type: 'string' }
+      }
+    }
+  ]
+};
+
+export async function generate(): Promise<void> {
+  const models = await generator.generate(jsonSchemaDraft7);
+  for (const model of models) {
+    console.log(model.result);
+  }
+}
+if (require.main === module) {
+  generate();
+}

--- a/examples/java-generate-union-deduction/package-lock.json
+++ b/examples/java-generate-union-deduction/package-lock.json
@@ -1,0 +1,10 @@
+{
+  "name": "java-generate-union-deduction",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "hasInstallScript": true
+    }
+  }
+}

--- a/examples/java-generate-union-deduction/package.json
+++ b/examples/java-generate-union-deduction/package.json
@@ -1,0 +1,12 @@
+{
+  "config": {
+    "example_name": "java-generate-union-deduction"
+  },
+  "scripts": {
+    "install": "cd ../.. && npm i",
+    "start": "../../node_modules/.bin/ts-node --cwd ../../ ./examples/$npm_package_config_example_name/index.ts",
+    "start:windows": "..\\..\\node_modules\\.bin\\ts-node --cwd ..\\..\\ .\\examples\\%npm_package_config_example_name%\\index.ts",
+    "test": "../../node_modules/.bin/jest --config=../../jest.config.js ./examples/$npm_package_config_example_name/index.spec.ts",
+    "test:windows": "..\\..\\node_modules\\.bin\\jest --config=..\\..\\jest.config.js examples/%npm_package_config_example_name%/index.spec.ts"
+  }
+}

--- a/examples/java-generate-union-discriminator-jackson/README.md
+++ b/examples/java-generate-union-discriminator-jackson/README.md
@@ -1,0 +1,17 @@
+# Java Generate Jackson Annotation
+
+A basic example on how to generate models for jackson annotation
+
+## How to run this example
+
+Run this example using:
+
+```sh
+npm i && npm run start
+```
+
+If you are on Windows, use the `start:windows` script instead:
+
+```sh
+npm i && npm run start:windows
+```

--- a/examples/java-generate-union-discriminator-jackson/__snapshots__/index.spec.ts.snap
+++ b/examples/java-generate-union-discriminator-jackson/__snapshots__/index.spec.ts.snap
@@ -1,0 +1,55 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Should be able to generate data models for jackson annotation and should log expected output to console 1`] = `
+Array [
+  Array [
+    "@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.PROPERTY, property=\\"vehicleType\\")
+@JsonSubTypes({
+  @JsonSubTypes.Type(value = Car.class, name = \\"Car\\"),
+  @JsonSubTypes.Type(value = Truck.class, name = \\"Truck\\")
+})
+/**
+ * Vehicle represents a union of types: Car, Truck
+ */
+public interface Vehicle {
+  String getVehicleType();
+}",
+  ],
+  Array [
+    "public class Car implements Vehicle {
+  @JsonProperty(\\"vehicleType\\")
+  private String vehicleType = \\"Car\\";
+  @JsonProperty(\\"name\\")
+  private String name;
+  private Map<String, Object> additionalProperties;
+
+  public String getVehicleType() { return this.vehicleType; }
+  public void setVehicleType(String vehicleType) { this.vehicleType = vehicleType; }
+
+  public String getName() { return this.name; }
+  public void setName(String name) { this.name = name; }
+
+  public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
+  public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
+}",
+  ],
+  Array [
+    "public class Truck implements Vehicle {
+  @JsonProperty(\\"vehicleType\\")
+  private String vehicleType = \\"Truck\\";
+  @JsonProperty(\\"name\\")
+  private String name;
+  private Map<String, Object> additionalProperties;
+
+  public String getVehicleType() { return this.vehicleType; }
+  public void setVehicleType(String vehicleType) { this.vehicleType = vehicleType; }
+
+  public String getName() { return this.name; }
+  public void setName(String name) { this.name = name; }
+
+  public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
+  public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
+}",
+  ],
+]
+`;

--- a/examples/java-generate-union-discriminator-jackson/__snapshots__/index.spec.ts.snap
+++ b/examples/java-generate-union-discriminator-jackson/__snapshots__/index.spec.ts.snap
@@ -13,6 +13,11 @@ Array [
  */
 public interface Vehicle {
   String getVehicleType();
+  void setVehicleType(String vehicleType);
+  String getName();
+  void setName(String name);
+  Map<String, Object> getAdditionalProperties();
+  void setAdditionalProperties(Map<String, Object> additionalProperties);
 }",
   ],
   Array [

--- a/examples/java-generate-union-discriminator-jackson/index.spec.ts
+++ b/examples/java-generate-union-discriminator-jackson/index.spec.ts
@@ -1,0 +1,14 @@
+const spy = jest.spyOn(global.console, 'log').mockImplementation(() => {
+  return;
+});
+import { generate } from './index';
+
+describe('Should be able to generate data models for jackson annotation', () => {
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+  test('and should log expected output to console', async () => {
+    await generate();
+    expect(spy.mock.calls).toMatchSnapshot();
+  });
+});

--- a/examples/java-generate-union-discriminator-jackson/index.ts
+++ b/examples/java-generate-union-discriminator-jackson/index.ts
@@ -1,0 +1,41 @@
+import { JavaGenerator, JAVA_JACKSON_PRESET } from '../../src';
+
+const generator = new JavaGenerator({
+  presets: [JAVA_JACKSON_PRESET]
+});
+
+const jsonSchemaDraft7 = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  title: 'Vehicle',
+  type: 'object',
+  discriminator: 'vehicleType',
+  oneOf: [{ $ref: '#/definitions/Car' }, { $ref: '#/definitions/Truck' }],
+  definitions: {
+    Car: {
+      title: 'Car',
+      type: 'object',
+      properties: {
+        vehicleType: { type: 'string' },
+        name: { type: 'string' }
+      }
+    },
+    Truck: {
+      title: 'Truck',
+      type: 'object',
+      properties: {
+        vehicleType: { type: 'string' },
+        name: { type: 'string' }
+      }
+    }
+  }
+};
+
+export async function generate(): Promise<void> {
+  const models = await generator.generate(jsonSchemaDraft7);
+  for (const model of models) {
+    console.log(model.result);
+  }
+}
+if (require.main === module) {
+  generate();
+}

--- a/examples/java-generate-union-discriminator-jackson/package-lock.json
+++ b/examples/java-generate-union-discriminator-jackson/package-lock.json
@@ -1,0 +1,10 @@
+{
+  "name": "java-generate-union-discriminator-jackson",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "hasInstallScript": true
+    }
+  }
+}

--- a/examples/java-generate-union-discriminator-jackson/package.json
+++ b/examples/java-generate-union-discriminator-jackson/package.json
@@ -1,0 +1,12 @@
+{
+  "config": {
+    "example_name": "java-generate-union-discriminator-jackson"
+  },
+  "scripts": {
+    "install": "cd ../.. && npm i",
+    "start": "../../node_modules/.bin/ts-node --cwd ../../ ./examples/$npm_package_config_example_name/index.ts",
+    "start:windows": "..\\..\\node_modules\\.bin\\ts-node --cwd ..\\..\\ .\\examples\\%npm_package_config_example_name%\\index.ts",
+    "test": "../../node_modules/.bin/jest --config=../../jest.config.js ./examples/$npm_package_config_example_name/index.spec.ts",
+    "test:windows": "..\\..\\node_modules\\.bin\\jest --config=..\\..\\jest.config.js examples/%npm_package_config_example_name%/index.spec.ts"
+  }
+}

--- a/examples/java-generate-union-discriminator/README.md
+++ b/examples/java-generate-union-discriminator/README.md
@@ -1,0 +1,17 @@
+# Java Generate Jackson Annotation
+
+A basic example on how to generate models for jackson annotation
+
+## How to run this example
+
+Run this example using:
+
+```sh
+npm i && npm run start
+```
+
+If you are on Windows, use the `start:windows` script instead:
+
+```sh
+npm i && npm run start:windows
+```

--- a/examples/java-generate-union-discriminator/__snapshots__/index.spec.ts.snap
+++ b/examples/java-generate-union-discriminator/__snapshots__/index.spec.ts.snap
@@ -1,0 +1,46 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Should be able to generate data models for jackson annotation and should log expected output to console 1`] = `
+Array [
+  Array [
+    "/**
+ * Vehicle represents a union of types: Car, Truck
+ */
+public interface Vehicle {
+  String getVehicleType();
+}",
+  ],
+  Array [
+    "public class Car implements Vehicle {
+  private String vehicleType = \\"Car\\";
+  private String name;
+  private Map<String, Object> additionalProperties;
+
+  public String getVehicleType() { return this.vehicleType; }
+  public void setVehicleType(String vehicleType) { this.vehicleType = vehicleType; }
+
+  public String getName() { return this.name; }
+  public void setName(String name) { this.name = name; }
+
+  public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
+  public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
+}",
+  ],
+  Array [
+    "public class Truck implements Vehicle {
+  private String vehicleType = \\"Truck\\";
+  private String name;
+  private Map<String, Object> additionalProperties;
+
+  public String getVehicleType() { return this.vehicleType; }
+  public void setVehicleType(String vehicleType) { this.vehicleType = vehicleType; }
+
+  public String getName() { return this.name; }
+  public void setName(String name) { this.name = name; }
+
+  public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
+  public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
+}",
+  ],
+]
+`;

--- a/examples/java-generate-union-discriminator/__snapshots__/index.spec.ts.snap
+++ b/examples/java-generate-union-discriminator/__snapshots__/index.spec.ts.snap
@@ -8,6 +8,11 @@ Array [
  */
 public interface Vehicle {
   String getVehicleType();
+  void setVehicleType(String vehicleType);
+  String getName();
+  void setName(String name);
+  Map<String, Object> getAdditionalProperties();
+  void setAdditionalProperties(Map<String, Object> additionalProperties);
 }",
   ],
   Array [

--- a/examples/java-generate-union-discriminator/index.spec.ts
+++ b/examples/java-generate-union-discriminator/index.spec.ts
@@ -1,0 +1,14 @@
+const spy = jest.spyOn(global.console, 'log').mockImplementation(() => {
+  return;
+});
+import { generate } from './index';
+
+describe('Should be able to generate data models for jackson annotation', () => {
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+  test('and should log expected output to console', async () => {
+    await generate();
+    expect(spy.mock.calls).toMatchSnapshot();
+  });
+});

--- a/examples/java-generate-union-discriminator/index.ts
+++ b/examples/java-generate-union-discriminator/index.ts
@@ -1,0 +1,38 @@
+import { JavaGenerator } from '../../src';
+
+const generator = new JavaGenerator();
+
+const jsonSchemaDraft7 = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  title: 'Vehicle',
+  type: 'object',
+  discriminator: 'vehicleType',
+  oneOf: [
+    {
+      title: 'Car',
+      type: 'object',
+      properties: {
+        vehicleType: { type: 'string' },
+        name: { type: 'string' }
+      }
+    },
+    {
+      title: 'Truck',
+      type: 'object',
+      properties: {
+        vehicleType: { type: 'string' },
+        name: { type: 'string' }
+      }
+    }
+  ]
+};
+
+export async function generate(): Promise<void> {
+  const models = await generator.generate(jsonSchemaDraft7);
+  for (const model of models) {
+    console.log(model.result);
+  }
+}
+if (require.main === module) {
+  generate();
+}

--- a/examples/java-generate-union-discriminator/package-lock.json
+++ b/examples/java-generate-union-discriminator/package-lock.json
@@ -1,0 +1,10 @@
+{
+  "name": "java-generate-union-deduction",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "hasInstallScript": true
+    }
+  }
+}

--- a/examples/java-generate-union-discriminator/package.json
+++ b/examples/java-generate-union-discriminator/package.json
@@ -1,0 +1,12 @@
+{
+  "config": {
+    "example_name": "java-generate-union-discriminator"
+  },
+  "scripts": {
+    "install": "cd ../.. && npm i",
+    "start": "../../node_modules/.bin/ts-node --cwd ../../ ./examples/$npm_package_config_example_name/index.ts",
+    "start:windows": "..\\..\\node_modules\\.bin\\ts-node --cwd ..\\..\\ .\\examples\\%npm_package_config_example_name%\\index.ts",
+    "test": "../../node_modules/.bin/jest --config=../../jest.config.js ./examples/$npm_package_config_example_name/index.spec.ts",
+    "test:windows": "..\\..\\node_modules\\.bin\\jest --config=..\\..\\jest.config.js examples/%npm_package_config_example_name%/index.spec.ts"
+  }
+}

--- a/src/generators/java/JavaConstrainer.ts
+++ b/src/generators/java/JavaConstrainer.ts
@@ -170,9 +170,8 @@ export const JavaDefaultTypeMapping: JavaTypeMapping = {
 
     return uniqueTypes[0];
   },
-  Union(): string {
-    //Because Java have no notion of unions (and no custom implementation), we have to render it as any value.
-    return 'Object';
+  Union({ constrainedModel }): string {
+    return constrainedModel.name;
   },
   Dictionary({ constrainedModel }): string {
     //Limitations to Java is that maps cannot have specific value types...

--- a/src/generators/java/JavaPreset.ts
+++ b/src/generators/java/JavaPreset.ts
@@ -1,10 +1,13 @@
+import { AbstractRenderer } from 'generators/AbstractRenderer';
 import {
   Preset,
   ClassPreset,
   EnumPreset,
+  CommonPreset,
   PresetArgs,
   EnumArgs,
-  ConstrainedEnumModel
+  ConstrainedEnumModel,
+  ConstrainedUnionModel
 } from '../../models';
 import { JavaOptions } from './JavaGenerator';
 import {
@@ -15,6 +18,10 @@ import {
   EnumRenderer,
   JAVA_DEFAULT_ENUM_PRESET
 } from './renderers/EnumRenderer';
+import {
+  UnionRenderer,
+  JAVA_DEFAULT_UNION_PRESET
+} from './renderers/UnionRenderer';
 
 export type ClassPresetType<O> = ClassPreset<ClassRenderer, O>;
 export interface EnumPresetType<O> extends EnumPreset<EnumRenderer, O> {
@@ -29,12 +36,25 @@ export interface EnumPresetType<O> extends EnumPreset<EnumRenderer, O> {
   ) => string;
 }
 
+export type UnionPresetType<O> = UnionPreset<UnionRenderer, O>;
+
+export interface UnionPreset<R extends AbstractRenderer, O>
+  extends CommonPreset<R, O, ConstrainedUnionModel> {
+  ctor?: (args: PresetArgs<R, O, ConstrainedUnionModel>) => string;
+  enum?: (args: PresetArgs<R, O, ConstrainedUnionModel>) => string;
+  discriminatorGetter?: (
+    args: PresetArgs<R, O, ConstrainedUnionModel>
+  ) => string;
+}
+
 export type JavaPreset<O = any> = Preset<{
   class: ClassPresetType<O>;
   enum: EnumPresetType<O>;
+  union: UnionPresetType<O>;
 }>;
 
 export const JAVA_DEFAULT_PRESET: JavaPreset<JavaOptions> = {
   class: JAVA_DEFAULT_CLASS_PRESET,
-  enum: JAVA_DEFAULT_ENUM_PRESET
+  enum: JAVA_DEFAULT_ENUM_PRESET,
+  union: JAVA_DEFAULT_UNION_PRESET
 };

--- a/src/generators/java/JavaPreset.ts
+++ b/src/generators/java/JavaPreset.ts
@@ -7,7 +7,8 @@ import {
   PresetArgs,
   EnumArgs,
   ConstrainedEnumModel,
-  ConstrainedUnionModel
+  ConstrainedUnionModel,
+  PropertyArgs
 } from '../../models';
 import { JavaOptions } from './JavaGenerator';
 import {
@@ -42,8 +43,11 @@ export interface UnionPreset<R extends AbstractRenderer, O>
   extends CommonPreset<R, O, ConstrainedUnionModel> {
   ctor?: (args: PresetArgs<R, O, ConstrainedUnionModel>) => string;
   enum?: (args: PresetArgs<R, O, ConstrainedUnionModel>) => string;
-  discriminatorGetter?: (
-    args: PresetArgs<R, O, ConstrainedUnionModel>
+  getter?: (
+    args: PresetArgs<R, O, ConstrainedUnionModel> & PropertyArgs
+  ) => string;
+  setter?: (
+    args: PresetArgs<R, O, ConstrainedUnionModel> & PropertyArgs
   ) => string;
 }
 

--- a/src/generators/java/renderers/UnionRenderer.ts
+++ b/src/generators/java/renderers/UnionRenderer.ts
@@ -1,0 +1,54 @@
+import { JavaRenderer } from '../JavaRenderer';
+import { ConstrainedUnionModel } from '../../../models';
+import { JavaOptions } from '../JavaGenerator';
+import { UnionPresetType } from '../JavaPreset';
+import { FormatHelpers } from '../../../index';
+
+/**
+ * Renderer for Java's `union` type
+ *
+ * @extends JavaRenderer
+ */
+export class UnionRenderer extends JavaRenderer<ConstrainedUnionModel> {
+  async defaultSelf(): Promise<string> {
+    const doc = this.renderComments(
+      `${this.model.name} represents a union of types: ${this.model.union
+        .map((m) => m.type)
+        .join(', ')}`
+    );
+
+    const content = [];
+
+    if (this.model.originalInput.discriminator !== undefined) {
+      content.push(await this.runDiscriminatorAccessorPreset());
+    }
+    content.push(await this.runAdditionalContentPreset());
+
+    return this.renderBlock([
+      doc,
+      `public interface ${this.model.name} {`,
+      this.indent(this.renderBlock(content)),
+      '}'
+    ]);
+  }
+
+  runDiscriminatorAccessorPreset(): Promise<string> {
+    return this.runPreset('discriminatorGetter');
+  }
+}
+
+export const JAVA_DEFAULT_UNION_PRESET: UnionPresetType<JavaOptions> = {
+  self({ renderer }) {
+    return renderer.defaultSelf();
+  },
+  discriminatorGetter({ model }) {
+    if (model.originalInput.discriminator === undefined) {
+      return '';
+    }
+
+    const propertyName = FormatHelpers.toPascalCase(
+      model.originalInput.discriminator
+    );
+    return `String get${propertyName}();`;
+  }
+};

--- a/test/generators/java/JavaConstrainer.spec.ts
+++ b/test/generators/java/JavaConstrainer.spec.ts
@@ -441,7 +441,7 @@ describe('JavaConstrainer', () => {
         constrainedModel: model,
         ...defaultOptions
       });
-      expect(type).toEqual('Object');
+      expect(type).toEqual('test');
     });
   });
 

--- a/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
+++ b/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
@@ -1,303 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`JavaGenerator CloudEvent handle allOf with const in CloudEvent type 1`] = `
-Array [
-  "",
-  "public class Dog {
-  @NotNull
-  @JsonProperty(\\"id\\")
-  private String id;
-  @NotNull
-  @JsonProperty(\\"source\\")
-  private String source;
-  @NotNull
-  @JsonProperty(\\"specversion\\")
-  private final String specversion = \\"1.0\\";
-  @NotNull
-  @JsonProperty(\\"type\\")
-  private final CloudEventType type = CloudEventType.DOG;
-  @JsonProperty(\\"dataschema\\")
-  private String dataschema;
-  @JsonProperty(\\"time\\")
-  private java.time.OffsetDateTime time;
-  private Map<String, Object> additionalProperties;
-
-  public String getId() { return this.id; }
-  public void setId(String id) { this.id = id; }
-
-  public String getSource() { return this.source; }
-  public void setSource(String source) { this.source = source; }
-
-  public String getSpecversion() { return this.specversion; }
-
-  public CloudEventType getType() { return this.type; }
-
-  public String getDataschema() { return this.dataschema; }
-  public void setDataschema(String dataschema) { this.dataschema = dataschema; }
-
-  public java.time.OffsetDateTime getTime() { return this.time; }
-  public void setTime(java.time.OffsetDateTime time) { this.time = time; }
-
-  public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
-  public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    Dog self = (Dog) o;
-      return 
-        Objects.equals(this.id, self.id) &&
-        Objects.equals(this.source, self.source) &&
-        Objects.equals(this.specversion, self.specversion) &&
-        Objects.equals(this.type, self.type) &&
-        Objects.equals(this.dataschema, self.dataschema) &&
-        Objects.equals(this.time, self.time) &&
-        Objects.equals(this.additionalProperties, self.additionalProperties);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash((Object)id, (Object)source, (Object)specversion, (Object)type, (Object)dataschema, (Object)time, (Object)additionalProperties);
-  }
-
-  @Override
-  public String toString() {
-    return \\"class Dog {\\\\n\\" +   
-      \\"    id: \\" + toIndentedString(id) + \\"\\\\n\\" +
-      \\"    source: \\" + toIndentedString(source) + \\"\\\\n\\" +
-      \\"    specversion: \\" + toIndentedString(specversion) + \\"\\\\n\\" +
-      \\"    type: \\" + toIndentedString(type) + \\"\\\\n\\" +
-      \\"    dataschema: \\" + toIndentedString(dataschema) + \\"\\\\n\\" +
-      \\"    time: \\" + toIndentedString(time) + \\"\\\\n\\" +
-      \\"    additionalProperties: \\" + toIndentedString(additionalProperties) + \\"\\\\n\\" +
-    \\"}\\";
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return \\"null\\";
-    }
-    return o.toString().replace(\\"\\\\n\\", \\"\\\\n    \\");
-  }
-}",
-  "public enum CloudEventType {
-  DOG((String)\\"Dog\\"), CAT((String)\\"Cat\\");
-
-  private String value;
-
-  CloudEventType(String value) {
-    this.value = value;
-  }
-
-  @JsonValue
-  public String getValue() {
-    return value;
-  }
-
-  @JsonCreator
-  public static CloudEventType fromValue(String value) {
-    for (CloudEventType e : CloudEventType.values()) {
-      if (e.value.equals(value)) {
-        return e;
-      }
-    }
-    throw new IllegalArgumentException(\\"Unexpected value '\\" + value + \\"'\\");
-  }
-
-  @Override
-  public String toString() {
-    return String.valueOf(value);
-  }
-}",
-  "public class Cat {
-  @NotNull
-  @JsonProperty(\\"id\\")
-  private String id;
-  @NotNull
-  @JsonProperty(\\"source\\")
-  private String source;
-  @NotNull
-  @JsonProperty(\\"specversion\\")
-  private final String specversion = \\"1.0\\";
-  @NotNull
-  @JsonProperty(\\"type\\")
-  private final CloudEventType type = CloudEventType.CAT;
-  @JsonProperty(\\"dataschema\\")
-  private String dataschema;
-  @JsonProperty(\\"time\\")
-  private java.time.OffsetDateTime time;
-  private Map<String, Object> additionalProperties;
-
-  public String getId() { return this.id; }
-  public void setId(String id) { this.id = id; }
-
-  public String getSource() { return this.source; }
-  public void setSource(String source) { this.source = source; }
-
-  public String getSpecversion() { return this.specversion; }
-
-  public CloudEventType getType() { return this.type; }
-
-  public String getDataschema() { return this.dataschema; }
-  public void setDataschema(String dataschema) { this.dataschema = dataschema; }
-
-  public java.time.OffsetDateTime getTime() { return this.time; }
-  public void setTime(java.time.OffsetDateTime time) { this.time = time; }
-
-  public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
-  public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    Cat self = (Cat) o;
-      return 
-        Objects.equals(this.id, self.id) &&
-        Objects.equals(this.source, self.source) &&
-        Objects.equals(this.specversion, self.specversion) &&
-        Objects.equals(this.type, self.type) &&
-        Objects.equals(this.dataschema, self.dataschema) &&
-        Objects.equals(this.time, self.time) &&
-        Objects.equals(this.additionalProperties, self.additionalProperties);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash((Object)id, (Object)source, (Object)specversion, (Object)type, (Object)dataschema, (Object)time, (Object)additionalProperties);
-  }
-
-  @Override
-  public String toString() {
-    return \\"class Cat {\\\\n\\" +   
-      \\"    id: \\" + toIndentedString(id) + \\"\\\\n\\" +
-      \\"    source: \\" + toIndentedString(source) + \\"\\\\n\\" +
-      \\"    specversion: \\" + toIndentedString(specversion) + \\"\\\\n\\" +
-      \\"    type: \\" + toIndentedString(type) + \\"\\\\n\\" +
-      \\"    dataschema: \\" + toIndentedString(dataschema) + \\"\\\\n\\" +
-      \\"    time: \\" + toIndentedString(time) + \\"\\\\n\\" +
-      \\"    additionalProperties: \\" + toIndentedString(additionalProperties) + \\"\\\\n\\" +
-    \\"}\\";
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return \\"null\\";
-    }
-    return o.toString().replace(\\"\\\\n\\", \\"\\\\n    \\");
-  }
-}",
-]
-`;
-
-exports[`JavaGenerator CloudEvent handle one const with discriminator 1`] = `
-Array [
-  "public class Dog {
-  @NotNull
-  @JsonProperty(\\"id\\")
-  private String id;
-  @NotNull
-  @JsonProperty(\\"type\\")
-  private final CloudEventType type = CloudEventType.DOG;
-  private Map<String, Object> additionalProperties;
-
-  public String getId() { return this.id; }
-  public void setId(String id) { this.id = id; }
-
-  public CloudEventType getType() { return this.type; }
-
-  public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
-  public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    Dog self = (Dog) o;
-      return 
-        Objects.equals(this.id, self.id) &&
-        Objects.equals(this.type, self.type) &&
-        Objects.equals(this.additionalProperties, self.additionalProperties);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash((Object)id, (Object)type, (Object)additionalProperties);
-  }
-
-  @Override
-  public String toString() {
-    return \\"class Dog {\\\\n\\" +   
-      \\"    id: \\" + toIndentedString(id) + \\"\\\\n\\" +
-      \\"    type: \\" + toIndentedString(type) + \\"\\\\n\\" +
-      \\"    additionalProperties: \\" + toIndentedString(additionalProperties) + \\"\\\\n\\" +
-    \\"}\\";
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return \\"null\\";
-    }
-    return o.toString().replace(\\"\\\\n\\", \\"\\\\n    \\");
-  }
-}",
-  "public enum CloudEventType {
-  DOG((String)\\"Dog\\");
-
-  private String value;
-
-  CloudEventType(String value) {
-    this.value = value;
-  }
-
-  @JsonValue
-  public String getValue() {
-    return value;
-  }
-
-  @JsonCreator
-  public static CloudEventType fromValue(String value) {
-    for (CloudEventType e : CloudEventType.values()) {
-      if (e.value.equals(value)) {
-        return e;
-      }
-    }
-    throw new IllegalArgumentException(\\"Unexpected value '\\" + value + \\"'\\");
-  }
-
-  @Override
-  public String toString() {
-    return String.valueOf(value);
-  }
-}",
-]
-`;
-
 exports[`JavaGenerator should not render reserved keyword 1`] = `
 "public class Address {
   private String reservedReservedEnum;
@@ -309,6 +11,67 @@ exports[`JavaGenerator should not render reserved keyword 1`] = `
   public String getReservedEnum() { return this.reservedEnum; }
   public void setReservedEnum(String reservedEnum) { this.reservedEnum = reservedEnum; }
 }"
+`;
+
+exports[`JavaGenerator should render \`class\` part of multiple \`union\` types 1`] = `
+Array [
+  "public class Root {
+  private UnionX unionX;
+  private UnionY unionY;
+  private Map<String, Object> additionalProperties;
+
+  public UnionX getUnionX() { return this.unionX; }
+  public void setUnionX(UnionX unionX) { this.unionX = unionX; }
+
+  public UnionY getUnionY() { return this.unionY; }
+  public void setUnionY(UnionY unionY) { this.unionY = unionY; }
+
+  public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
+  public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
+}",
+  "/**
+ * UnionX represents a union of types: Common, A
+ */
+public interface UnionX {
+  
+}",
+  "public class Common implements UnionX, UnionY {
+  private Object propCommon;
+  private Map<String, Object> additionalProperties;
+
+  public Object getPropCommon() { return this.propCommon; }
+  public void setPropCommon(Object propCommon) { this.propCommon = propCommon; }
+
+  public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
+  public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
+}",
+  "public class A implements UnionX {
+  private Double propA;
+  private Map<String, Object> additionalProperties;
+
+  public Double getPropA() { return this.propA; }
+  public void setPropA(Double propA) { this.propA = propA; }
+
+  public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
+  public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
+}",
+  "/**
+ * UnionY represents a union of types: Common, B
+ */
+public interface UnionY {
+  
+}",
+  "public class B implements UnionY {
+  private String propB;
+  private Map<String, Object> additionalProperties;
+
+  public String getPropB() { return this.propB; }
+  public void setPropB(String propB) { this.propB = propB; }
+
+  public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
+  public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
+}",
+]
 `;
 
 exports[`JavaGenerator should render \`class\` type 1`] = `
@@ -476,6 +239,76 @@ public enum CustomEnum {
     return String.valueOf(value);
   }
 }"
+`;
+
+exports[`JavaGenerator should render deduced \`union\` type 1`] = `
+Array [
+  "/**
+ * Union represents a union of types: A, B
+ */
+public interface Union {
+  
+}",
+  "public class A implements Union {
+  private Double propA;
+  private Map<String, Object> additionalProperties;
+
+  public Double getPropA() { return this.propA; }
+  public void setPropA(Double propA) { this.propA = propA; }
+
+  public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
+  public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
+}",
+  "public class B implements Union {
+  private String propB;
+  private Map<String, Object> additionalProperties;
+
+  public String getPropB() { return this.propB; }
+  public void setPropB(String propB) { this.propB = propB; }
+
+  public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
+  public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
+}",
+]
+`;
+
+exports[`JavaGenerator should render discriminated \`union\` type 1`] = `
+Array [
+  "/**
+ * Union represents a union of types: A, B
+ */
+public interface Union {
+  String getUnionCase();
+}",
+  "public class A implements Union {
+  private String unionCase = \\"A\\";
+  private Double propA;
+  private Map<String, Object> additionalProperties;
+
+  public String getUnionCase() { return this.unionCase; }
+  public void setUnionCase(String unionCase) { this.unionCase = unionCase; }
+
+  public Double getPropA() { return this.propA; }
+  public void setPropA(Double propA) { this.propA = propA; }
+
+  public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
+  public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
+}",
+  "public class B implements Union {
+  private String unionCase = \\"B\\";
+  private String propB;
+  private Map<String, Object> additionalProperties;
+
+  public String getUnionCase() { return this.unionCase; }
+  public void setUnionCase(String unionCase) { this.unionCase = unionCase; }
+
+  public String getPropB() { return this.propB; }
+  public void setPropB(String propB) { this.propB = propB; }
+
+  public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
+  public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
+}",
+]
 `;
 
 exports[`JavaGenerator should render enums with translated special characters 1`] = `

--- a/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
+++ b/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
@@ -33,7 +33,8 @@ Array [
  * UnionX represents a union of types: Common, A
  */
 public interface UnionX {
-  
+  Map<String, Object> getAdditionalProperties();
+  void setAdditionalProperties(Map<String, Object> additionalProperties);
 }",
   "public class Common implements UnionX, UnionY {
   private Object propCommon;
@@ -59,7 +60,8 @@ public interface UnionX {
  * UnionY represents a union of types: Common, B
  */
 public interface UnionY {
-  
+  Map<String, Object> getAdditionalProperties();
+  void setAdditionalProperties(Map<String, Object> additionalProperties);
 }",
   "public class B implements UnionY {
   private String propB;
@@ -247,7 +249,8 @@ Array [
  * Union represents a union of types: A, B
  */
 public interface Union {
-  
+  Map<String, Object> getAdditionalProperties();
+  void setAdditionalProperties(Map<String, Object> additionalProperties);
 }",
   "public class A implements Union {
   private Double propA;
@@ -279,6 +282,9 @@ Array [
  */
 public interface Union {
   String getUnionCase();
+  void setUnionCase(String unionCase);
+  Map<String, Object> getAdditionalProperties();
+  void setAdditionalProperties(Map<String, Object> additionalProperties);
 }",
   "public class A implements Union {
   private String unionCase = \\"A\\";

--- a/test/generators/java/presets/JacksonPreset.spec.ts
+++ b/test/generators/java/presets/JacksonPreset.spec.ts
@@ -42,4 +42,69 @@ describe('JAVA_JACKSON_PRESET', () => {
     expect(models[0].result).toMatchSnapshot();
     expect(models[0].dependencies).toEqual(expectedDependencies);
   });
+
+  test('should render Jackson annotations for discriminated union', async () => {
+    const doc = {
+      $id: 'Union',
+      type: 'object',
+      discriminator: 'union_case',
+      oneOf: [
+        {
+          type: 'object',
+          $id: 'A',
+          properties: {
+            union_case: { type: 'string' },
+            prop_a: { type: 'number' }
+          }
+        },
+        {
+          type: 'object',
+          $id: 'B',
+          properties: {
+            union_case: { type: 'string' },
+            prop_b: { type: 'string' }
+          }
+        }
+      ]
+    };
+    const expectedDependency = 'import com.fasterxml.jackson.annotation.*;';
+    const models = await generator.generate(doc);
+    expect(models).toHaveLength(3);
+    expect(models[0].result).toContain('JsonTypeInfo.Id.NAME');
+    expect(models.map((m) => m.result)).toMatchSnapshot();
+    expect(models[0].dependencies).toContain(expectedDependency);
+    expect(models[1].dependencies).toContain(expectedDependency);
+    expect(models[2].dependencies).toContain(expectedDependency);
+  });
+
+  test('should render Jackson annotations for deduced union', async () => {
+    const doc = {
+      $id: 'Union',
+      type: 'object',
+      oneOf: [
+        {
+          type: 'object',
+          $id: 'A',
+          properties: {
+            prop_a: { type: 'number' }
+          }
+        },
+        {
+          type: 'object',
+          $id: 'B',
+          properties: {
+            prop_b: { type: 'string' }
+          }
+        }
+      ]
+    };
+    const expectedDependency = 'import com.fasterxml.jackson.annotation.*;';
+    const models = await generator.generate(doc);
+    expect(models).toHaveLength(3);
+    expect(models[0].result).toContain('JsonTypeInfo.Id.DEDUCTION');
+    expect(models.map((m) => m.result)).toMatchSnapshot();
+    expect(models[0].dependencies).toContain(expectedDependency);
+    expect(models[1].dependencies).toContain(expectedDependency);
+    expect(models[2].dependencies).toContain(expectedDependency);
+  });
 });

--- a/test/generators/java/presets/__snapshots__/JacksonPreset.spec.ts.snap
+++ b/test/generators/java/presets/__snapshots__/JacksonPreset.spec.ts.snap
@@ -19,6 +19,92 @@ exports[`JAVA_JACKSON_PRESET should render Jackson annotations for class 1`] = `
 }"
 `;
 
+exports[`JAVA_JACKSON_PRESET should render Jackson annotations for deduced union 1`] = `
+Array [
+  "@JsonTypeInfo(use=JsonTypeInfo.Id.DEDUCTION)
+@JsonSubTypes({
+  @JsonSubTypes.Type(value = A.class, name = \\"A\\"),
+  @JsonSubTypes.Type(value = B.class, name = \\"B\\")
+})
+/**
+ * Union represents a union of types: A, B
+ */
+public interface Union {
+  
+}",
+  "public class A implements Union {
+  @JsonProperty(\\"prop_a\\")
+  private Double propA;
+  private Map<String, Object> additionalProperties;
+
+  public Double getPropA() { return this.propA; }
+  public void setPropA(Double propA) { this.propA = propA; }
+
+  public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
+  public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
+}",
+  "public class B implements Union {
+  @JsonProperty(\\"prop_b\\")
+  private String propB;
+  private Map<String, Object> additionalProperties;
+
+  public String getPropB() { return this.propB; }
+  public void setPropB(String propB) { this.propB = propB; }
+
+  public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
+  public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
+}",
+]
+`;
+
+exports[`JAVA_JACKSON_PRESET should render Jackson annotations for discriminated union 1`] = `
+Array [
+  "@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.PROPERTY, property=\\"union_case\\")
+@JsonSubTypes({
+  @JsonSubTypes.Type(value = A.class, name = \\"A\\"),
+  @JsonSubTypes.Type(value = B.class, name = \\"B\\")
+})
+/**
+ * Union represents a union of types: A, B
+ */
+public interface Union {
+  String getUnionCase();
+}",
+  "public class A implements Union {
+  @JsonProperty(\\"union_case\\")
+  private String unionCase = \\"A\\";
+  @JsonProperty(\\"prop_a\\")
+  private Double propA;
+  private Map<String, Object> additionalProperties;
+
+  public String getUnionCase() { return this.unionCase; }
+  public void setUnionCase(String unionCase) { this.unionCase = unionCase; }
+
+  public Double getPropA() { return this.propA; }
+  public void setPropA(Double propA) { this.propA = propA; }
+
+  public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
+  public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
+}",
+  "public class B implements Union {
+  @JsonProperty(\\"union_case\\")
+  private String unionCase = \\"B\\";
+  @JsonProperty(\\"prop_b\\")
+  private String propB;
+  private Map<String, Object> additionalProperties;
+
+  public String getUnionCase() { return this.unionCase; }
+  public void setUnionCase(String unionCase) { this.unionCase = unionCase; }
+
+  public String getPropB() { return this.propB; }
+  public void setPropB(String propB) { this.propB = propB; }
+
+  public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
+  public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
+}",
+]
+`;
+
 exports[`JAVA_JACKSON_PRESET should render Jackson annotations for enum 1`] = `
 "public enum ReservedEnum {
   ON((String)\\"on\\"), OFF((String)\\"off\\");


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->
This is a first end to end draft.  The first priority is to agree a way forward for representing `allOf` in Java. Any feedback on the direction of the implementation, coding style and generated code would be appreciated.

**Description**

- Generate a Java interface for unions
  - Common property accessors are defined as part of the interface
- All classes that are part of unions implement the union interface
- Add union support to the Jackson annotation preset
  - Support using a `discriminator` property or deducing union members via property names

**Example output - java-generate-union-discriminator-jackson**

Schema:
```json
{
   "$schema":"http://json-schema.org/draft-07/schema#",
   "title":"Vehicle",
   "type":"object",
   "discriminator":"vehicleType",
   "oneOf":[
      {
         "$ref":"#/definitions/Car"
      },
      {
         "$ref":"#/definitions/Truck"
      }
   ],
   "definitions":{
      "Car":{
         "title":"Car",
         "type":"object",
         "properties":{
            "vehicleType":{
               "type":"string"
            },
            "name":{
               "type":"string"
            }
         }
      },
      "Truck":{
         "title":"Truck",
         "type":"object",
         "properties":{
            "vehicleType":{
               "type":"string"
            },
            "name":{
               "type":"string"
            }
         }
      }
   }
}
```

Java output:
```java
@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.PROPERTY, property="vehicleType")
@JsonSubTypes({
  @JsonSubTypes.Type(value = Car.class, name = "Car"),
  @JsonSubTypes.Type(value = Truck.class, name = "Truck")
})
/**
 * Vehicle represents a union of types: Car, Truck
 */
public interface Vehicle {
  String getVehicleType();
  void setVehicleType(String vehicleType);
  String getName();
  void setName(String name);
  Map<String, Object> getAdditionalProperties();
  void setAdditionalProperties(Map<String, Object> additionalProperties);
}

public class Car implements Vehicle {
  @JsonProperty("vehicleType")
  private String vehicleType = "Car";
  @JsonProperty("name")
  private String name;
  private Map<String, Object> additionalProperties;

  public String getVehicleType() { return this.vehicleType; }
  public void setVehicleType(String vehicleType) { this.vehicleType = vehicleType; }

  public String getName() { return this.name; }
  public void setName(String name) { this.name = name; }

  public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
  public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
}

public class Truck implements Vehicle {
  @JsonProperty("vehicleType")
  private String vehicleType = "Truck";
  @JsonProperty("name")
  private String name;
  private Map<String, Object> additionalProperties;

  public String getVehicleType() { return this.vehicleType; }
  public void setVehicleType(String vehicleType) { this.vehicleType = vehicleType; }

  public String getName() { return this.name; }
  public void setName(String name) { this.name = name; }

  public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
  public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
}
```

**Todo**

- --Add common property assessors methods to the interface--
- Work through the various options around the discriminator property semantics (constant, read only, set by default, etc...) and make sure the right flexibility/safety trade offs are being weighted up
- Work out what do to when unions include primitive/built-in types (int, bool, float, String, etc...)
- Documentation
- Fix up the failing tests (currently due to primitive type handling)
- Support `OpenAPI` style discriminator property syntax

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->
#391 