### PR TITLE
fix: #1438 java enable nullable models doesn't support double

### DIFF
--- a/examples/java-from-typescript-type/__snapshots__/index.spec.ts.snap
+++ b/examples/java-from-typescript-type/__snapshots__/index.spec.ts.snap
@@ -3,13 +3,13 @@
 exports[`Should be able to generate Java model from a TypeScript type file and should log expected output to console 1`] = `
 Array [
   "public class InnerData {
-  private Double age;
+  private double age;
   private String name;
   private boolean free;
   private Map<String, Object> additionalProperties;
 
-  public Double getAge() { return this.age; }
-  public void setAge(Double age) { this.age = age; }
+  public double getAge() { return this.age; }
+  public void setAge(double age) { this.age = age; }
 
   public String getName() { return this.name; }
   public void setName(String name) { this.name = name; }

--- a/examples/java-generate-jackson-annotation/__snapshots__/index.spec.ts.snap
+++ b/examples/java-generate-jackson-annotation/__snapshots__/index.spec.ts.snap
@@ -4,16 +4,16 @@ exports[`Should be able to generate data models for jackson annotation and shoul
 Array [
   "public class Root {
   @JsonProperty(\\"min_number_prop\\")
-  private Double minNumberProp;
+  private double minNumberProp;
   @JsonProperty(\\"max_number_prop\\")
-  private Double maxNumberProp;
+  private double maxNumberProp;
   private Map<String, Object> additionalProperties;
 
-  public Double getMinNumberProp() { return this.minNumberProp; }
-  public void setMinNumberProp(Double minNumberProp) { this.minNumberProp = minNumberProp; }
+  public double getMinNumberProp() { return this.minNumberProp; }
+  public void setMinNumberProp(double minNumberProp) { this.minNumberProp = minNumberProp; }
 
-  public Double getMaxNumberProp() { return this.maxNumberProp; }
-  public void setMaxNumberProp(Double maxNumberProp) { this.maxNumberProp = maxNumberProp; }
+  public double getMaxNumberProp() { return this.maxNumberProp; }
+  public void setMaxNumberProp(double maxNumberProp) { this.maxNumberProp = maxNumberProp; }
 
   public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
   public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }

