### PR TITLE
feat!: use EXISTING_PROPERTY as JsonTypeInfo.As annotation to avoid duplicates when serializing

### DIFF
--- a/docs/migrations/version-1-to-2.md
+++ b/docs/migrations/version-1-to-2.md
@@ -199,7 +199,7 @@ components:
 will generate
 
 ```java
-@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.PROPERTY, property="vehicleType")
+@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.EXISTING_PROPERTY, property="vehicleType")
 @JsonSubTypes({
   @JsonSubTypes.Type(value = Car.class, name = "Car"),
   @JsonSubTypes.Type(value = Truck.class, name = "Truck")

--- a/src/generators/java/presets/JacksonPreset.ts
+++ b/src/generators/java/presets/JacksonPreset.ts
@@ -62,7 +62,7 @@ ${content}`;
         blocks.push(
           renderer.renderAnnotation('JsonTypeInfo', {
             use: 'JsonTypeInfo.Id.NAME',
-            include: 'JsonTypeInfo.As.PROPERTY',
+            include: 'JsonTypeInfo.As.EXISTING_PROPERTY',
             property: `"${discriminator.discriminator}"`
           })
         );

--- a/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
+++ b/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
@@ -58,7 +58,7 @@ public interface Vehicle {
 
 exports[`JavaGenerator oneOf/discriminator with jackson preset handle allOf with const in CloudEvent type 1`] = `
 Array [
-  "@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.PROPERTY, property=\\"type\\")
+  "@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.EXISTING_PROPERTY, property=\\"type\\")
 @JsonSubTypes({
   @JsonSubTypes.Type(value = Dog.class, name = \\"Dog\\"),
   @JsonSubTypes.Type(value = Cat.class, name = \\"Cat\\")
@@ -366,7 +366,7 @@ Array [
 
 exports[`JavaGenerator oneOf/discriminator with jackson preset handle setting title with const 1`] = `
 Array [
-  "@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.PROPERTY, property=\\"type\\")
+  "@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.EXISTING_PROPERTY, property=\\"type\\")
 @JsonSubTypes({
   @JsonSubTypes.Type(value = Dog.class, name = \\"Dog\\"),
   @JsonSubTypes.Type(value = Cat.class, name = \\"Cat\\")

--- a/test/generators/java/presets/__snapshots__/JacksonPreset.spec.ts.snap
+++ b/test/generators/java/presets/__snapshots__/JacksonPreset.spec.ts.snap
@@ -53,7 +53,7 @@ exports[`JAVA_JACKSON_PRESET should render Jackson annotations for enum 1`] = `
 
 exports[`JAVA_JACKSON_PRESET union handle oneOf with AsyncAPI discriminator with Jackson 1`] = `
 Array [
-  "@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.PROPERTY, property=\\"vehicleType\\")
+  "@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.EXISTING_PROPERTY, property=\\"vehicleType\\")
 @JsonSubTypes({
   @JsonSubTypes.Type(value = Car.class, name = \\"Car\\"),
   @JsonSubTypes.Type(value = Truck.class, name = \\"Truck\\")
@@ -101,7 +101,7 @@ public interface Vehicle {
 
 exports[`JAVA_JACKSON_PRESET union handle oneOf with OpenAPI v3 discriminator with Jackson 1`] = `
 Array [
-  "@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.PROPERTY, property=\\"vehicleType\\")
+  "@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.EXISTING_PROPERTY, property=\\"vehicleType\\")
 @JsonSubTypes({
   @JsonSubTypes.Type(value = Car.class, name = \\"Car\\"),
   @JsonSubTypes.Type(value = Truck.class, name = \\"Truck\\")
@@ -139,7 +139,7 @@ public interface Vehicle {
 
 exports[`JAVA_JACKSON_PRESET union handle oneOf with Swagger v2 discriminator with Jackson 1`] = `
 Array [
-  "@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.PROPERTY, property=\\"vehicleType\\")
+  "@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.EXISTING_PROPERTY, property=\\"vehicleType\\")
 @JsonSubTypes({
   @JsonSubTypes.Type(value = Car.class, name = \\"Car\\"),
   @JsonSubTypes.Type(value = Truck.class, name = \\"Truck\\")


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Use EXISTING_PROPERTY as JsonTypeInfo.As annotation to avoid duplicates when serializing (ref https://fasterxml.github.io/jackson-annotations/javadoc/2.4/com/fasterxml/jackson/annotation/JsonTypeInfo.As.html)

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->