### PR TITLE
ci: temporarily enable release for next

### DIFF
--- a/.github/workflows/if-nodejs-release.yml
+++ b/.github/workflows/if-nodejs-release.yml
@@ -15,6 +15,7 @@ on:
       - next-major-spec
       - beta
       - alpha
+      - next
 
 jobs:
 


### PR DESCRIPTION
**Description**
This is just a temporary fix for the release workflow, as we should use `next-major` instead of just `next`.