### PR TITLE
fix: dotnet JSON Serializer preset does not access accessors

### DIFF
--- a/examples/csharp-generate-json-serializer/__snapshots__/index.spec.ts.snap
+++ b/examples/csharp-generate-json-serializer/__snapshots__/index.spec.ts.snap
@@ -47,7 +47,7 @@ internal class RootConverter : JsonConverter<Root>
       if (propertyName == \\"email\\")
         {
           var value = JsonSerializer.Deserialize<string?>(ref reader, options);
-          instance.email = value;
+          instance.Email = value;
           continue;
         }
     }
@@ -65,10 +65,10 @@ internal class RootConverter : JsonConverter<Root>
   
     writer.WriteStartObject();
 
-    if(value.email != null) { 
+    if(value.Email != null) { 
       // write property name and let the serializer serialize the value itself
       writer.WritePropertyName(\\"email\\");
-      JsonSerializer.Serialize(writer, value.email, options);
+      JsonSerializer.Serialize(writer, value.Email, options);
     }
 
 

--- a/src/generators/csharp/presets/JsonSerializerPreset.ts
+++ b/src/generators/csharp/presets/JsonSerializerPreset.ts
@@ -8,6 +8,7 @@ import {
   ConstrainedReferenceModel
 } from '../../../models';
 import { CSharpOptions } from '../CSharpGenerator';
+import { pascalCase } from 'change-case';
 
 function renderSerializeProperty(
   modelInstanceVariable: string,
@@ -30,7 +31,7 @@ function renderSerializeProperties(model: ConstrainedObjectModel) {
     for (const [propertyName, propertyModel] of Object.entries(
       model.properties
     )) {
-      const modelInstanceVariable = `value.${propertyName}`;
+      const modelInstanceVariable = `value.${pascalCase(propertyName)}`;
       if (
         propertyModel.property instanceof ConstrainedDictionaryModel &&
         propertyModel.property.serializationType === 'unwrap'
@@ -72,7 +73,7 @@ function renderPropertiesList(
       );
     })
     .map((value) => {
-      return value.propertyName;
+      return `prop.Name != "${pascalCase(value.propertyName)}"`;
     });
 
   let propertiesList = 'var properties = value.GetType().GetProperties();';
@@ -130,22 +131,23 @@ function renderDeserializeProperty(model: ConstrainedObjectPropertyModel) {
 function renderDeserializeProperties(model: ConstrainedObjectModel) {
   const propertyEntries = Object.entries(model.properties || {});
   const deserializeProperties = propertyEntries.map(([prop, propModel]) => {
+    const pascalProp = pascalCase(prop);
     //Unwrapped dictionary properties, need to be unwrapped in JSON
     if (
       propModel.property instanceof ConstrainedDictionaryModel &&
       propModel.property.serializationType === 'unwrap'
     ) {
-      return `if(instance.${prop} == null) { instance.${prop} = new Dictionary<${
+      return `if(instance.${pascalProp} == null) { instance.${pascalProp} = new Dictionary<${
         propModel.property.key.type
-      }, ${propModel.property.key.type}>(); }
+      }, ${propModel.property.value.type}>(); }
       var deserializedValue = ${renderDeserializeProperty(propModel)};
-      instance.${prop}.Add(propertyName, deserializedValue);
+      instance.${pascalProp}.Add(propertyName, deserializedValue);
       continue;`;
     }
     return `if (propertyName == "${propModel.unconstrainedPropertyName}")
   {
     var value = ${renderDeserializeProperty(propModel)};
-    instance.${prop} = value;
+    instance.${pascalProp} = value;
     continue;
   }`;
   });

--- a/test/generators/csharp/presets/__snapshots__/JsonSerializerPreset.spec.ts.snap
+++ b/test/generators/csharp/presets/__snapshots__/JsonSerializerPreset.spec.ts.snap
@@ -74,30 +74,30 @@ internal class TestConverter : JsonConverter<Test>
       if (propertyName == \\"string prop\\")
         {
           var value = JsonSerializer.Deserialize<string>(ref reader, options);
-          instance.stringProp = value;
+          instance.StringProp = value;
           continue;
         }
       if (propertyName == \\"numberProp\\")
         {
           var value = JsonSerializer.Deserialize<double?>(ref reader, options);
-          instance.numberProp = value;
+          instance.NumberProp = value;
           continue;
         }
       if (propertyName == \\"enumProp\\")
         {
           var value = EnumTestExtension.ToEnumTest(JsonSerializer.Deserialize<dynamic>(ref reader, options));
-          instance.enumProp = value;
+          instance.EnumProp = value;
           continue;
         }
       if (propertyName == \\"objectProp\\")
         {
           var value = JsonSerializer.Deserialize<NestedTest?>(ref reader, options);
-          instance.objectProp = value;
+          instance.ObjectProp = value;
           continue;
         }
-      if(instance.additionalProperties == null) { instance.additionalProperties = new Dictionary<string, string>(); }
+      if(instance.AdditionalProperties == null) { instance.AdditionalProperties = new Dictionary<string, dynamic>(); }
             var deserializedValue = JsonSerializer.Deserialize<Dictionary<string, dynamic>?>(ref reader, options);
-            instance.additionalProperties.Add(propertyName, deserializedValue);
+            instance.AdditionalProperties.Add(propertyName, deserializedValue);
             continue;
     }
   
@@ -110,33 +110,33 @@ internal class TestConverter : JsonConverter<Test>
       JsonSerializer.Serialize(writer, null, options);
       return;
     }
-    var properties = value.GetType().GetProperties().Where(prop => additionalProperties);
+    var properties = value.GetType().GetProperties().Where(prop => prop.Name != \\"AdditionalProperties\\");
   
     writer.WriteStartObject();
 
-    if(value.stringProp != null) { 
+    if(value.StringProp != null) { 
       // write property name and let the serializer serialize the value itself
       writer.WritePropertyName(\\"string prop\\");
-      JsonSerializer.Serialize(writer, value.stringProp, options);
+      JsonSerializer.Serialize(writer, value.StringProp, options);
     }
-    if(value.numberProp != null) { 
+    if(value.NumberProp != null) { 
       // write property name and let the serializer serialize the value itself
       writer.WritePropertyName(\\"numberProp\\");
-      JsonSerializer.Serialize(writer, value.numberProp, options);
+      JsonSerializer.Serialize(writer, value.NumberProp, options);
     }
-    if(value.enumProp != null) { 
+    if(value.EnumProp != null) { 
       // write property name and let the serializer serialize the value itself
       writer.WritePropertyName(\\"enumProp\\");
       JsonSerializer.Serialize(writer, EnumTest?.GetValue(), options);
     }
-    if(value.objectProp != null) { 
+    if(value.ObjectProp != null) { 
       // write property name and let the serializer serialize the value itself
       writer.WritePropertyName(\\"objectProp\\");
-      JsonSerializer.Serialize(writer, value.objectProp, options);
+      JsonSerializer.Serialize(writer, value.ObjectProp, options);
     }
     // Unwrap dictionary properties
-    if (value.additionalProperties != null) {
-      foreach (var unwrappedProperty in value.additionalProperties)
+    if (value.AdditionalProperties != null) {
+      foreach (var unwrappedProperty in value.AdditionalProperties)
       {
         // Ignore any unwrapped properties which might already be part of the core properties
         if (properties.Any(prop => prop.Name == unwrappedProperty.Key))
@@ -147,10 +147,10 @@ internal class TestConverter : JsonConverter<Test>
         writer.WritePropertyName(unwrappedProperty.Key);
         JsonSerializer.Serialize(writer, unwrappedProperty.Value, options);
       }
-    }if(value.additionalProperties != null) { 
+    }if(value.AdditionalProperties != null) { 
       // write property name and let the serializer serialize the value itself
       writer.WritePropertyName(\\"additionalProperties\\");
-      JsonSerializer.Serialize(writer, value.additionalProperties, options);
+      JsonSerializer.Serialize(writer, value.AdditionalProperties, options);
     }
 
 
@@ -252,12 +252,12 @@ internal class NestedTestConverter : JsonConverter<NestedTest>
       if (propertyName == \\"stringProp\\")
         {
           var value = JsonSerializer.Deserialize<string?>(ref reader, options);
-          instance.stringProp = value;
+          instance.StringProp = value;
           continue;
         }
-      if(instance.additionalProperties == null) { instance.additionalProperties = new Dictionary<string, string>(); }
+      if(instance.AdditionalProperties == null) { instance.AdditionalProperties = new Dictionary<string, dynamic>(); }
             var deserializedValue = JsonSerializer.Deserialize<Dictionary<string, dynamic>?>(ref reader, options);
-            instance.additionalProperties.Add(propertyName, deserializedValue);
+            instance.AdditionalProperties.Add(propertyName, deserializedValue);
             continue;
     }
   
@@ -270,18 +270,18 @@ internal class NestedTestConverter : JsonConverter<NestedTest>
       JsonSerializer.Serialize(writer, null, options);
       return;
     }
-    var properties = value.GetType().GetProperties().Where(prop => additionalProperties);
+    var properties = value.GetType().GetProperties().Where(prop => prop.Name != \\"AdditionalProperties\\");
   
     writer.WriteStartObject();
 
-    if(value.stringProp != null) { 
+    if(value.StringProp != null) { 
       // write property name and let the serializer serialize the value itself
       writer.WritePropertyName(\\"stringProp\\");
-      JsonSerializer.Serialize(writer, value.stringProp, options);
+      JsonSerializer.Serialize(writer, value.StringProp, options);
     }
     // Unwrap dictionary properties
-    if (value.additionalProperties != null) {
-      foreach (var unwrappedProperty in value.additionalProperties)
+    if (value.AdditionalProperties != null) {
+      foreach (var unwrappedProperty in value.AdditionalProperties)
       {
         // Ignore any unwrapped properties which might already be part of the core properties
         if (properties.Any(prop => prop.Name == unwrappedProperty.Key))
@@ -292,10 +292,10 @@ internal class NestedTestConverter : JsonConverter<NestedTest>
         writer.WritePropertyName(unwrappedProperty.Key);
         JsonSerializer.Serialize(writer, unwrappedProperty.Value, options);
       }
-    }if(value.additionalProperties != null) { 
+    }if(value.AdditionalProperties != null) { 
       // write property name and let the serializer serialize the value itself
       writer.WritePropertyName(\\"additionalProperties\\");
-      JsonSerializer.Serialize(writer, value.additionalProperties, options);
+      JsonSerializer.Serialize(writer, value.AdditionalProperties, options);
     }
 
 


### PR DESCRIPTION
**Description**
Use pascalCase in JSON Serializer preset

**Related issue(s)**
Fixes #1448 

**Test Run Output**
[test.txt](https://github.com/asyncapi/modelina/files/12286854/test.txt)
