### PR TITLE
refactor: adds discriminator in CommonModel and interpreters

### DIFF
--- a/src/interpreter/InterpretAllOf.ts
+++ b/src/interpreter/InterpretAllOf.ts
@@ -38,6 +38,8 @@ export default function interpretAllOf(
         ...interpreterOptions,
         discriminator: allOfSchema.discriminator
       };
+
+      model.discriminator = allOfSchema.discriminator;
     }
   }
 

--- a/src/interpreter/InterpretOneOf.ts
+++ b/src/interpreter/InterpretOneOf.ts
@@ -1,4 +1,4 @@
-import { CommonModel } from '../models/CommonModel';
+import { AsyncapiV2Schema, CommonModel } from '../models';
 import {
   Interpreter,
   InterpreterOptions,
@@ -29,11 +29,26 @@ export default function interpretOneOf(
   ) {
     return;
   }
+
+  if (schema instanceof AsyncapiV2Schema && schema.discriminator) {
+    interpreterOptions = {
+      ...interpreterOptions,
+      discriminator: schema.discriminator
+    };
+
+    model.discriminator = schema.discriminator;
+  }
+
   for (const oneOfSchema of schema.oneOf) {
     const oneOfModel = interpreter.interpret(oneOfSchema, interpreterOptions);
     if (oneOfModel === undefined) {
       continue;
     }
+
+    if (oneOfModel.discriminator) {
+      model.discriminator = oneOfModel.discriminator;
+    }
+
     model.addItemUnion(oneOfModel);
   }
 }

--- a/src/interpreter/InterpretOneOfWithAllOf.ts
+++ b/src/interpreter/InterpretOneOfWithAllOf.ts
@@ -37,6 +37,8 @@ export default function interpretOneOfWithAllOf(
         ...interpreterOptions,
         discriminator: allOfSchema.discriminator
       };
+
+      model.discriminator = allOfSchema.discriminator;
     }
   }
 

--- a/src/interpreter/InterpretOneOfWithProperties.ts
+++ b/src/interpreter/InterpretOneOfWithProperties.ts
@@ -35,6 +35,8 @@ export default function interpretOneOfWithProperties(
       ...interpreterOptions,
       discriminator: schema.discriminator
     };
+
+    model.discriminator = schema.discriminator;
   }
 
   for (const oneOfSchema of schema.oneOf) {

--- a/src/interpreter/InterpretProperties.ts
+++ b/src/interpreter/InterpretProperties.ts
@@ -31,12 +31,18 @@ export default function interpretProperties(
   for (const [propertyName, propertySchema] of Object.entries(
     schema.properties
   )) {
+    const discriminator =
+      propertyName === interpreterOptions.discriminator
+        ? interpreterOptions.discriminator
+        : undefined;
+
+    if (discriminator) {
+      model.discriminator = discriminator;
+    }
+
     const propertyModel = interpreter.interpret(propertySchema, {
       ...interpreterOptions,
-      discriminator:
-        propertyName === interpreterOptions.discriminator
-          ? interpreterOptions.discriminator
-          : undefined
+      discriminator
     });
     if (propertyModel !== undefined) {
       model.addProperty(propertyName, propertyModel, schema);

--- a/src/models/CommonModel.ts
+++ b/src/models/CommonModel.ts
@@ -21,6 +21,7 @@ export class CommonModel {
   type?: string | string[];
   enum?: any[];
   const?: unknown;
+  discriminator?: string;
   items?: CommonModel | CommonModel[];
   properties?: { [key: string]: CommonModel };
   additionalProperties?: CommonModel;

--- a/test/interpreter/unit/InterpretAllOf.spec.ts
+++ b/test/interpreter/unit/InterpretAllOf.spec.ts
@@ -3,6 +3,7 @@ import { CommonModel } from '../../../src/models/CommonModel';
 import { Interpreter } from '../../../src/interpreter/Interpreter';
 import { isModelObject } from '../../../src/interpreter/Utils';
 import interpretAllOf from '../../../src/interpreter/InterpretAllOf';
+import { AsyncapiV2Schema } from '../../../src/models';
 const interpreterOptionsAllowInheritance = { allowInheritance: true };
 jest.mock('../../../src/interpreter/Interpreter');
 jest.mock('../../../src/models/CommonModel');
@@ -109,5 +110,27 @@ describe('Interpretation of allOf', () => {
     expect(interpreter.interpretAndCombineSchema).not.toHaveBeenCalled();
     expect(isModelObject).toHaveBeenCalled();
     expect(model.addExtendedModel).toHaveBeenCalledWith(interpretedModel);
+  });
+
+  test('should set discriminator', () => {
+    const item1 = AsyncapiV2Schema.toSchema({
+      type: 'object',
+      $id: 'test',
+      discriminator: 'test'
+    });
+    const schema = AsyncapiV2Schema.toSchema({ allOf: [item1] });
+    const model = new CommonModel();
+    const interpreter = new Interpreter();
+    (interpreter.interpret as jest.Mock).mockReturnValue(new CommonModel());
+
+    interpretAllOf(schema, model, interpreter, {});
+
+    expect(model.discriminator).toBe(item1.discriminator);
+    expect(interpreter.interpretAndCombineSchema).toHaveBeenCalledWith(
+      item1,
+      model,
+      schema,
+      { discriminator: item1.discriminator }
+    );
   });
 });

--- a/test/interpreter/unit/InterpretOneOf.spec.ts
+++ b/test/interpreter/unit/InterpretOneOf.spec.ts
@@ -3,6 +3,7 @@ import { CommonModel } from '../../../src/models/CommonModel';
 import { Interpreter } from '../../../src/interpreter/Interpreter';
 import { isModelObject } from '../../../src/interpreter/Utils';
 import InterpretOneOf from '../../../src/interpreter/InterpretOneOf';
+import { AsyncapiV2Schema } from '../../../src/models';
 jest.mock('../../../src/interpreter/Interpreter');
 jest.mock('../../../src/models/CommonModel');
 jest.mock('../../../src/interpreter/Utils');
@@ -47,5 +48,48 @@ describe('Interpretation of oneOf', () => {
     });
     expect(model.addItemUnion).toHaveBeenCalledTimes(2);
     expect(JSON.stringify(model)).toEqual(JSON.stringify(new CommonModel()));
+  });
+
+  describe('discriminator', () => {
+    test('should set discriminator when discriminator is set in schema', () => {
+      const item1 = AsyncapiV2Schema.toSchema({
+        type: 'object',
+        $id: 'test'
+      });
+      const schema = AsyncapiV2Schema.toSchema({
+        discriminator: 'test',
+        oneOf: [item1]
+      });
+      const model = new CommonModel();
+      const interpreter = new Interpreter();
+
+      InterpretOneOf(schema, model, interpreter, {});
+
+      expect(model.discriminator).toBe(schema.discriminator);
+      expect(interpreter.interpret).toHaveBeenCalledWith(item1, {
+        discriminator: schema.discriminator
+      });
+    });
+
+    test('should set discriminator when discriminator is set in one of the oneOf models', () => {
+      const item1 = AsyncapiV2Schema.toSchema({
+        discriminator: 'test',
+        type: 'object',
+        $id: 'test'
+      });
+      const schema = AsyncapiV2Schema.toSchema({
+        oneOf: [item1]
+      });
+      const model = new CommonModel();
+      const interpreter = new Interpreter();
+      const interpretedModel = new CommonModel();
+      interpretedModel.discriminator = item1.discriminator;
+      (interpreter.interpret as jest.Mock).mockReturnValue(interpretedModel);
+
+      InterpretOneOf(schema, model, interpreter, {});
+
+      expect(model.discriminator).toBe(item1.discriminator);
+      expect(interpreter.interpret).toHaveBeenCalledWith(item1, {});
+    });
   });
 });

