### PR TITLE
fix: json serialization equals not working

### DIFF
--- a/examples/csharp-generate-json-serializer/__snapshots__/index.spec.ts.snap
+++ b/examples/csharp-generate-json-serializer/__snapshots__/index.spec.ts.snap
@@ -44,7 +44,7 @@ internal class RootConverter : JsonConverter<Root>
       }
 
       string propertyName = reader.GetString();
-      if (propertyName == \\"email\\")
+      if (string.Equals(propertyName, \\"email\\", StringComparison.OrdinalIgnoreCase))
         {
           var value = JsonSerializer.Deserialize<string?>(ref reader, options);
           instance.Email = value;

--- a/src/generators/csharp/presets/JsonSerializerPreset.ts
+++ b/src/generators/csharp/presets/JsonSerializerPreset.ts
@@ -144,7 +144,7 @@ function renderDeserializeProperties(model: ConstrainedObjectModel) {
       instance.${pascalProp}.Add(propertyName, deserializedValue);
       continue;`;
     }
-    return `if (propertyName == "${propModel.unconstrainedPropertyName}")
+    return `if (string.Equals(propertyName, "${propModel.unconstrainedPropertyName}", StringComparison.OrdinalIgnoreCase))
   {
     var value = ${renderDeserializeProperty(propModel)};
     instance.${pascalProp} = value;

--- a/test/generators/csharp/presets/JsonSerializerPreset.spec.ts
+++ b/test/generators/csharp/presets/JsonSerializerPreset.spec.ts
@@ -14,6 +14,7 @@ const doc = {
       $id: 'EnumTest',
       enum: ['Some enum String', true, { test: 'test' }, 2]
     },
+    NumberPropWithCapitalCase: { type: 'number' },
     objectProp: {
       type: 'object',
       $id: 'NestedTest',

--- a/test/generators/csharp/presets/__snapshots__/JsonSerializerPreset.spec.ts.snap
+++ b/test/generators/csharp/presets/__snapshots__/JsonSerializerPreset.spec.ts.snap
@@ -7,6 +7,7 @@ public class Test
   private string stringProp;
   private double? numberProp;
   private EnumTest? enumProp;
+  private double? numberPropWithCapitalCase;
   private NestedTest? objectProp;
   private Dictionary<string, dynamic>? additionalProperties;
 
@@ -26,6 +27,12 @@ public class Test
   {
     get { return enumProp; }
     set { enumProp = value; }
+  }
+
+  public double? NumberPropWithCapitalCase 
+  {
+    get { return numberPropWithCapitalCase; }
+    set { numberPropWithCapitalCase = value; }
   }
 
   public NestedTest? ObjectProp 
@@ -89,6 +96,12 @@ internal class TestConverter : JsonConverter<Test>
           instance.EnumProp = value;
           continue;
         }
+      if (string.Equals(propertyName, \\"NumberPropWithCapitalCase\\", StringComparison.OrdinalIgnoreCase))
+        {
+          var value = JsonSerializer.Deserialize<double?>(ref reader, options);
+          instance.NumberPropWithCapitalCase = value;
+          continue;
+        }
       if (string.Equals(propertyName, \\"objectProp\\", StringComparison.OrdinalIgnoreCase))
         {
           var value = JsonSerializer.Deserialize<NestedTest?>(ref reader, options);
@@ -128,6 +141,11 @@ internal class TestConverter : JsonConverter<Test>
       // write property name and let the serializer serialize the value itself
       writer.WritePropertyName(\\"enumProp\\");
       JsonSerializer.Serialize(writer, value.EnumTest?.GetValue(), options);
+    }
+    if(value.NumberPropWithCapitalCase != null) {
+      // write property name and let the serializer serialize the value itself
+      writer.WritePropertyName(\\"NumberPropWithCapitalCase\\");
+      JsonSerializer.Serialize(writer, value.NumberPropWithCapitalCase, options);
     }
     if(value.ObjectProp != null) {
       // write property name and let the serializer serialize the value itself

--- a/test/generators/csharp/presets/__snapshots__/JsonSerializerPreset.spec.ts.snap
+++ b/test/generators/csharp/presets/__snapshots__/JsonSerializerPreset.spec.ts.snap
@@ -71,25 +71,25 @@ internal class TestConverter : JsonConverter<Test>
       }
 
       string propertyName = reader.GetString();
-      if (propertyName == \\"string prop\\")
+      if (string.Equals(propertyName, \\"string prop\\", StringComparison.OrdinalIgnoreCase))
         {
           var value = JsonSerializer.Deserialize<string>(ref reader, options);
           instance.StringProp = value;
           continue;
         }
-      if (propertyName == \\"numberProp\\")
+      if (string.Equals(propertyName, \\"numberProp\\", StringComparison.OrdinalIgnoreCase))
         {
           var value = JsonSerializer.Deserialize<double?>(ref reader, options);
           instance.NumberProp = value;
           continue;
         }
-      if (propertyName == \\"enumProp\\")
+      if (string.Equals(propertyName, \\"enumProp\\", StringComparison.OrdinalIgnoreCase))
         {
           var value = EnumTestExtensions.ToEnumTest(JsonSerializer.Deserialize<dynamic>(ref reader, options));
           instance.EnumProp = value;
           continue;
         }
-      if (propertyName == \\"objectProp\\")
+      if (string.Equals(propertyName, \\"objectProp\\", StringComparison.OrdinalIgnoreCase))
         {
           var value = JsonSerializer.Deserialize<NestedTest?>(ref reader, options);
           instance.ObjectProp = value;
@@ -249,7 +249,7 @@ internal class NestedTestConverter : JsonConverter<NestedTest>
       }
 
       string propertyName = reader.GetString();
-      if (propertyName == \\"stringProp\\")
+      if (string.Equals(propertyName, \\"stringProp\\", StringComparison.OrdinalIgnoreCase))
         {
           var value = JsonSerializer.Deserialize<string?>(ref reader, options);
           instance.StringProp = value;


### PR DESCRIPTION
**Description**

When using serialization with Json with capital letters, it was not working. I fix it by ignoring case during the comparison.