--- a/examples/java-generate-javax-constraint-annotation/__snapshots__/index.spec.ts.snap
+++ b/examples/java-generate-javax-constraint-annotation/__snapshots__/index.spec.ts.snap
@@ -5,10 +5,10 @@ Array [
   "public class JavaxAnnotation {
   @NotNull
   @Min(0)
-  private Double minNumberProp;
+  private double minNumberProp;
   @NotNull
   @Max(99)
-  private Double maxNumberProp;
+  private double maxNumberProp;
   @Size(min=2, max=3)
   private Object[] arrayProp;
   @Pattern(regexp=\\"^I_\\")
@@ -16,11 +16,11 @@ Array [
   private String stringProp;
   private Map<String, Object> additionalProperties;
 
-  public Double getMinNumberProp() { return this.minNumberProp; }
-  public void setMinNumberProp(Double minNumberProp) { this.minNumberProp = minNumberProp; }
+  public double getMinNumberProp() { return this.minNumberProp; }
+  public void setMinNumberProp(double minNumberProp) { this.minNumberProp = minNumberProp; }
 
-  public Double getMaxNumberProp() { return this.maxNumberProp; }
-  public void setMaxNumberProp(Double maxNumberProp) { this.maxNumberProp = maxNumberProp; }
+  public double getMaxNumberProp() { return this.maxNumberProp; }
+  public void setMaxNumberProp(double maxNumberProp) { this.maxNumberProp = maxNumberProp; }
 
   public Object[] getArrayProp() { return this.arrayProp; }
   public void setArrayProp(Object[] arrayProp) { this.arrayProp = arrayProp; }

--- a/src/generators/java/JavaConstrainer.ts
+++ b/src/generators/java/JavaConstrainer.ts
@@ -109,7 +109,7 @@ export const JavaDefaultTypeMapping: JavaTypeMapping = {
     return 'Object';
   },
   Float({ constrainedModel }): string {
-    let type = 'Double';
+    let type = constrainedModel.options.isNullable ? 'Double' : 'double';
     const format =
       constrainedModel.originalInput &&
       constrainedModel.originalInput['format'];

--- a/test/generators/java/JavaConstrainer.spec.ts
+++ b/test/generators/java/JavaConstrainer.spec.ts
@@ -113,6 +113,19 @@ describe('JavaConstrainer', () => {
         constrainedModel: model,
         ...defaultOptions
       });
+      expect(type).toEqual('double');
+    });
+    test('should render nullable type', () => {
+      const model = new ConstrainedFloatModel(
+        'test',
+        undefined,
+        { isNullable: true },
+        ''
+      );
+      const type = JavaDefaultTypeMapping.Float({
+        constrainedModel: model,
+        ...defaultOptions
+      });
       expect(type).toEqual('Double');
     });
     test('should render double when original input has number format', () => {

--- a/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
+++ b/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
@@ -747,7 +747,7 @@ Array [
   private String streetName;
   private String city;
   private String state;
-  private Double houseNumber;
+  private double houseNumber;
   private boolean marriage;
   private Object members;
   private Object[] arrayType;
@@ -762,8 +762,8 @@ Array [
   public String getState() { return this.state; }
   public void setState(String state) { this.state = state; }
 
-  public Double getHouseNumber() { return this.houseNumber; }
-  public void setHouseNumber(Double houseNumber) { this.houseNumber = houseNumber; }
+  public double getHouseNumber() { return this.houseNumber; }
+  public void setHouseNumber(double houseNumber) { this.houseNumber = houseNumber; }
 
   public boolean getMarriage() { return this.marriage; }
   public void setMarriage(boolean marriage) { this.marriage = marriage; }
@@ -952,7 +952,7 @@ public class Address {
   private String streetName;
   private String city;
   private String state;
-  private Double houseNumber;
+  private double houseNumber;
   private boolean marriage;
   private Object members;
   private Object[] arrayType;
@@ -968,8 +968,8 @@ public class Address {
   public String getState() { return this.state; }
   public void setState(String state) { this.state = state; }
 
-  public Double getHouseNumber() { return this.houseNumber; }
-  public void setHouseNumber(Double houseNumber) { this.houseNumber = houseNumber; }
+  public double getHouseNumber() { return this.houseNumber; }
+  public void setHouseNumber(double houseNumber) { this.houseNumber = houseNumber; }
 
   public boolean getMarriage() { return this.marriage; }
   public void setMarriage(boolean marriage) { this.marriage = marriage; }

--- a/test/generators/java/presets/__snapshots__/CommonPreset.spec.ts.snap
+++ b/test/generators/java/presets/__snapshots__/CommonPreset.spec.ts.snap
@@ -4,7 +4,7 @@ exports[`JAVA_COMMON_PRESET should render accurately when there is no additional
 "public class Clazz {
   private boolean requiredProp;
   private String stringProp;
-  private Double numberProp;
+  private double numberProp;
   private boolean booleanProp;
   private String[] arrayProp;
 
@@ -14,8 +14,8 @@ exports[`JAVA_COMMON_PRESET should render accurately when there is no additional
   public String getStringProp() { return this.stringProp; }
   public void setStringProp(String stringProp) { this.stringProp = stringProp; }
 
-  public Double getNumberProp() { return this.numberProp; }
-  public void setNumberProp(Double numberProp) { this.numberProp = numberProp; }
+  public double getNumberProp() { return this.numberProp; }
+  public void setNumberProp(double numberProp) { this.numberProp = numberProp; }
 
   public boolean getBooleanProp() { return this.booleanProp; }
   public void setBooleanProp(boolean booleanProp) { this.booleanProp = booleanProp; }
@@ -73,7 +73,7 @@ exports[`JAVA_COMMON_PRESET should render common function in class by common pre
 "public class Clazz {
   private boolean requiredProp;
   private String stringProp;
-  private Double numberProp;
+  private double numberProp;
   private boolean booleanProp;
   private String[] arrayProp;
   private Map<String, Object> additionalProperties;
@@ -84,8 +84,8 @@ exports[`JAVA_COMMON_PRESET should render common function in class by common pre
   public String getStringProp() { return this.stringProp; }
   public void setStringProp(String stringProp) { this.stringProp = stringProp; }
 
-  public Double getNumberProp() { return this.numberProp; }
-  public void setNumberProp(Double numberProp) { this.numberProp = numberProp; }
+  public double getNumberProp() { return this.numberProp; }
+  public void setNumberProp(double numberProp) { this.numberProp = numberProp; }
 
   public boolean getBooleanProp() { return this.booleanProp; }
   public void setBooleanProp(boolean booleanProp) { this.booleanProp = booleanProp; }
@@ -148,7 +148,7 @@ exports[`JAVA_COMMON_PRESET with option should not render any functions when all
 "public class Clazz {
   private boolean requiredProp;
   private String stringProp;
-  private Double numberProp;
+  private double numberProp;
   private boolean booleanProp;
   private String[] arrayProp;
   private Map<String, Object> additionalProperties;
@@ -159,8 +159,8 @@ exports[`JAVA_COMMON_PRESET with option should not render any functions when all
   public String getStringProp() { return this.stringProp; }
   public void setStringProp(String stringProp) { this.stringProp = stringProp; }
 
-  public Double getNumberProp() { return this.numberProp; }
-  public void setNumberProp(Double numberProp) { this.numberProp = numberProp; }
+  public double getNumberProp() { return this.numberProp; }
+  public void setNumberProp(double numberProp) { this.numberProp = numberProp; }
 
   public boolean getBooleanProp() { return this.booleanProp; }
   public void setBooleanProp(boolean booleanProp) { this.booleanProp = booleanProp; }
@@ -177,7 +177,7 @@ exports[`JAVA_COMMON_PRESET with option should render all functions 1`] = `
 "public class Clazz {
   private boolean requiredProp;
   private String stringProp;
-  private Double numberProp;
+  private double numberProp;
   private boolean booleanProp;
   private String[] arrayProp;
   private Map<String, Object> additionalProperties;
@@ -188,8 +188,8 @@ exports[`JAVA_COMMON_PRESET with option should render all functions 1`] = `
   public String getStringProp() { return this.stringProp; }
   public void setStringProp(String stringProp) { this.stringProp = stringProp; }
 
-  public Double getNumberProp() { return this.numberProp; }
-  public void setNumberProp(Double numberProp) { this.numberProp = numberProp; }
+  public double getNumberProp() { return this.numberProp; }
+  public void setNumberProp(double numberProp) { this.numberProp = numberProp; }
 
   public boolean getBooleanProp() { return this.booleanProp; }
   public void setBooleanProp(boolean booleanProp) { this.booleanProp = booleanProp; }
@@ -252,7 +252,7 @@ exports[`JAVA_COMMON_PRESET with option should render classToString 1`] = `
 "public class Clazz {
   private boolean requiredProp;
   private String stringProp;
-  private Double numberProp;
+  private double numberProp;
   private boolean booleanProp;
   private String[] arrayProp;
   private Map<String, Object> additionalProperties;
@@ -263,8 +263,8 @@ exports[`JAVA_COMMON_PRESET with option should render classToString 1`] = `
   public String getStringProp() { return this.stringProp; }
   public void setStringProp(String stringProp) { this.stringProp = stringProp; }
 
-  public Double getNumberProp() { return this.numberProp; }
-  public void setNumberProp(Double numberProp) { this.numberProp = numberProp; }
+  public double getNumberProp() { return this.numberProp; }
+  public void setNumberProp(double numberProp) { this.numberProp = numberProp; }
 
   public boolean getBooleanProp() { return this.booleanProp; }
   public void setBooleanProp(boolean booleanProp) { this.booleanProp = booleanProp; }
@@ -304,7 +304,7 @@ exports[`JAVA_COMMON_PRESET with option should render equals 1`] = `
 "public class Clazz {
   private boolean requiredProp;
   private String stringProp;
-  private Double numberProp;
+  private double numberProp;
   private boolean booleanProp;
   private String[] arrayProp;
   private Map<String, Object> additionalProperties;
@@ -315,8 +315,8 @@ exports[`JAVA_COMMON_PRESET with option should render equals 1`] = `
   public String getStringProp() { return this.stringProp; }
   public void setStringProp(String stringProp) { this.stringProp = stringProp; }
 
-  public Double getNumberProp() { return this.numberProp; }
-  public void setNumberProp(Double numberProp) { this.numberProp = numberProp; }
+  public double getNumberProp() { return this.numberProp; }
+  public void setNumberProp(double numberProp) { this.numberProp = numberProp; }
 
   public boolean getBooleanProp() { return this.booleanProp; }
   public void setBooleanProp(boolean booleanProp) { this.booleanProp = booleanProp; }
@@ -351,7 +351,7 @@ exports[`JAVA_COMMON_PRESET with option should render hashCode 1`] = `
 "public class Clazz {
   private boolean requiredProp;
   private String stringProp;
-  private Double numberProp;
+  private double numberProp;
   private boolean booleanProp;
   private String[] arrayProp;
   private Map<String, Object> additionalProperties;
@@ -362,8 +362,8 @@ exports[`JAVA_COMMON_PRESET with option should render hashCode 1`] = `
   public String getStringProp() { return this.stringProp; }
   public void setStringProp(String stringProp) { this.stringProp = stringProp; }
 
-  public Double getNumberProp() { return this.numberProp; }
-  public void setNumberProp(Double numberProp) { this.numberProp = numberProp; }
+  public double getNumberProp() { return this.numberProp; }
+  public void setNumberProp(double numberProp) { this.numberProp = numberProp; }
 
   public boolean getBooleanProp() { return this.booleanProp; }
   public void setBooleanProp(boolean booleanProp) { this.booleanProp = booleanProp; }
@@ -385,7 +385,7 @@ exports[`JAVA_COMMON_PRESET with option should render un/marshal 1`] = `
 "public class Clazz {
   private boolean requiredProp;
   private String stringProp;
-  private Double numberProp;
+  private double numberProp;
   private boolean booleanProp;
   private String[] arrayProp;
   private Map<String, Object> additionalProperties;
@@ -396,8 +396,8 @@ exports[`JAVA_COMMON_PRESET with option should render un/marshal 1`] = `
   public String getStringProp() { return this.stringProp; }
   public void setStringProp(String stringProp) { this.stringProp = stringProp; }
 
-  public Double getNumberProp() { return this.numberProp; }
-  public void setNumberProp(Double numberProp) { this.numberProp = numberProp; }
+  public double getNumberProp() { return this.numberProp; }
+  public void setNumberProp(double numberProp) { this.numberProp = numberProp; }
 
   public boolean getBooleanProp() { return this.booleanProp; }
   public void setBooleanProp(boolean booleanProp) { this.booleanProp = booleanProp; }

--- a/test/generators/java/presets/__snapshots__/ConstraintsPreset.spec.ts.snap
+++ b/test/generators/java/presets/__snapshots__/ConstraintsPreset.spec.ts.snap
@@ -4,10 +4,10 @@ exports[`JAVA_CONSTRAINTS_PRESET should render constraints annotations 1`] = `
 "public class Clazz {
   @NotNull
   @Min(0)
-  private Double minNumberProp;
+  private double minNumberProp;
   @NotNull
   @Max(99)
-  private Double maxNumberProp;
+  private double maxNumberProp;
   @Size(min=2, max=3)
   private Object[] arrayProp;
   @Pattern(regexp=\\"^I_\\")
@@ -15,11 +15,11 @@ exports[`JAVA_CONSTRAINTS_PRESET should render constraints annotations 1`] = `
   private String stringProp;
   private Map<String, Object> additionalProperties;
 
-  public Double getMinNumberProp() { return this.minNumberProp; }
-  public void setMinNumberProp(Double minNumberProp) { this.minNumberProp = minNumberProp; }
+  public double getMinNumberProp() { return this.minNumberProp; }
+  public void setMinNumberProp(double minNumberProp) { this.minNumberProp = minNumberProp; }
 
-  public Double getMaxNumberProp() { return this.maxNumberProp; }
-  public void setMaxNumberProp(Double maxNumberProp) { this.maxNumberProp = maxNumberProp; }
+  public double getMaxNumberProp() { return this.maxNumberProp; }
+  public void setMaxNumberProp(double maxNumberProp) { this.maxNumberProp = maxNumberProp; }
 
   public Object[] getArrayProp() { return this.arrayProp; }
   public void setArrayProp(Object[] arrayProp) { this.arrayProp = arrayProp; }

--- a/test/generators/java/presets/__snapshots__/JacksonPreset.spec.ts.snap
+++ b/test/generators/java/presets/__snapshots__/JacksonPreset.spec.ts.snap
@@ -3,16 +3,16 @@
 exports[`JAVA_JACKSON_PRESET should render Jackson annotations for class 1`] = `
 "public class Clazz {
   @JsonProperty(\\"min_number_prop\\")
-  private Double minNumberProp;
+  private double minNumberProp;
   @JsonProperty(\\"max_number_prop\\")
-  private Double maxNumberProp;
+  private double maxNumberProp;
   private Map<String, Object> additionalProperties;
 
-  public Double getMinNumberProp() { return this.minNumberProp; }
-  public void setMinNumberProp(Double minNumberProp) { this.minNumberProp = minNumberProp; }
+  public double getMinNumberProp() { return this.minNumberProp; }
+  public void setMinNumberProp(double minNumberProp) { this.minNumberProp = minNumberProp; }
 
-  public Double getMaxNumberProp() { return this.maxNumberProp; }
-  public void setMaxNumberProp(Double maxNumberProp) { this.maxNumberProp = maxNumberProp; }
+  public double getMaxNumberProp() { return this.maxNumberProp; }
+  public void setMaxNumberProp(double maxNumberProp) { this.maxNumberProp = maxNumberProp; }
 
   public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
   public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }


### PR DESCRIPTION
**Description**

- add missing `double` nullability support for java models to `src/generators/java/JavaConstrainer.ts`

**Related issue(s)**

* #1141 