### PR TITLE
chore: remove isAsyncAPIOwner field from .asyncapi-tool

### DIFF
--- a/.asyncapi-tool
+++ b/.asyncapi-tool
@@ -10,7 +10,6 @@
     "language": "TypeScript",
     "technology": ["React JS", "Docker"],
     "categories": ["code-generator"],
-    "hasCommercial": false,
-    "isAsyncAPIOwner": true
+    "hasCommercial": false
   }
 }


### PR DESCRIPTION


**Description**

- Removes field to prevent script from failing to add it to asyncapi website

**Related issue(s)**
Fixes https://github.com/asyncapi/modelina/issues/1555