### PR TITLE
chore(website): add info to options for c++, kotlin, and go

### DIFF
--- a/modelina-website/src/components/playground/options/CplusplusGeneratorOptions.tsx
+++ b/modelina-website/src/components/playground/options/CplusplusGeneratorOptions.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { PlaygroundCplusplusConfigContext } from '@/components/contexts/PlaygroundConfigContext';
 import { debounce } from 'lodash';
+import InfoModal from '@/components/InfoModal';
 
 interface CplusplusGeneratorOptionsProps {
   setNewConfig?: (queryKey: string, queryValue: string) => void;
@@ -45,8 +46,13 @@ class CplusplusGeneratorOptions extends React.Component<
         <h3 className="text-lg font-medium leading-6 text-gray-900">
           C++ Specific options
         </h3>
-        <li>
-          <label className="flex items-center py-2 justify-between cursor-pointer">
+        <li className=' flex items-center'>
+          <InfoModal text="Namespace :">
+            <p>
+            In C++, a namespace is a feature that allows you to organize your code into logical groups or containers. It helps in avoiding naming conflicts between different parts of your code and provides a way to encapsulate related code.
+            </p>
+          </InfoModal>
+          <label className="flex flex-grow items-center py-2 justify-between cursor-pointer">
             <span className="mt-1 max-w-2xl text-sm text-gray-500">
               Namespace
             </span>

--- a/modelina-website/src/components/playground/options/GoGeneratorOptions.tsx
+++ b/modelina-website/src/components/playground/options/GoGeneratorOptions.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { debounce } from 'lodash';
 import { PlaygroundGoConfigContext } from '@/components/contexts/PlaygroundConfigContext';
+import InfoModal from '@/components/InfoModal';
 
 interface GoGeneratorOptionsProps {
   setNewConfig?: (queryKey: string, queryValue: string) => void;
@@ -45,8 +46,13 @@ class GoGeneratorOptions extends React.Component<
         <h3 className="text-lg font-medium leading-6 text-gray-900">
           Go Specific options
         </h3>
-        <li>
-          <label className="flex items-center py-2 justify-between cursor-pointer">
+        <li className=' flex items-center'>
+        <InfoModal text="Package Name :">
+            <p>
+            In Go, a package name is used to organize code into logical groups or containers. It serves as a namespace for the code elements within it and helps in avoiding naming conflicts.
+            </p>
+          </InfoModal>
+          <label className="flex flex-grow items-center py-2 justify-between cursor-pointer">
             <span className="mt-1 max-w-2xl text-sm text-gray-500">
               Package Name
             </span>

--- a/modelina-website/src/components/playground/options/KotlinGeneratorOptions.tsx
+++ b/modelina-website/src/components/playground/options/KotlinGeneratorOptions.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { debounce } from 'lodash';
 import { PlaygroundKotlinConfigContext } from '@/components/contexts/PlaygroundConfigContext';
+import InfoModal from '@/components/InfoModal';
 
 interface KotlinGeneratorOptionsProps {
   setNewConfig?: (queryKey: string, queryValue: string) => void;
@@ -44,8 +45,13 @@ class KotlinGeneratorOptions extends React.Component<
         <h3 className="text-lg font-medium leading-6 text-gray-900">
           Kotlin Specific options
         </h3>
-        <li>
-          <label className="flex items-center py-2 justify-between cursor-pointer">
+        <li className=' flex items-center'>
+        <InfoModal text="Package Name :">
+            <p>
+            In Kotlin, a package name is used to organize classes, functions, and other code elements into logical groups or containers. It helps in avoiding naming conflicts and provides a way to structure your code.
+            </p>
+          </InfoModal>
+          <label className="flex flex-grow items-center py-2 justify-between cursor-pointer">
             <span className="mt-1 max-w-2xl text-sm text-gray-500">
               Package Name
             </span>


### PR DESCRIPTION
this PR tries to add info to options for the language c++, kotlin and go as mentioned in issue #1392 