### PR TITLE
feat!: add java oneOf union support for properties of models 

### DIFF
--- a/src/generators/java/JavaConstrainer.ts
+++ b/src/generators/java/JavaConstrainer.ts
@@ -79,7 +79,8 @@ export const JavaDefaultTypeMapping: JavaTypeMapping = {
     return constrainedModel.name;
   },
   Reference({ constrainedModel }): string {
-    return constrainedModel.name;
+    //propagate the type mapping of the referenced model
+    return constrainedModel.ref.type;
   },
   Any(): string {
     return 'Object';
@@ -170,9 +171,35 @@ export const JavaDefaultTypeMapping: JavaTypeMapping = {
 
     return uniqueTypes[0];
   },
-  Union(): string {
-    //Because Java have no notion of unions (and no custom implementation), we have to render it as any value.
-    return 'Object';
+  Union({ constrainedModel }): string {
+    //We don't have a good solution for unions including primitive types and
+    //collection types, so they are represented by the 'Object' type
+    if (
+      constrainedModel.union.find(
+        (u) =>
+          //Primitive types and boxed versions
+          u.type.toLowerCase() === 'byte' ||
+          u.type.toLowerCase() === 'short' ||
+          u.type === 'int' ||
+          u.type === 'Integer' ||
+          u.type.toLowerCase() === 'long' ||
+          u.type.toLowerCase() === 'float' ||
+          u.type.toLowerCase() === 'double' ||
+          u.type === 'char' ||
+          u.type === 'Character' ||
+          u.type.toLowerCase() === 'boolean' ||
+          u.type.toLowerCase() === 'int' ||
+          //Collections
+          u.type.startsWith('Map<') ||
+          u.type.startsWith('List<') ||
+          u.type.startsWith('Set<') ||
+          u.type === 'String' ||
+          u.type.endsWith('[]')
+      )
+    ) {
+      return 'Object';
+    }
+    return constrainedModel.type;
   },
   Dictionary({ constrainedModel }): string {
     //Limitations to Java is that maps cannot have specific value types...

--- a/src/generators/java/JavaConstrainer.ts
+++ b/src/generators/java/JavaConstrainer.ts
@@ -1,5 +1,5 @@
 import { Constraints } from '../../helpers';
-import { ConstrainedEnumValueModel } from '../../models';
+import { ConstrainedEnumModel, ConstrainedEnumValueModel } from '../../models';
 import {
   defaultEnumKeyConstraints,
   defaultEnumValueConstraints
@@ -80,7 +80,12 @@ export const JavaDefaultTypeMapping: JavaTypeMapping = {
   },
   Reference({ constrainedModel }): string {
     //propagate the type mapping of the referenced model
-    return constrainedModel.ref.type;
+    if (constrainedModel.ref instanceof ConstrainedEnumModel) {
+      //use the enum name rather than the underlying type of the Enum
+      return constrainedModel.ref.name;
+    } else {
+      return constrainedModel.ref.type;
+    }
   },
   Any(): string {
     return 'Object';
@@ -199,7 +204,7 @@ export const JavaDefaultTypeMapping: JavaTypeMapping = {
     ) {
       return 'Object';
     }
-    return constrainedModel.type;
+    return constrainedModel.name;
   },
   Dictionary({ constrainedModel }): string {
     //Limitations to Java is that maps cannot have specific value types...

--- a/src/generators/java/JavaConstrainer.ts
+++ b/src/generators/java/JavaConstrainer.ts
@@ -79,13 +79,11 @@ export const JavaDefaultTypeMapping: JavaTypeMapping = {
     return constrainedModel.name;
   },
   Reference({ constrainedModel }): string {
-    //propagate the type mapping of the referenced model
     if (constrainedModel.ref instanceof ConstrainedEnumModel) {
       //use the enum name rather than the underlying type of the Enum
       return constrainedModel.ref.name;
-    } else {
-      return constrainedModel.ref.type;
     }
+    return constrainedModel.ref.type;
   },
   Any(): string {
     return 'Object';
@@ -194,6 +192,7 @@ export const JavaDefaultTypeMapping: JavaTypeMapping = {
           u.type === 'Character' ||
           u.type.toLowerCase() === 'boolean' ||
           u.type.toLowerCase() === 'int' ||
+          u.type === 'Object' ||
           //Collections
           u.type.startsWith('Map<') ||
           u.type.startsWith('List<') ||

--- a/src/generators/java/JavaGenerator.ts
+++ b/src/generators/java/JavaGenerator.ts
@@ -90,7 +90,8 @@ export class JavaGenerator extends AbstractGenerator<
     //These are the models that we have separate renderers for
     const metaModelsToSplit: SplitOptions = {
       splitEnum: true,
-      splitObject: true
+      splitObject: true,
+      splitUnion: true
     };
     return split(model, metaModelsToSplit);
   }

--- a/test/generators/java/JavaConstrainer.spec.ts
+++ b/test/generators/java/JavaConstrainer.spec.ts
@@ -33,8 +33,13 @@ describe('JavaConstrainer', () => {
     });
   });
   describe('Reference', () => {
-    test('should render the constrained name as type', () => {
-      const refModel = new ConstrainedAnyModel('test', undefined, {}, '');
+    test('should render non-enum referenced type', () => {
+      const refModel = new ConstrainedAnyModel(
+        'ref-name',
+        undefined,
+        {},
+        'ref-type'
+      );
       const model = new ConstrainedReferenceModel(
         'test',
         undefined,
@@ -46,7 +51,28 @@ describe('JavaConstrainer', () => {
         constrainedModel: model,
         ...defaultOptions
       });
-      expect(type).toEqual(model.name);
+      expect(type).toEqual(refModel.type);
+    });
+    test('should render enum referenced name', () => {
+      const refModel = new ConstrainedEnumModel(
+        'ref-name',
+        undefined,
+        {},
+        'ref-type',
+        []
+      );
+      const model = new ConstrainedReferenceModel(
+        'test',
+        undefined,
+        {},
+        '',
+        refModel
+      );
+      const type = JavaDefaultTypeMapping.Reference({
+        constrainedModel: model,
+        ...defaultOptions
+      });
+      expect(type).toEqual(refModel.name);
     });
   });
   describe('Any', () => {
@@ -435,8 +461,27 @@ describe('JavaConstrainer', () => {
   });
 
   describe('Union', () => {
-    test('should render type', () => {
-      const model = new ConstrainedUnionModel('test', undefined, {}, '', []);
+    test('should render the constrained name for non-primitive type unions', () => {
+      const union = new ConstrainedAnyModel(
+        'test-union',
+        undefined,
+        {},
+        'UnionType'
+      );
+      const model = new ConstrainedUnionModel('test', undefined, {}, '', [
+        union
+      ]);
+      const type = JavaDefaultTypeMapping.Union({
+        constrainedModel: model,
+        ...defaultOptions
+      });
+      expect(type).toEqual('test');
+    });
+    test('should render Object for primitive type unions', () => {
+      const union = new ConstrainedAnyModel('test-union', undefined, {}, 'int');
+      const model = new ConstrainedUnionModel('test', undefined, {}, '', [
+        union
+      ]);
       const type = JavaDefaultTypeMapping.Union({
         constrainedModel: model,
         ...defaultOptions

--- a/test/generators/java/JavaGenerator.spec.ts
+++ b/test/generators/java/JavaGenerator.spec.ts
@@ -342,6 +342,74 @@ describe('JavaGenerator', () => {
       expect(models.map((model) => model.result)).toMatchSnapshot();
     });
 
+    test('should create an interface for child models', async () => {
+      const asyncapiDoc = {
+        asyncapi: '2.6.0',
+        info: {
+          title: 'Vehicle example',
+          version: '1.0.0'
+        },
+        channels: {},
+        components: {
+          messages: {
+            Vehicle: {
+              payload: {
+                title: 'Cargo',
+                type: 'object',
+                properties: {
+                  vehicle: {
+                    $ref: '#/components/schemas/Vehicle'
+                  }
+                }
+              }
+            }
+          },
+          schemas: {
+            Vehicle: {
+              title: 'Vehicle',
+              type: 'object',
+              discriminator: 'vehicleType',
+              properties: {
+                vehicleType: {
+                  title: 'VehicleType',
+                  type: 'string'
+                }
+              },
+              required: ['vehicleType'],
+              oneOf: [
+                {
+                  $ref: '#/components/schemas/Car'
+                },
+                {
+                  $ref: '#/components/schemas/Truck'
+                }
+              ]
+            },
+            Car: {
+              type: 'object',
+              properties: {
+                vehicleType: {
+                  const: 'Car'
+                }
+              }
+            },
+
+            Truck: {
+              type: 'object',
+              properties: {
+                vehicleType: {
+                  const: 'Truck'
+                }
+              }
+            }
+          }
+        }
+      };
+
+      const models = await generator.generate(asyncapiDoc);
+      expect(models.map((model) => model.result)).toMatchSnapshot();
+    });
+
     describe('with jackson preset', () => {
       beforeEach(() => {
         generator = new JavaGenerator({

--- a/test/generators/java/JavaGenerator.spec.ts
+++ b/test/generators/java/JavaGenerator.spec.ts
@@ -734,6 +734,73 @@ describe('JavaGenerator', () => {
         expect(cloudEventType).not.toBeUndefined();
         expect(cloudEventType?.result).toContain('DOG');
       });
+      test('should create an interface for child models', async () => {
+        const asyncapiDoc = {
+          asyncapi: '2.6.0',
+          info: {
+            title: 'Vehicle example',
+            version: '1.0.0'
+          },
+          channels: {},
+          components: {
+            messages: {
+              Vehicle: {
+                payload: {
+                  title: 'Cargo',
+                  type: 'object',
+                  properties: {
+                    vehicle: {
+                      $ref: '#/components/schemas/Vehicle'
+                    }
+                  }
+                }
+              }
+            },
+            schemas: {
+              Vehicle: {
+                title: 'Vehicle',
+                type: 'object',
+                discriminator: 'vehicleType',
+                properties: {
+                  vehicleType: {
+                    title: 'VehicleType',
+                    type: 'string'
+                  }
+                },
+                required: ['vehicleType'],
+                oneOf: [
+                  {
+                    $ref: '#/components/schemas/Car'
+                  },
+                  {
+                    $ref: '#/components/schemas/Truck'
+                  }
+                ]
+              },
+              Car: {
+                type: 'object',
+                properties: {
+                  vehicleType: {
+                    const: 'Car'
+                  }
+                }
+              },
+
+              Truck: {
+                type: 'object',
+                properties: {
+                  vehicleType: {
+                    const: 'Truck'
+                  }
+                }
+              }
+            }
+          }
+        };
+
+        const models = await generator.generate(asyncapiDoc);
+        expect(models.map((model) => model.result)).toMatchSnapshot();
+      });
     });
   });
 });

--- a/test/generators/java/JavaGenerator.spec.ts
+++ b/test/generators/java/JavaGenerator.spec.ts
@@ -60,8 +60,8 @@ describe('JavaGenerator', () => {
     };
     const expectedDependencies = ['import java.util.Map;'];
     const models = await generator.generate(doc);
-    expect(models).toHaveLength(1);
-    expect(models[0].result).toMatchSnapshot();
+    expect(models).toHaveLength(4);
+    expect(models.map((model) => model.result)).toMatchSnapshot();
     expect(models[0].dependencies).toEqual(expectedDependencies);
   });
 
@@ -241,9 +241,8 @@ describe('JavaGenerator', () => {
     };
     const config = { packageName: 'test.packageName' };
     const models = await generator.generateCompleteModels(doc, config);
-    expect(models).toHaveLength(2);
-    expect(models[0].result).toMatchSnapshot();
-    expect(models[1].result).toMatchSnapshot();
+    expect(models).toHaveLength(5);
+    expect(models.map((model) => model.result)).toMatchSnapshot();
   });
   test('should throw error when reserved keyword is used in any part of the package name', async () => {
     const doc = {

--- a/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
+++ b/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
@@ -56,6 +56,72 @@ public interface Vehicle {
 ]
 `;
 
+exports[`JavaGenerator oneOf/discriminator should create an interface for child models 1`] = `
+Array [
+  "public class Cargo {
+  private Vehicle vehicle;
+  private Map<String, Object> additionalProperties;
+
+  public Vehicle getVehicle() { return this.vehicle; }
+  public void setVehicle(Vehicle vehicle) { this.vehicle = vehicle; }
+
+  public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
+  public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
+}",
+  "/**
+ * Vehicle represents a union of types: Car, Truck
+ */
+public interface Vehicle {
+  VehicleType getVehicleType();
+}",
+  "public class Car implements Vehicle {
+  private final VehicleType vehicleType = VehicleType.CAR;
+  private Map<String, Object> additionalProperties;
+
+  public VehicleType getVehicleType() { return this.vehicleType; }
+
+  public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
+  public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
+}",
+  "public enum VehicleType {
+  CAR((String)\\"Car\\"), TRUCK((String)\\"Truck\\");
+
+  private String value;
+
+  VehicleType(String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public static VehicleType fromValue(String value) {
+    for (VehicleType e : VehicleType.values()) {
+      if (e.value.equals(value)) {
+        return e;
+      }
+    }
+    throw new IllegalArgumentException(\\"Unexpected value '\\" + value + \\"'\\");
+  }
+
+  @Override
+  public String toString() {
+    return String.valueOf(value);
+  }
+}",
+  "public class Truck implements Vehicle {
+  private final VehicleType vehicleType = VehicleType.TRUCK;
+  private Map<String, Object> additionalProperties;
+
+  public VehicleType getVehicleType() { return this.vehicleType; }
+
+  public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
+  public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
+}",
+]
+`;
+
 exports[`JavaGenerator oneOf/discriminator with jackson preset handle allOf with const in CloudEvent type 1`] = `
 Array [
   "@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.EXISTING_PROPERTY, property=\\"type\\")

--- a/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
+++ b/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
@@ -602,6 +602,198 @@ public interface Pet {
 ]
 `;
 
+exports[`JavaGenerator oneOf/discriminator with jackson preset should create an interface for child models 1`] = `
+Array [
+  "public class Cargo {
+  @JsonProperty(\\"vehicle\\")
+  private Vehicle vehicle;
+  private Map<String, Object> additionalProperties;
+
+  public Vehicle getVehicle() { return this.vehicle; }
+  public void setVehicle(Vehicle vehicle) { this.vehicle = vehicle; }
+
+  public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
+  public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Cargo self = (Cargo) o;
+      return 
+        Objects.equals(this.vehicle, self.vehicle) &&
+        Objects.equals(this.additionalProperties, self.additionalProperties);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash((Object)vehicle, (Object)additionalProperties);
+  }
+
+  @Override
+  public String toString() {
+    return \\"class Cargo {\\\\n\\" +   
+      \\"    vehicle: \\" + toIndentedString(vehicle) + \\"\\\\n\\" +
+      \\"    additionalProperties: \\" + toIndentedString(additionalProperties) + \\"\\\\n\\" +
+    \\"}\\";
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return \\"null\\";
+    }
+    return o.toString().replace(\\"\\\\n\\", \\"\\\\n    \\");
+  }
+}",
+  "@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.EXISTING_PROPERTY, property=\\"vehicleType\\")
+@JsonSubTypes({
+  @JsonSubTypes.Type(value = Car.class, name = \\"Car\\"),
+  @JsonSubTypes.Type(value = Truck.class, name = \\"Truck\\")
+})
+/**
+ * Vehicle represents a union of types: Car, Truck
+ */
+public interface Vehicle {
+  VehicleType getVehicleType();
+}",
+  "public class Car implements Vehicle {
+  @NotNull
+  @JsonProperty(\\"vehicleType\\")
+  private final VehicleType vehicleType = VehicleType.CAR;
+  private Map<String, Object> additionalProperties;
+
+  public VehicleType getVehicleType() { return this.vehicleType; }
+
+  public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
+  public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Car self = (Car) o;
+      return 
+        Objects.equals(this.vehicleType, self.vehicleType) &&
+        Objects.equals(this.additionalProperties, self.additionalProperties);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash((Object)vehicleType, (Object)additionalProperties);
+  }
+
+  @Override
+  public String toString() {
+    return \\"class Car {\\\\n\\" +   
+      \\"    vehicleType: \\" + toIndentedString(vehicleType) + \\"\\\\n\\" +
+      \\"    additionalProperties: \\" + toIndentedString(additionalProperties) + \\"\\\\n\\" +
+    \\"}\\";
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return \\"null\\";
+    }
+    return o.toString().replace(\\"\\\\n\\", \\"\\\\n    \\");
+  }
+}",
+  "public enum VehicleType {
+  CAR((String)\\"Car\\"), TRUCK((String)\\"Truck\\");
+
+  private String value;
+
+  VehicleType(String value) {
+    this.value = value;
+  }
+
+  @JsonValue
+  public String getValue() {
+    return value;
+  }
+
+  @JsonCreator
+  public static VehicleType fromValue(String value) {
+    for (VehicleType e : VehicleType.values()) {
+      if (e.value.equals(value)) {
+        return e;
+      }
+    }
+    throw new IllegalArgumentException(\\"Unexpected value '\\" + value + \\"'\\");
+  }
+
+  @Override
+  public String toString() {
+    return String.valueOf(value);
+  }
+}",
+  "public class Truck implements Vehicle {
+  @NotNull
+  @JsonProperty(\\"vehicleType\\")
+  private final VehicleType vehicleType = VehicleType.TRUCK;
+  private Map<String, Object> additionalProperties;
+
+  public VehicleType getVehicleType() { return this.vehicleType; }
+
+  public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
+  public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Truck self = (Truck) o;
+      return 
+        Objects.equals(this.vehicleType, self.vehicleType) &&
+        Objects.equals(this.additionalProperties, self.additionalProperties);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash((Object)vehicleType, (Object)additionalProperties);
+  }
+
+  @Override
+  public String toString() {
+    return \\"class Truck {\\\\n\\" +   
+      \\"    vehicleType: \\" + toIndentedString(vehicleType) + \\"\\\\n\\" +
+      \\"    additionalProperties: \\" + toIndentedString(additionalProperties) + \\"\\\\n\\" +
+    \\"}\\";
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return \\"null\\";
+    }
+    return o.toString().replace(\\"\\\\n\\", \\"\\\\n    \\");
+  }
+}",
+]
+`;
+
 exports[`JavaGenerator should not render reserved keyword 1`] = `
 "public class Address {
   private String reservedReservedEnum;

--- a/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
+++ b/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
@@ -616,7 +616,8 @@ exports[`JavaGenerator should not render reserved keyword 1`] = `
 `;
 
 exports[`JavaGenerator should render \`class\` type 1`] = `
-"public class Address {
+Array [
+  "public class Address {
   private String streetName;
   private String city;
   private String state;
@@ -649,7 +650,26 @@ exports[`JavaGenerator should render \`class\` type 1`] = `
 
   public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
   public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
-}"
+}",
+  "/**
+ * Members represents a union of types: String, Double, Boolean
+ */
+public interface Members {
+  
+}",
+  "/**
+ * Union represents a union of types: String, Double, Object
+ */
+public interface Union {
+  
+}",
+  "/**
+ * AdditionalProperties represents a union of types: Object, String
+ */
+public interface AdditionalProperties {
+  
+}",
+]
 `;
 
 exports[`JavaGenerator should render \`enum\` type (integer type) 1`] = `
@@ -813,8 +833,12 @@ exports[`JavaGenerator should render enums with translated special characters 1`
 `;
 
 exports[`JavaGenerator should render models and their dependencies 1`] = `
-"package test.packageName;
+Array [
+  "package test.packageName;
+import test.packageName.Members;
+import test.packageName.Union;
 import test.packageName.OtherModel;
+import test.packageName.AdditionalProperties;
 import java.util.Map;
 public class Address {
   private String streetName;
@@ -853,11 +877,26 @@ public class Address {
 
   public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
   public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
-}"
-`;
+}",
+  "package test.packageName;
 
-exports[`JavaGenerator should render models and their dependencies 2`] = `
-"package test.packageName;
+
+/**
+ * Members represents a union of types: String, Double, Boolean
+ */
+public interface Members {
+  
+}",
+  "package test.packageName;
+
+
+/**
+ * Union represents a union of types: String, Double, Object
+ */
+public interface Union {
+  
+}",
+  "package test.packageName;
 
 import java.util.Map;
 public class OtherModel {
@@ -869,7 +908,17 @@ public class OtherModel {
 
   public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
   public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
-}"
+}",
+  "package test.packageName;
+
+
+/**
+ * AdditionalProperties represents a union of types: Object, String
+ */
+public interface AdditionalProperties {
+  
+}",
+]
 `;
 
 exports[`JavaGenerator should work custom preset for \`class\` type 1`] = `


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- add type safe support for the properties of Java models to be represented as an interface with types that implement that interface
- if the union includes a primitive type or collection the union will be represented as an Object, as is the case for all union properties at the moment

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->