### PR TITLE
fix: problem with json serializer option with C# generator

### DIFF
--- a/examples/csharp-generate-json-serializer/__snapshots__/index.spec.ts.snap
+++ b/examples/csharp-generate-json-serializer/__snapshots__/index.spec.ts.snap
@@ -65,7 +65,7 @@ internal class RootConverter : JsonConverter<Root>
   
     writer.WriteStartObject();
 
-    if(value.Email != null) { 
+    if(value.Email != null) {
       // write property name and let the serializer serialize the value itself
       writer.WritePropertyName(\\"email\\");
       JsonSerializer.Serialize(writer, value.Email, options);

--- a/src/generators/csharp/presets/JsonSerializerPreset.ts
+++ b/src/generators/csharp/presets/JsonSerializerPreset.ts
@@ -20,7 +20,7 @@ function renderSerializeProperty(
     model.property instanceof ConstrainedReferenceModel &&
     model.property.ref instanceof ConstrainedEnumModel
   ) {
-    value = `${model.property.type}.GetValue()`;
+    value = `value.${model.property.type}.GetValue()`;
   }
   return `JsonSerializer.Serialize(writer, ${value}, options);`;
 }
@@ -123,7 +123,7 @@ function renderDeserializeProperty(model: ConstrainedObjectPropertyModel) {
     model.property instanceof ConstrainedReferenceModel &&
     model.property.ref instanceof ConstrainedEnumModel
   ) {
-    return `${model.property.name}Extension.To${model.property.name}(JsonSerializer.Deserialize<dynamic>(ref reader, options))`;
+    return `${model.property.name}Extensions.To${model.property.name}(JsonSerializer.Deserialize<dynamic>(ref reader, options))`;
   }
   return `JsonSerializer.Deserialize<${model.property.type}>(ref reader, options)`;
 }

--- a/src/generators/csharp/presets/JsonSerializerPreset.ts
+++ b/src/generators/csharp/presets/JsonSerializerPreset.ts
@@ -51,7 +51,7 @@ if (${modelInstanceVariable} != null) {
   }
 }`;
       }
-      serializeProperties += `if(${modelInstanceVariable} != null) { 
+      serializeProperties += `if(${modelInstanceVariable} != null) {
   // write property name and let the serializer serialize the value itself
   writer.WritePropertyName("${propertyModel.unconstrainedPropertyName}");
   ${renderSerializeProperty(modelInstanceVariable, propertyModel)}

--- a/test/generators/csharp/presets/__snapshots__/JsonSerializerPreset.spec.ts.snap
+++ b/test/generators/csharp/presets/__snapshots__/JsonSerializerPreset.spec.ts.snap
@@ -114,22 +114,22 @@ internal class TestConverter : JsonConverter<Test>
   
     writer.WriteStartObject();
 
-    if(value.StringProp != null) { 
+    if(value.StringProp != null) {
       // write property name and let the serializer serialize the value itself
       writer.WritePropertyName(\\"string prop\\");
       JsonSerializer.Serialize(writer, value.StringProp, options);
     }
-    if(value.NumberProp != null) { 
+    if(value.NumberProp != null) {
       // write property name and let the serializer serialize the value itself
       writer.WritePropertyName(\\"numberProp\\");
       JsonSerializer.Serialize(writer, value.NumberProp, options);
     }
-    if(value.EnumProp != null) { 
+    if(value.EnumProp != null) {
       // write property name and let the serializer serialize the value itself
       writer.WritePropertyName(\\"enumProp\\");
-      JsonSerializer.Serialize(writer, EnumTest?.GetValue(), options);
+      JsonSerializer.Serialize(writer, value.EnumTest?.GetValue(), options);
     }
-    if(value.ObjectProp != null) { 
+    if(value.ObjectProp != null) {
       // write property name and let the serializer serialize the value itself
       writer.WritePropertyName(\\"objectProp\\");
       JsonSerializer.Serialize(writer, value.ObjectProp, options);
@@ -147,7 +147,7 @@ internal class TestConverter : JsonConverter<Test>
         writer.WritePropertyName(unwrappedProperty.Key);
         JsonSerializer.Serialize(writer, unwrappedProperty.Value, options);
       }
-    }if(value.AdditionalProperties != null) { 
+    }if(value.AdditionalProperties != null) {
       // write property name and let the serializer serialize the value itself
       writer.WritePropertyName(\\"additionalProperties\\");
       JsonSerializer.Serialize(writer, value.AdditionalProperties, options);
@@ -274,7 +274,7 @@ internal class NestedTestConverter : JsonConverter<NestedTest>
   
     writer.WriteStartObject();
 
-    if(value.StringProp != null) { 
+    if(value.StringProp != null) {
       // write property name and let the serializer serialize the value itself
       writer.WritePropertyName(\\"stringProp\\");
       JsonSerializer.Serialize(writer, value.StringProp, options);
@@ -292,7 +292,7 @@ internal class NestedTestConverter : JsonConverter<NestedTest>
         writer.WritePropertyName(unwrappedProperty.Key);
         JsonSerializer.Serialize(writer, unwrappedProperty.Value, options);
       }
-    }if(value.AdditionalProperties != null) { 
+    }if(value.AdditionalProperties != null) {
       // write property name and let the serializer serialize the value itself
       writer.WritePropertyName(\\"additionalProperties\\");
       JsonSerializer.Serialize(writer, value.AdditionalProperties, options);

--- a/test/generators/csharp/presets/__snapshots__/JsonSerializerPreset.spec.ts.snap
+++ b/test/generators/csharp/presets/__snapshots__/JsonSerializerPreset.spec.ts.snap
@@ -85,7 +85,7 @@ internal class TestConverter : JsonConverter<Test>
         }
       if (propertyName == \\"enumProp\\")
         {
-          var value = EnumTestExtension.ToEnumTest(JsonSerializer.Deserialize<dynamic>(ref reader, options));
+          var value = EnumTestExtensions.ToEnumTest(JsonSerializer.Deserialize<dynamic>(ref reader, options));
           instance.EnumProp = value;
           continue;
         }


### PR DESCRIPTION
**Description**

- Fix generation problem at 2 places when using C# generator with json serializer option
* Missing "s" for a class
* Missing "value." when deserializing.