### PR TITLE
feat: make discriminator property visible to deserializer from Java Jackson preset

### DIFF
--- a/src/generators/java/presets/JacksonPreset.ts
+++ b/src/generators/java/presets/JacksonPreset.ts
@@ -63,7 +63,8 @@ ${content}`;
           renderer.renderAnnotation('JsonTypeInfo', {
             use: 'JsonTypeInfo.Id.NAME',
             include: 'JsonTypeInfo.As.EXISTING_PROPERTY',
-            property: `"${discriminator.discriminator}"`
+            property: `"${discriminator.discriminator}"`,
+            visible: 'true'
           })
         );
 

--- a/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
+++ b/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
@@ -58,7 +58,7 @@ public interface Vehicle {
 
 exports[`JavaGenerator oneOf/discriminator with jackson preset handle allOf with const in CloudEvent type 1`] = `
 Array [
-  "@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.EXISTING_PROPERTY, property=\\"type\\")
+  "@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.EXISTING_PROPERTY, property=\\"type\\", visible=true)
 @JsonSubTypes({
   @JsonSubTypes.Type(value = Dog.class, name = \\"Dog\\"),
   @JsonSubTypes.Type(value = Cat.class, name = \\"Cat\\")
@@ -366,7 +366,7 @@ Array [
 
 exports[`JavaGenerator oneOf/discriminator with jackson preset handle setting title with const 1`] = `
 Array [
-  "@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.EXISTING_PROPERTY, property=\\"type\\")
+  "@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.EXISTING_PROPERTY, property=\\"type\\", visible=true)
 @JsonSubTypes({
   @JsonSubTypes.Type(value = Dog.class, name = \\"Dog\\"),
   @JsonSubTypes.Type(value = Cat.class, name = \\"Cat\\")
@@ -587,7 +587,7 @@ Array [
     return o.toString().replace(\\"\\\\n\\", \\"\\\\n    \\");
   }
 }",
-  "@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.EXISTING_PROPERTY, property=\\"vehicleType\\")
+  "@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.EXISTING_PROPERTY, property=\\"vehicleType\\", visible=true)
 @JsonSubTypes({
   @JsonSubTypes.Type(value = Car.class, name = \\"Car\\"),
   @JsonSubTypes.Type(value = Truck.class, name = \\"Truck\\")

--- a/test/generators/java/presets/__snapshots__/JacksonPreset.spec.ts.snap
+++ b/test/generators/java/presets/__snapshots__/JacksonPreset.spec.ts.snap
@@ -53,7 +53,7 @@ exports[`JAVA_JACKSON_PRESET should render Jackson annotations for enum 1`] = `
 
 exports[`JAVA_JACKSON_PRESET union handle oneOf with AsyncAPI discriminator with Jackson 1`] = `
 Array [
-  "@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.EXISTING_PROPERTY, property=\\"vehicleType\\")
+  "@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.EXISTING_PROPERTY, property=\\"vehicleType\\", visible=true)
 @JsonSubTypes({
   @JsonSubTypes.Type(value = Car.class, name = \\"Car\\"),
   @JsonSubTypes.Type(value = Truck.class, name = \\"Truck\\")
@@ -101,7 +101,7 @@ public interface Vehicle {
 
 exports[`JAVA_JACKSON_PRESET union handle oneOf with OpenAPI v3 discriminator with Jackson 1`] = `
 Array [
-  "@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.EXISTING_PROPERTY, property=\\"vehicleType\\")
+  "@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.EXISTING_PROPERTY, property=\\"vehicleType\\", visible=true)
 @JsonSubTypes({
   @JsonSubTypes.Type(value = Car.class, name = \\"Car\\"),
   @JsonSubTypes.Type(value = Truck.class, name = \\"Truck\\")
@@ -139,7 +139,7 @@ public interface Vehicle {
 
 exports[`JAVA_JACKSON_PRESET union handle oneOf with Swagger v2 discriminator with Jackson 1`] = `
 Array [
-  "@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.EXISTING_PROPERTY, property=\\"vehicleType\\")
+  "@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.EXISTING_PROPERTY, property=\\"vehicleType\\", visible=true)
 @JsonSubTypes({
   @JsonSubTypes.Type(value = Car.class, name = \\"Car\\"),
   @JsonSubTypes.Type(value = Truck.class, name = \\"Truck\\")


### PR DESCRIPTION
**Description**

When deserializing `oneOf` structures using non-const discriminators, the discriminator value is not visible in the deserialized model.

Add `visible=true` to `@JsonTypeInfo`

This doesn't change the behaviour when using const discriminators.