### PR TITLE
fix: escape java string literals used for regex patterns and string constants

### DIFF
--- a/src/generators/java/JavaRenderer.ts
+++ b/src/generators/java/JavaRenderer.ts
@@ -54,4 +54,19 @@ ${newLiteral}
     }
     return values !== undefined ? `${name}(${values})` : name;
   }
+
+  static renderStringLiteral(value: string): string {
+    const escaped = value
+      .replace(/\\/g, '\\\\')
+      .replace(/\t/g, '\\t')
+      .replace(/\n/g, '\\n')
+      .replace(/\r/g, '\\r')
+      .replace(/\f/g, '\\f')
+      .replace(/"/g, '\\"');
+    return `"${escaped}"`;
+  }
+
+  renderStringLiteral(value: string): string {
+    return JavaRenderer.renderStringLiteral(value);
+  }
 }

--- a/src/generators/java/constrainer/ConstantConstrainer.ts
+++ b/src/generators/java/constrainer/ConstantConstrainer.ts
@@ -6,6 +6,7 @@ import {
   ConstrainedStringModel
 } from '../../../models';
 import { ConstantConstraint } from '../../../helpers';
+import { JavaRenderer } from '../JavaRenderer';
 
 const getConstrainedEnumModelConstant = (args: {
   constrainedMetaModel: ConstrainedMetaModel;
@@ -45,7 +46,7 @@ export function defaultConstantConstraints(): ConstantConstraint {
         constOptions
       });
     } else if (constrainedMetaModel instanceof ConstrainedStringModel) {
-      return `"${constOptions.originalInput}"`;
+      return JavaRenderer.renderStringLiteral(`${constOptions.originalInput}`);
     }
 
     return undefined;

--- a/src/generators/java/presets/ConstraintsPreset.ts
+++ b/src/generators/java/presets/ConstraintsPreset.ts
@@ -33,7 +33,9 @@ export const JAVA_CONSTRAINTS_PRESET: JavaPreset = {
         const pattern = originalInput['pattern'];
         if (pattern !== undefined) {
           annotations.push(
-            renderer.renderAnnotation('Pattern', { regexp: `"${pattern}"` })
+            renderer.renderAnnotation('Pattern', {
+              regexp: renderer.renderStringLiteral(pattern)
+            })
           );
         }
         const minLength = originalInput['minLength'];

--- a/test/generators/java/JavaRenderer.spec.ts
+++ b/test/generators/java/JavaRenderer.spec.ts
@@ -36,4 +36,16 @@ describe('JavaRenderer', () => {
       ).toEqual('@SomeComment(test=test2)');
     });
   });
+
+  describe('renderStringLiteral()', () => {
+    test('Should be able to render string literal with special characters', () => {
+      expect(
+        renderer.renderStringLiteral(
+          'this is a "literal" string with \'special\' characters: \\a\n\t\\b'
+        )
+      ).toEqual(
+        '"this is a \\"literal\\" string with \'special\' characters: \\\\a\\n\\t\\\\b"'
+      );
+    });
+  });
 });

--- a/test/generators/java/presets/ConstraintsPreset.spec.ts
+++ b/test/generators/java/presets/ConstraintsPreset.spec.ts
@@ -17,7 +17,11 @@ describe('JAVA_CONSTRAINTS_PRESET', () => {
         min_number_prop: { type: 'number', minimum: 0 },
         max_number_prop: { type: 'number', exclusiveMaximum: 100 },
         array_prop: { type: 'array', minItems: 2, maxItems: 3 },
-        string_prop: { type: 'string', pattern: '^I_', minLength: 3 }
+        string_prop: {
+          type: 'string',
+          pattern: '^\\w+("\\.\\w+)*$',
+          minLength: 3
+        }
       },
       required: ['min_number_prop', 'max_number_prop']
     };

--- a/test/generators/java/presets/__snapshots__/ConstraintsPreset.spec.ts.snap
+++ b/test/generators/java/presets/__snapshots__/ConstraintsPreset.spec.ts.snap
@@ -10,7 +10,7 @@ exports[`JAVA_CONSTRAINTS_PRESET should render constraints annotations 1`] = `
   private double maxNumberProp;
   @Size(min=2, max=3)
   private Object[] arrayProp;
-  @Pattern(regexp=\\"^I_\\")
+  @Pattern(regexp=\\"^\\\\\\\\w+(\\\\\\"\\\\\\\\.\\\\\\\\w+)*$\\")
   @Size(min=3)
   private String stringProp;
   private Map<String, Object> additionalProperties;


### PR DESCRIPTION
**Description**

- Java string constants were being rendered without escaping. This could generate invalid java. This was a particular issue for regex patters as these frequently include the `\` character
