### PR TITLE
fix: downgrade AnyModel error to a warning (#1561)

### DIFF
--- a/src/helpers/CommonModelToMetaModel.ts
+++ b/src/helpers/CommonModelToMetaModel.ts
@@ -92,7 +92,7 @@ export function convertToMetaModel(
   if (booleanModel !== undefined) {
     return booleanModel;
   }
-  Logger.error('Failed to convert to MetaModel, defaulting to AnyModel');
+  Logger.warn('Failed to convert to MetaModel, defaulting to AnyModel');
   return new AnyModel(modelName, jsonSchemaModel.originalInput);
 }
 function isEnumModel(jsonSchemaModel: CommonModel): boolean {


### PR DESCRIPTION
**Downgrade AnyModel error to a warning**

This is needed to prevent the asyncapi CLI from aborting when an AnyModel is encountered.

**Related issue(s)**
Resolves #1561. 
