### PR TITLE
fix!: update default Kotlin renderer to make non-required properties nullable

### DIFF
--- a/docs/migrations/version-1-to-2.md
+++ b/docs/migrations/version-1-to-2.md
@@ -135,3 +135,29 @@ schemas:
 ```
 
 This example will generate a model for `Cat` and `Dog` where `PetType` is a shared enum that contains two values (`Cat` and `Dog`). `PetType` will not have a setter, and will automatically be initialized.
+
+## Optional properties in Kotlin
+
+In Kotlin, if property is not `required` in JSON Schema, it will be nullable in Kotlin with default value `null`.
+
+```yaml
+Response:
+  type: object
+  properties:
+    result:
+      type: string
+    message:
+      type: string
+  required:
+    - result
+  additionalProperties: false
+```
+
+will generate
+
+```kotlin
+data class Response(
+    val result: String,
+    val message: String? = null
+)
+```

--- a/examples/generate-kotlin-models/__snapshots__/index.spec.ts.snap
+++ b/examples/generate-kotlin-models/__snapshots__/index.spec.ts.snap
@@ -3,9 +3,9 @@
 exports[`Should be able to render Kotlin Models and should log expected output to console 1`] = `
 Array [
   "data class Root(
-    val email: String,
-    val cache: Int,
-    val website: Website,
+    val email: String? = null,
+    val cache: Int? = null,
+    val website: Website? = null,
 )",
 ]
 `;

--- a/examples/kotlin-change-collection-type/__snapshots__/index.spec.ts.snap
+++ b/examples/kotlin-change-collection-type/__snapshots__/index.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`Should be able to render collections in Kotlin as Array and should log expected output to console 1`] = `
 Array [
   "data class Root(
-    val email: Array<String>,
+    val email: Array<String>? = null,
 )",
 ]
 `;

--- a/examples/kotlin-generate-javax-constraint-annotation/__snapshots__/index.spec.ts.snap
+++ b/examples/kotlin-generate-javax-constraint-annotation/__snapshots__/index.spec.ts.snap
@@ -10,13 +10,13 @@ Array [
     @get:Max(99)
     val maxNumberProp: Double,
     @get:Min(101)
-    val minNumberPropExclusive: Double,
+    val minNumberPropExclusive: Double? = null,
     @get:Size(min=2, max=3)
-    val arrayProp: List<Any>,
+    val arrayProp: List<Any>? = null,
     @get:Pattern(regexp=\\"^I_\\")
     @get:Size(min=3)
-    val stringProp: String,
-    val additionalProperties: Map<String, Any>,
+    val stringProp: String? = null,
+    val additionalProperties: Map<String, Any>? = null,
 )",
 ]
 `;

--- a/examples/kotlin-generate-kdoc/__snapshots__/index.spec.ts.snap
+++ b/examples/kotlin-generate-kdoc/__snapshots__/index.spec.ts.snap
@@ -14,10 +14,10 @@ Array [
  * {\\"prop\\":\\"value\\"}, {\\"prop\\":\\"test\\"}
  */
 data class KDoc(
-    val prop: String,
-    val enum: Enum,
-    val nodesc: String,
-    val additionalProperties: Map<String, Any>,
+    val prop: String? = null,
+    val enum: Enum? = null,
+    val nodesc: String? = null,
+    val additionalProperties: Map<String, Any>? = null,
 )",
 ]
 `;

--- a/src/generators/kotlin/renderers/ClassRenderer.ts
+++ b/src/generators/kotlin/renderers/ClassRenderer.ts
@@ -53,6 +53,6 @@ export const KOTLIN_DEFAULT_CLASS_PRESET: ClassPresetType<KotlinOptions> = {
     return renderer.defaultSelf(hasProperties);
   },
   property({ property }) {
-    return `val ${property.propertyName}: ${property.property.type},`;
+    return `val ${property.propertyName}: ${property.property.type}${property.required ? '' : '? = null'},`;
   }
 };

--- a/src/generators/kotlin/renderers/ClassRenderer.ts
+++ b/src/generators/kotlin/renderers/ClassRenderer.ts
@@ -53,6 +53,8 @@ export const KOTLIN_DEFAULT_CLASS_PRESET: ClassPresetType<KotlinOptions> = {
     return renderer.defaultSelf(hasProperties);
   },
   property({ property }) {
-    return `val ${property.propertyName}: ${property.property.type}${property.required ? '' : '? = null'},`;
+    return `val ${property.propertyName}: ${property.property.type}${
+      property.required ? '' : '? = null'
+    },`;
   }
 };

--- a/test/generators/kotlin/__snapshots__/KotlinGenerator.spec.ts.snap
+++ b/test/generators/kotlin/__snapshots__/KotlinGenerator.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`KotlinGenerator should not render reserved keyword 1`] = `
 "data class Address(
