### PR TITLE
fix: ts/js unmarshalling function bug

### DIFF
--- a/src/generators/javascript/presets/CommonPreset.ts
+++ b/src/generators/javascript/presets/CommonPreset.ts
@@ -127,8 +127,8 @@ function renderUnmarshalUnwrapProperties(
       `instance.${prop}.set(key, ${unmarshalCode});`
     );
   }
-  const propertyNames = Object.keys(model.properties).map(
-    (prop) => `"${prop}"`
+  const propertyNames = Object.values(model.properties).map(
+    (model) => `"${model.unconstrainedPropertyName}"`
   );
   return `
 //Not part of core properties

--- a/src/generators/typescript/presets/CommonPreset.ts
+++ b/src/generators/typescript/presets/CommonPreset.ts
@@ -226,7 +226,7 @@ function renderUnmarshalProperty(
 function renderUnmarshalProperties(model: ConstrainedObjectModel) {
   const properties = model.properties || {};
   const propertyKeys = [...Object.entries(properties)];
-  const propertyNames = propertyKeys.map(([name]) => {
+  const originalPropertyNames = propertyKeys.map(([, name]) => {
     return name;
   });
   //These are a bit special as 'unwrap' dictionary models means they have to be unwrapped within the JSON object.
@@ -276,7 +276,7 @@ function renderUnmarshalProperties(model: ConstrainedObjectModel) {
       `instance.${prop}.set(key, ${unmarshalCode});`
     );
   }
-  const corePropertyKeys = propertyNames
+  const corePropertyKeys = originalPropertyNames
     .map((propertyKey) => `"${propertyKey}"`)
     .join(',');
   const unwrappedDictionaryCode =

--- a/src/generators/typescript/presets/CommonPreset.ts
+++ b/src/generators/typescript/presets/CommonPreset.ts
@@ -226,8 +226,8 @@ function renderUnmarshalProperty(
 function renderUnmarshalProperties(model: ConstrainedObjectModel) {
   const properties = model.properties || {};
   const propertyKeys = [...Object.entries(properties)];
-  const originalPropertyNames = propertyKeys.map(([, name]) => {
-    return name;
+  const originalPropertyNames = propertyKeys.map(([, model]) => {
+    return model.unconstrainedPropertyName;
   });
   //These are a bit special as 'unwrap' dictionary models means they have to be unwrapped within the JSON object.
   const unwrapDictionaryProperties = [];

--- a/test/generators/javascript/preset/__snapshots__/MarshallingPreset.spec.ts.snap
+++ b/test/generators/javascript/preset/__snapshots__/MarshallingPreset.spec.ts.snap
@@ -60,7 +60,7 @@ exports[`Marshalling preset should render un/marshal code 1`] = `
     //Not part of core properties
 
     //Only go over remaining. properties 
-    for (const [key, value] of Object.entries(obj).filter((([key,]) => {return ![\\"stringProp\\",\\"numberProp\\",\\"additionalProperties\\"].includes(key);}))) {
+    for (const [key, value] of Object.entries(obj).filter((([key,]) => {return ![\\"string prop\\",\\"numberProp\\",\\"additionalProperties\\"].includes(key);}))) {
   
     }
 

--- a/test/generators/typescript/preset/__snapshots__/JsonBinPackPreset.spec.ts.snap
+++ b/test/generators/typescript/preset/__snapshots__/JsonBinPackPreset.spec.ts.snap
@@ -45,7 +45,7 @@ exports[`JsonBinPack preset should work fine with AsyncAPI inputs 1`] = `
     }
 
     if (instance.additionalProperties === undefined) {instance.additionalProperties = new Map();}
-      for (const [key, value] of Object.entries(obj).filter((([key,]) => {return ![\\"[object Object]\\",\\"[object Object]\\"].includes(key);}))) {
+      for (const [key, value] of Object.entries(obj).filter((([key,]) => {return ![\\"email\\",\\"additionalProperties\\"].includes(key);}))) {
         instance.additionalProperties.set(key, value as any);
       }
 
@@ -111,7 +111,7 @@ exports[`JsonBinPack preset should work fine with JSON Schema draft 4 1`] = `
     }
 
     if (instance.additionalProperties === undefined) {instance.additionalProperties = new Map();}
-      for (const [key, value] of Object.entries(obj).filter((([key,]) => {return ![\\"[object Object]\\",\\"[object Object]\\"].includes(key);}))) {
+      for (const [key, value] of Object.entries(obj).filter((([key,]) => {return ![\\"email\\",\\"additionalProperties\\"].includes(key);}))) {
         instance.additionalProperties.set(key, value as any);
       }
 
@@ -177,7 +177,7 @@ exports[`JsonBinPack preset should work fine with JSON Schema draft 6 1`] = `
     }
 
     if (instance.additionalProperties === undefined) {instance.additionalProperties = new Map();}
-      for (const [key, value] of Object.entries(obj).filter((([key,]) => {return ![\\"[object Object]\\",\\"[object Object]\\"].includes(key);}))) {
+      for (const [key, value] of Object.entries(obj).filter((([key,]) => {return ![\\"email\\",\\"additionalProperties\\"].includes(key);}))) {
         instance.additionalProperties.set(key, value as any);
       }
 

--- a/test/generators/typescript/preset/__snapshots__/JsonBinPackPreset.spec.ts.snap
+++ b/test/generators/typescript/preset/__snapshots__/JsonBinPackPreset.spec.ts.snap
@@ -45,7 +45,7 @@ exports[`JsonBinPack preset should work fine with AsyncAPI inputs 1`] = `
     }
 
     if (instance.additionalProperties === undefined) {instance.additionalProperties = new Map();}
-      for (const [key, value] of Object.entries(obj).filter((([key,]) => {return ![\\"email\\",\\"additionalProperties\\"].includes(key);}))) {
+      for (const [key, value] of Object.entries(obj).filter((([key,]) => {return ![\\"[object Object]\\",\\"[object Object]\\"].includes(key);}))) {
         instance.additionalProperties.set(key, value as any);
       }
 
@@ -111,7 +111,7 @@ exports[`JsonBinPack preset should work fine with JSON Schema draft 4 1`] = `
     }
 
     if (instance.additionalProperties === undefined) {instance.additionalProperties = new Map();}
-      for (const [key, value] of Object.entries(obj).filter((([key,]) => {return ![\\"email\\",\\"additionalProperties\\"].includes(key);}))) {
+      for (const [key, value] of Object.entries(obj).filter((([key,]) => {return ![\\"[object Object]\\",\\"[object Object]\\"].includes(key);}))) {
         instance.additionalProperties.set(key, value as any);
       }
 
@@ -177,7 +177,7 @@ exports[`JsonBinPack preset should work fine with JSON Schema draft 6 1`] = `
     }
 
     if (instance.additionalProperties === undefined) {instance.additionalProperties = new Map();}
-      for (const [key, value] of Object.entries(obj).filter((([key,]) => {return ![\\"email\\",\\"additionalProperties\\"].includes(key);}))) {
+      for (const [key, value] of Object.entries(obj).filter((([key,]) => {return ![\\"[object Object]\\",\\"[object Object]\\"].includes(key);}))) {
         instance.additionalProperties.set(key, value as any);
       }
 

--- a/test/generators/typescript/preset/__snapshots__/MarshallingPreset.spec.ts.snap
+++ b/test/generators/typescript/preset/__snapshots__/MarshallingPreset.spec.ts.snap
@@ -133,7 +133,7 @@ exports[`Marshalling preset should render un/marshal code 1`] = `
     }
 
     if (instance.additionalProperties === undefined) {instance.additionalProperties = new Map();}
-      for (const [key, value] of Object.entries(obj).filter((([key,]) => {return ![\\"[object Object]\\",\\"[object Object]\\",\\"[object Object]\\",\\"[object Object]\\",\\"[object Object]\\",\\"[object Object]\\",\\"[object Object]\\",\\"[object Object]\\"].includes(key);}))) {
+      for (const [key, value] of Object.entries(obj).filter((([key,]) => {return ![\\"string prop\\",\\"enumProp\\",\\"numberProp\\",\\"nestedObject\\",\\"unionTest\\",\\"unionArrayTest\\",\\"arrayTest\\",\\"additionalProperties\\"].includes(key);}))) {
         instance.additionalProperties.set(key, NestedTest.unmarshal(value as any));
       }
 
@@ -196,7 +196,7 @@ exports[`Marshalling preset should render un/marshal code 3`] = `
     }
 
     if (instance.additionalProperties === undefined) {instance.additionalProperties = new Map();}
-      for (const [key, value] of Object.entries(obj).filter((([key,]) => {return ![\\"[object Object]\\",\\"[object Object]\\"].includes(key);}))) {
+      for (const [key, value] of Object.entries(obj).filter((([key,]) => {return ![\\"stringProp\\",\\"additionalProperties\\"].includes(key);}))) {
         instance.additionalProperties.set(key, value as any);
       }
 

--- a/test/generators/typescript/preset/__snapshots__/MarshallingPreset.spec.ts.snap
+++ b/test/generators/typescript/preset/__snapshots__/MarshallingPreset.spec.ts.snap
@@ -133,7 +133,7 @@ exports[`Marshalling preset should render un/marshal code 1`] = `
     }
 
     if (instance.additionalProperties === undefined) {instance.additionalProperties = new Map();}
-      for (const [key, value] of Object.entries(obj).filter((([key,]) => {return ![\\"stringProp\\",\\"enumProp\\",\\"numberProp\\",\\"nestedObject\\",\\"unionTest\\",\\"unionArrayTest\\",\\"arrayTest\\",\\"additionalProperties\\"].includes(key);}))) {
+      for (const [key, value] of Object.entries(obj).filter((([key,]) => {return ![\\"[object Object]\\",\\"[object Object]\\",\\"[object Object]\\",\\"[object Object]\\",\\"[object Object]\\",\\"[object Object]\\",\\"[object Object]\\",\\"[object Object]\\"].includes(key);}))) {
         instance.additionalProperties.set(key, NestedTest.unmarshal(value as any));
       }
 
@@ -196,7 +196,7 @@ exports[`Marshalling preset should render un/marshal code 3`] = `
     }
 
     if (instance.additionalProperties === undefined) {instance.additionalProperties = new Map();}
-      for (const [key, value] of Object.entries(obj).filter((([key,]) => {return ![\\"stringProp\\",\\"additionalProperties\\"].includes(key);}))) {
+      for (const [key, value] of Object.entries(obj).filter((([key,]) => {return ![\\"[object Object]\\",\\"[object Object]\\"].includes(key);}))) {
         instance.additionalProperties.set(key, value as any);
       }
 


### PR DESCRIPTION
**Description**
This PR fixes a bug where wrong property names are filtered for typescript and js generator.

This fixes the runtime testing problems.

**Related issue(s)**
Fixes https://github.com/asyncapi/modelina/issues/1391