### PR TITLE
chore: remove LouisXhaferi from codeowners

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -470,11 +470,7 @@
       "avatar_url": "https://avatars.githubusercontent.com/u/52397677?v=4",
       "profile": "https://github.com/LouisXhaferi",
       "contributions": [
-        "code",
-        "test",
-        "doc",
-        "example",
-        "maintenance"
+        "code"
       ]
     },
     {

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -47,4 +47,3 @@
 */generators/rust @leigh-johnson
 
 # Language Champions for Kotlin and it's presets
-*/generators/kotlin @LouisXhaferi


### PR DESCRIPTION
**Description**
As I've practically not put any all that much time into modelina, since I first joined as a contributor, and won't be able to do so in the future, I'd step down as contributor/codeowner etc. 

I'll probably do the same for the TSC, as my focus shifted away from cloud and messaging related stuff.