### PR TITLE
fix: typescript interface variable assignment

### DIFF
--- a/src/generators/typescript/TypeScriptObjectRenderer.ts
+++ b/src/generators/typescript/TypeScriptObjectRenderer.ts
@@ -46,7 +46,11 @@ export abstract class TypeScriptObjectRenderer extends TypeScriptRenderer<Constr
     }`;
 
     if (property.property.options.const?.value) {
-      return `${renderedProperty}: ${property.property.options.const.value} = ${property.property.options.const.value};`;
+      return `${renderedProperty}: ${property.property.options.const.value}${
+        this.options.modelType === 'class'
+          ? ` = ${property.property.options.const.value}`
+          : ''
+      };`;
     }
 
     return `${renderedProperty}: ${property.property.type};`;


### PR DESCRIPTION
Fixed an issue where a constant in an interface model type would try to assign a value to the variable, which resulted in invalid TypeScript. Tested with both class and interface modeltypes. Issue described in comments of #1471