--- a/test/interpreter/unit/InterpretOneOfWithAllOf.spec.ts
+++ b/test/interpreter/unit/InterpretOneOfWithAllOf.spec.ts
@@ -85,6 +85,7 @@ describe('Interpretation of oneOf with allOf', () => {
 
     expect(model.type).toBeUndefined();
     expect(model.union).toHaveLength(2);
+    expect(model.discriminator).toBe('animalType');
 
     const cat = model.union?.find((item) => item.$id === 'Cat');
     expect(cat).not.toBeUndefined();

--- a/test/interpreter/unit/InterpretProperties.spec.ts
+++ b/test/interpreter/unit/InterpretProperties.spec.ts
@@ -2,6 +2,7 @@
 import { CommonModel } from '../../../src/models/CommonModel';
 import { Interpreter } from '../../../src/interpreter/Interpreter';
 import interpretProperties from '../../../src/interpreter/InterpretProperties';
+import { AsyncapiV2Schema } from '../../../src';
 jest.mock('../../../src/interpreter/Interpreter');
 jest.mock('../../../src/models/CommonModel');
 CommonModel.mergeCommonModels = jest.fn();
@@ -69,5 +70,28 @@ describe('Interpretation of properties', () => {
       mockedReturnModel,
       schema
     );
+  });
+
+  test('should set discriminator when discriminator is set in interpreterOptions', () => {
+    const property = AsyncapiV2Schema.toSchema({
+      type: 'string'
+    });
+    const schema = AsyncapiV2Schema.toSchema({
+      type: 'object',
+      properties: {
+        discriminatorProperty: property
+      }
+    });
+    const model = new CommonModel();
+    const interpreter = new Interpreter();
+
+    interpretProperties(schema, model, interpreter, {
+      discriminator: 'discriminatorProperty'
+    });
+
+    expect(model.discriminator).toBe('discriminatorProperty');
+    expect(interpreter.interpret).toHaveBeenCalledWith(property, {
+      discriminator: 'discriminatorProperty'
+    });
   });
 });

--- a/test/interpreter/unit/interpretOneOfWithProperties.spec.ts
+++ b/test/interpreter/unit/interpretOneOfWithProperties.spec.ts
@@ -81,6 +81,7 @@ describe('Interpretation of oneOf with properties', () => {
 
     expect(model.type).toBeUndefined();
     expect(model.union).toHaveLength(2);
+    expect(model.discriminator).toBe('animalType');
 
     const cat = model.union?.find((item) => item.$id === 'Cat');
     expect(cat).not.toBeUndefined();


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

This is a preparation PR to support union for objects in Java (https://github.com/asyncapi/modelina/pull/1264). It adds `discriminator` in the CommonModel, and the interpreters set that value when they should.

**Description**

- adds `discriminator` in the CommonModel
- sets `discriminator` in the interpreters

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->