### PR TITLE
fix: additional content presets for PHP enums are not applied

### DIFF
--- a/src/generators/php/renderers/EnumRenderer.ts
+++ b/src/generators/php/renderers/EnumRenderer.ts
@@ -13,7 +13,10 @@ import { PhpOptions } from '../PhpGenerator';
  */
 export class EnumRenderer extends PhpRenderer<ConstrainedEnumModel> {
   async defaultSelf(): Promise<string> {
-    const content = [await this.renderItems()];
+    const content = [
+      await this.renderItems(),
+      await this.runAdditionalContentPreset()
+    ];
     return `enum ${this.model.name}
 {
 ${this.indent(this.renderBlock(content, 2))}

--- a/test/generators/php/PhpGenerator.spec.ts
+++ b/test/generators/php/PhpGenerator.spec.ts
@@ -50,6 +50,32 @@ describe('PhpGenerator', () => {
       expect(models).toHaveLength(1);
       expect(models[0].result).toMatchSnapshot();
     });
+
+    test('should render `enum` with presets applied', async () => {
+      const doc = {
+        $id: 'Things',
+        enum: ['A', 'B', 'C']
+      };
+
+      generator = new PhpGenerator({
+        presets: [
+          {
+            enum: {
+              self({ content }) {
+                return `${content}// self content`;
+              },
+              additionalContent({ content }) {
+                return `${content}// additional content`;
+              }
+            }
+          }
+        ]
+      });
+
+      const models = await generator.generate(doc);
+      expect(models).toHaveLength(1);
+      expect(models[0].result).toMatchSnapshot();
+    });
   });
   describe('Class', () => {
     test('should not render reserved keyword', async () => {

--- a/test/generators/php/__snapshots__/PhpGenerator.spec.ts.snap
+++ b/test/generators/php/__snapshots__/PhpGenerator.spec.ts.snap
@@ -132,6 +132,18 @@ exports[`PhpGenerator Enum should render \`enum\` with mixed types (union type) 
 "
 `;
 
+exports[`PhpGenerator Enum should render \`enum\` with presets applied 1`] = `
+"enum Things
+{
+  case A;
+  case B;
+  case C;
+
+  // additional content
+}
+// self content"
+`;
+
 exports[`PhpGenerator Enum should render enums with translated special characters 1`] = `
 "enum States
 {


### PR DESCRIPTION
When using the preset option `additionalContent`, the content was not added to the PHP enum.