### PR TITLE
chore(website): fix react prop warning

### DIFF
--- a/modelina-website/src/components/CodeBlock.tsx
+++ b/modelina-website/src/components/CodeBlock.tsx
@@ -222,7 +222,7 @@ export default function CodeBlock({
             style={theme}
             showLineNumbers={showLineNumbers}
             startingLineNumber={startingLineNumber}
-            lineNumberContainerProps={{
+            linenumbercontainerprops={{
               className: 'pl-2 float-left left-0 sticky bg-code-editor-dark',
               style: {}
             }}


### PR DESCRIPTION
**Description**
This PR fixes the warning 
```
Warning: React does not recognize the `lineNumberProps` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `linenumberprops` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
    at pre
    at SyntaxHighlighter (/Users/lagoni/Documents/github/generator-model-sdk/modelina-website/node_modules/react-syntax-highlighter/dist/cjs/highlight.js:333:26)
    at div
    at div
    at div
    at CodeBlock (webpack-internal:///./src/components/CodeBlock.tsx:162:22)
    at div
    at div
    at div
    at div
    at div
    at Container (webpack-internal:///./src/components/layouts/Container.tsx:8:22)
    at GenericLayout (webpack-internal:///./src/components/layouts/GenericLayout.tsx:19:26)
    at Index
    at div
    at App (webpack-internal:///./src/pages/_app.tsx:18:16)
    at StyleRegistry (/Users/lagoni/Documents/github/generator-model-sdk/modelina-website/node_modules/styled-jsx/dist/index/index.js:449:36)
    at PathnameContextProviderAdapter (/Users/lagoni/Documents/github/generator-model-sdk/modelina-website/node_modules/next/dist/shared/lib/router/adapters.js:60:11)
    at AppContainer (/Users/lagoni/Documents/github/generator-model-sdk/modelina-website/node_modules/next/dist/server/render.js:290:29)
    at AppContainerWithIsomorphicFiberStructure (/Users/lagoni/Documents/github/generator-model-sdk/modelina-website/node_modules/next/dist/server/render.js:326:57)
    at div
    at Body (/Users/lagoni/Documents/github/generator-model-sdk/modelina-website/node_modules/next/dist/server/render.js:613:21)
```