### PR TITLE
feat!: generate models for OpenAPI parameters

### DIFF
--- a/src/processors/OpenAPIInputProcessor.ts
+++ b/src/processors/OpenAPIInputProcessor.ts
@@ -163,14 +163,16 @@ export class OpenAPIInputProcessor extends AbstractInputProcessor {
   }
 
   private iterateParameters(
-    parameters: (OpenAPIV3.ReferenceObject | OpenAPIV3.ParameterObject)[] | undefined,
+    parameters:
+      | (OpenAPIV3.ReferenceObject | OpenAPIV3.ParameterObject)[]
+      | undefined,
     path: string,
     inputModel: InputMetaModel,
     options?: ProcessorOptions
   ) {
     for (const parameterObject of parameters || []) {
       const parameter = parameterObject as OpenAPIV3.ParameterObject;
-      if(parameter.schema){
+      if (parameter.schema) {
         this.includeSchema(
           parameter.schema as OpenAPIV3.SchemaObject,
           `${path}_parameter_${parameter.in}_${parameter.name}`,

--- a/src/processors/OpenAPIInputProcessor.ts
+++ b/src/processors/OpenAPIInputProcessor.ts
@@ -101,6 +101,7 @@ export class OpenAPIInputProcessor extends AbstractInputProcessor {
         inputModel,
         options
       );
+      this.iterateParameters(pathObject.parameters, path, inputModel, options);
     }
   }
 
@@ -112,6 +113,7 @@ export class OpenAPIInputProcessor extends AbstractInputProcessor {
   ) {
     if (operation) {
       this.iterateResponses(operation.responses, path, inputModel, options);
+      this.iterateParameters(operation.parameters, path, inputModel, options);
 
       if (operation.requestBody) {
         this.iterateMediaType(
@@ -157,6 +159,25 @@ export class OpenAPIInputProcessor extends AbstractInputProcessor {
         inputModel,
         options
       );
+    }
+  }
+
+  private iterateParameters(
+    parameters: (OpenAPIV3.ReferenceObject | OpenAPIV3.ParameterObject)[] | undefined,
+    path: string,
+    inputModel: InputMetaModel,
+    options?: ProcessorOptions
+  ) {
+    for (const parameterObject of parameters || []) {
+      const parameter = parameterObject as OpenAPIV3.ParameterObject;
+      if(parameter.schema){
+        this.includeSchema(
+          parameter.schema as OpenAPIV3.SchemaObject,
+          `${path}_parameter_${parameter.in}_${parameter.name}`,
+          inputModel,
+          options
+        );
+      }
     }
   }
 

--- a/src/processors/OpenAPIInputProcessor.ts
+++ b/src/processors/OpenAPIInputProcessor.ts
@@ -101,7 +101,12 @@ export class OpenAPIInputProcessor extends AbstractInputProcessor {
         inputModel,
         options
       );
-      this.iterateParameters(pathObject.parameters, path, inputModel, options);
+      this.iterateParameters(
+        pathObject.parameters,
+        `${formattedPathName}_parameters`,
+        inputModel,
+        options
+      );
     }
   }
 
@@ -113,7 +118,12 @@ export class OpenAPIInputProcessor extends AbstractInputProcessor {
   ) {
     if (operation) {
       this.iterateResponses(operation.responses, path, inputModel, options);
-      this.iterateParameters(operation.parameters, path, inputModel, options);
+      this.iterateParameters(
+        operation.parameters,
+        `${path}_parameters`,
+        inputModel,
+        options
+      );
 
       if (operation.requestBody) {
         this.iterateMediaType(
@@ -175,7 +185,7 @@ export class OpenAPIInputProcessor extends AbstractInputProcessor {
       if (parameter.schema) {
         this.includeSchema(
           parameter.schema as OpenAPIV3.SchemaObject,
-          `${path}_parameter_${parameter.in}_${parameter.name}`,
+          `${path}_${parameter.in}_${parameter.name}`,
           inputModel,
           options
         );

--- a/test/processors/OpenAPIInputProcessor/basic.json
+++ b/test/processors/OpenAPIInputProcessor/basic.json
@@ -5,6 +5,17 @@
   },
   "paths": {
     "/test": {
+      "parameters": [
+        {
+          "name": "Authorization",
+          "in": "header",
+          "required": true,
+          "description": "credentials that authenticate a user agent with a server",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "post": {
         "parameters": [
           {

--- a/test/processors/__snapshots__/OpenAPIInputProcessor.spec.ts.snap
+++ b/test/processors/__snapshots__/OpenAPIInputProcessor.spec.ts.snap
@@ -568,7 +568,7 @@ Array [
       "format": "uri",
       "type": "string",
     },
-    "test_post_parameter_query_callbackUrl",
+    "test_post_parameters_query_callbackUrl",
   ],
   Array [
     Object {
@@ -790,7 +790,7 @@ Array [
     Object {
       "type": "string",
     },
-    "/test_parameter_header_Authorization",
+    "test_parameters_header_Authorization",
   ],
 ]
 `;

--- a/test/processors/__snapshots__/OpenAPIInputProcessor.spec.ts.snap
+++ b/test/processors/__snapshots__/OpenAPIInputProcessor.spec.ts.snap
@@ -197,6 +197,17 @@ InputMetaModel {
             },
           },
         },
+        "parameters": Array [
+          Object {
+            "description": "credentials that authenticate a user agent with a server",
+            "in": "header",
+            "name": "Authorization",
+            "required": true,
+            "schema": Object {
+              "type": "string",
+            },
+          },
+        ],
         "patch": Object {
           "requestBody": Object {
             "content": Object {
@@ -554,6 +565,13 @@ Array [
   ],
   Array [
     Object {
+      "format": "uri",
+      "type": "string",
+    },
+    "test_post_parameter_query_callbackUrl",
+  ],
+  Array [
+    Object {
       "properties": Object {
         "code": Object {
           "format": "int32",
@@ -767,6 +785,12 @@ Array [
       "type": "object",
     },
     "test_trace_application_json",
+  ],
+  Array [
+    Object {
+      "type": "string",
+    },
+    "/test_parameter_header_Authorization",
   ],
 ]
 `;


### PR DESCRIPTION
**Description**
Models that were only present in OpenAPIV3 parameters were not being generated. This was causing problems for parameters with schema like `enum` that can be reflected in the language type system.
