### PR TITLE
chore(website): change default playground namespace for PHP

### DIFF
--- a/modelina-website/src/pages/api/functions/PhpGenerator.ts
+++ b/modelina-website/src/pages/api/functions/PhpGenerator.ts
@@ -45,7 +45,7 @@ export async function getPhpModels(
     const generator = new PhpGenerator(options);
     const generatedModels = await generator.generateCompleteModels(
       processedInput,
-      { namespace: 'asyncapi.models' }
+      { namespace: 'AsyncAPI\\Models' }
     );
     return convertModelsToProps(generatedModels);
   } catch (e : any) {


### PR DESCRIPTION
I overlooked the namespace name. PHP must have namespaces separated by `\` 😄 