-    val reservedClass: String,
+    val reservedClass: String? = null,
 )"
 `;
 
@@ -12,14 +12,14 @@ exports[`KotlinGenerator should render \`data class\` type 1`] = `
     val city: String,
     val state: String,
     val houseNumber: Double,
-    val marriage: Boolean,
-    val members: Any,
+    val marriage: Boolean? = null,
+    val members: Any? = null,
     val arrayType: List<Any>,
-    val date: java.time.LocalDate,
-    val time: java.time.OffsetTime,
-    val dateTime: java.time.OffsetDateTime,
-    val binary: ByteArray,
-    val additionalProperties: Map<String, Any>,
+    val date: java.time.LocalDate? = null,
+    val time: java.time.OffsetTime? = null,
+    val dateTime: java.time.OffsetDateTime? = null,
+    val binary: ByteArray? = null,
+    val additionalProperties: Map<String, Any>? = null,
 )"
 `;
 
@@ -55,7 +55,7 @@ exports[`KotlinGenerator should render \`enum\` type (union type) 1`] = `
 
 exports[`KotlinGenerator should render List type for collections 1`] = `
 "data class CustomClass(
-    val arrayType: List<Int>,
+    val arrayType: List<Int>? = null,
 )"
 `;
 
@@ -78,11 +78,11 @@ data class Address(
     val city: String,
     val state: String,
     val houseNumber: Double,
-    val marriage: Boolean,
-    val members: Any,
+    val marriage: Boolean? = null,
+    val members: Any? = null,
     val arrayType: List<Any>,
-    val otherModel: OtherModel,
-    val additionalProperties: Map<String, Any>,
+    val otherModel: OtherModel? = null,
+    val additionalProperties: Map<String, Any>? = null,
 )"
 `;
 
@@ -91,7 +91,7 @@ exports[`KotlinGenerator should render models and their dependencies 2`] = `
 
 
 data class OtherModel(
-    val streetName: String,
-    val additionalProperties: Map<String, Any>,
+    val streetName: String? = null,
+    val additionalProperties: Map<String, Any>? = null,
 )"
 `;

--- a/test/generators/kotlin/presets/__snapshots__/ConstraintsPreset.spec.ts.snap
+++ b/test/generators/kotlin/presets/__snapshots__/ConstraintsPreset.spec.ts.snap
@@ -9,10 +9,10 @@ exports[`KOTLIN_CONSTRAINTS_PRESET should render constraints annotations 1`] = `
     @get:Max(99)
     val maxNumberProp: Double,
     @get:Size(min=2, max=3)
-    val arrayProp: List<Any>,
+    val arrayProp: List<Any>? = null,
     @get:Pattern(regexp=\\"^I_\\")
     @get:Size(min=3)
-    val stringProp: String,
-    val additionalProperties: Map<String, Any>,
+    val stringProp: String? = null,
+    val additionalProperties: Map<String, Any>? = null,
 )"
 `;

--- a/test/generators/kotlin/presets/__snapshots__/DescriptionPreset.spec.ts.snap
+++ b/test/generators/kotlin/presets/__snapshots__/DescriptionPreset.spec.ts.snap
@@ -11,8 +11,8 @@ exports[`KOTLIN_DESCRIPTION_PRESET should render description and examples for cl
  * {\\"prop\\":\\"value\\"}
  */
 data class Clazz(
-    val prop: String,
-    val additionalProperties: Map<String, Any>,
+    val prop: String? = null,
+    val additionalProperties: Map<String, Any>? = null,
 )"
 `;
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Update default Kotlin renderer to make non-required properties nullable and `null` by default.
- Updated snapshots

**Related issue(s)**
Fixes #1273
Retarget of #1274 