### PR TITLE
fix!: fixes java jackson discriminator when property is not camel case

### DIFF
--- a/src/generators/java/presets/JacksonPreset.ts
+++ b/src/generators/java/presets/JacksonPreset.ts
@@ -103,11 +103,16 @@ ${content}`;
               union instanceof ConstrainedReferenceModel &&
               union.ref instanceof ConstrainedObjectModel
             ) {
-              const discriminatorProp =
-                union.ref.properties[discriminator.discriminator].property;
+              const discriminatorProp = Object.values(
+                union.ref.properties
+              ).find(
+                (model) =>
+                  model.unconstrainedPropertyName ===
+                  discriminator.discriminator
+              );
 
-              if (discriminatorProp.options.const) {
-                return `  @JsonSubTypes.Type(value = ${union.name}.class, name = "${discriminatorProp.options.const.originalInput}")`;
+              if (discriminatorProp?.property.options.const) {
+                return `  @JsonSubTypes.Type(value = ${union.name}.class, name = "${discriminatorProp.property.options.const.originalInput}")`;
               }
             }
 

--- a/test/generators/java/presets/JacksonPreset.spec.ts
+++ b/test/generators/java/presets/JacksonPreset.spec.ts
@@ -1,4 +1,3 @@
-import { AsyncapiV2Schema } from '../../../../src';
 import { JavaGenerator, JAVA_JACKSON_PRESET } from '../../../../src/generators';
 
 describe('JAVA_JACKSON_PRESET', () => {
@@ -59,7 +58,7 @@ describe('JAVA_JACKSON_PRESET', () => {
             Vehicle: {
               payload: {
                 title: 'Vehicle',
-                discriminator: 'vehicleType',
+                discriminator: 'vehicle_type',
                 oneOf: [
                   { $ref: '#/components/schemas/Car' },
                   { $ref: '#/components/schemas/Truck' }
@@ -72,7 +71,7 @@ describe('JAVA_JACKSON_PRESET', () => {
               title: 'Car',
               type: 'object',
               properties: {
-                vehicleType: { type: 'string' },
+                vehicle_type: { type: 'string' },
                 name: { type: 'string' }
               }
             },
@@ -80,7 +79,7 @@ describe('JAVA_JACKSON_PRESET', () => {
               title: 'Truck',
               type: 'object',
               properties: {
-                vehicleType: { type: 'string' },
+                vehicle_type: { type: 'string' },
                 name: { type: 'string' }
               }
             }

--- a/test/generators/java/presets/__snapshots__/JacksonPreset.spec.ts.snap
+++ b/test/generators/java/presets/__snapshots__/JacksonPreset.spec.ts.snap
@@ -55,7 +55,7 @@ exports[`JAVA_JACKSON_PRESET should render Jackson annotations for enum 1`] = `
 
 exports[`JAVA_JACKSON_PRESET union handle oneOf with AsyncAPI discriminator with Jackson 1`] = `
 Array [
-  "@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.EXISTING_PROPERTY, property=\\"vehicleType\\", visible=true)
+  "@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.EXISTING_PROPERTY, property=\\"vehicle_type\\", visible=true)
 @JsonSubTypes({
   @JsonSubTypes.Type(value = Car.class, name = \\"Car\\"),
   @JsonSubTypes.Type(value = Truck.class, name = \\"Truck\\")
@@ -64,10 +64,10 @@ Array [
  * Vehicle represents a union of types: Car, Truck
  */
 public interface Vehicle {
-  String getVehicleType();
+  
 }",
   "public class Car implements Vehicle {
-  @JsonProperty(\\"vehicleType\\")
+  @JsonProperty(\\"vehicle_type\\")
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String vehicleType;
   @JsonProperty(\\"name\\")
@@ -86,7 +86,7 @@ public interface Vehicle {
   public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
 }",
   "public class Truck implements Vehicle {
-  @JsonProperty(\\"vehicleType\\")
+  @JsonProperty(\\"vehicle_type\\")
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String vehicleType;
   @JsonProperty(\\"name\\")


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- fixes Java Jackson discriminator when the property is not camel case. You get a runtime error without this fix.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->