### PR TITLE
chore(website): fix missing link to API docs in mobile view

### DIFF
--- a/modelina-website/scripts/build-examples.js
+++ b/modelina-website/scripts/build-examples.js
@@ -1,6 +1,12 @@
 const path = require('path');
 const {readdir, readFile, writeFile, mkdir, } = require('fs/promises');
 
+const refactorExampleName = (name) => {
+  const [first, ...rest] = name.split('-');
+  return first.charAt(0).toUpperCase() + first.slice(1) + " " + rest.join(" ")
+
+}
+
 const getDirectories = async source =>
   (await readdir(source, { withFileTypes: true }))
     .filter(dirent => dirent.isDirectory())
@@ -88,7 +94,7 @@ async function start() {
     const language = getLanguage(example);
     templateConfig[example] = {
       description: description,
-      displayName: example,
+      displayName: refactorExampleName(example),
       code,
       output,
       language

--- a/modelina-website/src/components/layouts/MobileNavMenu.tsx
+++ b/modelina-website/src/components/layouts/MobileNavMenu.tsx
@@ -44,6 +44,11 @@ export default function MobileNavMenu({ onClickClose = () => { } }) {
                   <a className="cursor-pointer">Playground</a>
                 </h4>
               </Link>
+              <Link href="/docs/api" className="flex" legacyBehavior>
+                <h4 className="text-gray-500 font-medium block mb-4">
+                  <a className="cursor-pointer">API docs</a>
+                </h4>
+              </Link>
             </div>
           </div>
         </div>


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
![Screenshot 2023-07-07 203530](https://github.com/asyncapi/modelina/assets/114330931/11e6fe06-f204-4643-8b83-bbfe479c204a)
![Screenshot 2023-07-07 203546](https://github.com/asyncapi/modelina/assets/114330931/9c0cc46e-3556-4e22-a109-8e41cf760aec)

Issue #1431 fixed, changes the mobile nav menu to include API docs link.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->

Fixes https://github.com/asyncapi/modelina/issues/1431