### PR TITLE
feat!: convert to use multi parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,8 @@
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^9.0.9",
         "@apidevtools/swagger-parser": "^10.0.3",
-        "@asyncapi/avro-schema-parser": "^3.0.2",
-        "@asyncapi/openapi-schema-parser": "^3.0.5",
         "@asyncapi/parser": "^2.1.0",
-        "@asyncapi/raml-dt-schema-parser": "^4.0.4",
+        "@smoya/multi-parser": "^4.0.0",
         "@swc/core": "^1.3.5",
         "@swc/jest": "^0.2.23",
         "@types/node": "^20.3.3",
@@ -99,11 +97,11 @@
       }
     },
     "node_modules/@asyncapi/avro-schema-parser": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@asyncapi/avro-schema-parser/-/avro-schema-parser-3.0.2.tgz",
-      "integrity": "sha512-TZZedLaflgyYivwidJPqTN2LMk+Lqg0IByXtdzNYQZLNpLpcyEnXCxongoW0TVYgYGLWAghN3AmMOrrsVcGGOw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@asyncapi/avro-schema-parser/-/avro-schema-parser-3.0.4.tgz",
+      "integrity": "sha512-2EwTS+0deHsqIJG41dJGE2/O9pD1RJZpUCahz24tgZzcK/GQM1HBuoVvqBkPcloS9EeOXo/ZcfCMAvflj5UB/g==",
       "dependencies": {
-        "@asyncapi/parser": "^2.0.3",
+        "@asyncapi/parser": "^2.1.1",
         "@types/json-schema": "^7.0.11",
         "avsc": "^5.7.6"
       }
@@ -231,6 +229,16 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@asyncapi/protobuf-schema-parser": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@asyncapi/protobuf-schema-parser/-/protobuf-schema-parser-3.0.1.tgz",
+      "integrity": "sha512-w6y7/jvnCBwwhAee7/uv6Cb31YAbDm3I6V9s7Jj+MSStA91WOEq1rOFm4YHdJ23oYFbWaQmc5+8MLTnQBGfc4Q==",
+      "dependencies": {
+        "@asyncapi/parser": "^2.1.1",
+        "@types/protocol-buffers-schema": "^3.4.1",
+        "protocol-buffers-schema": "^3.6.0"
       }
     },
     "node_modules/@asyncapi/raml-dt-schema-parser": {
@@ -1820,6 +1828,19 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "node_modules/@smoya/multi-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smoya/multi-parser/-/multi-parser-4.1.0.tgz",
+      "integrity": "sha512-0q4805I7ZdkKNEbNrbxmBNAdYEAH9aBYCuXiIXCbu8WC0sdRqLWmTsvg/DaNO8ZnsrGhVzy5VITf+8CKlVnGoQ==",
+      "dependencies": {
+        "@asyncapi/avro-schema-parser": "^3.0.3",
+        "@asyncapi/openapi-schema-parser": "^3.0.4",
+        "@asyncapi/protobuf-schema-parser": "^3.0.0",
+        "@asyncapi/raml-dt-schema-parser": "^4.0.4",
+        "parserv2": "npm:@asyncapi/parser@^2.1.0",
+        "parserv3": "npm:@asyncapi/parser@^3.0.0-next-major-spec.3"
+      }
+    },
     "node_modules/@stoplight/better-ajv-errors": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@stoplight/better-ajv-errors/-/better-ajv-errors-1.0.3.tgz",
@@ -2283,6 +2304,14 @@
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.1.tgz",
       "integrity": "sha512-Fo79ojj3vdEZOHg3wR9ksAMRz4P3S5fDB5e/YWZiFnyFQI1WY2Vftu9XoXVVtJfxB7Bpce/QTqWSSntkz2Znrw==",
       "dev": true
+    },
+    "node_modules/@types/protocol-buffers-schema": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@types/protocol-buffers-schema/-/protocol-buffers-schema-3.4.2.tgz",
+      "integrity": "sha512-GaQpfsfFk4wGU3//d7uCGy9zy6B8QBEyWYd6+maZH+S6m861QrFvLWS5RyHj4UfIiON9tmqCz9C+oNpebDgGIw==",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/semver": {
       "version": "7.5.3",
@@ -9447,6 +9476,97 @@
       "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
       "dev": true
     },
+    "node_modules/parserv2": {
+      "name": "@asyncapi/parser",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-2.1.1.tgz",
+      "integrity": "sha512-FnJ5Du9iMu9MEb5mF90gF7z1ZkdnazisBsm3GHVFr7VaiF8luAoB+bklGYFwoMb+9QWKWr1099orY5VyXULAcQ==",
+      "dependencies": {
+        "@asyncapi/specs": "^5.1.0",
+        "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
+        "@stoplight/json": "^3.20.2",
+        "@stoplight/json-ref-readers": "^1.2.2",
+        "@stoplight/json-ref-resolver": "^3.1.5",
+        "@stoplight/spectral-core": "^1.16.1",
+        "@stoplight/spectral-functions": "^1.7.2",
+        "@stoplight/spectral-parsers": "^1.0.2",
+        "@stoplight/spectral-ref-resolver": "^1.0.3",
+        "@stoplight/types": "^13.12.0",
+        "@types/json-schema": "^7.0.11",
+        "@types/urijs": "^1.19.19",
+        "ajv": "^8.11.0",
+        "ajv-errors": "^3.0.0",
+        "ajv-formats": "^2.1.1",
+        "avsc": "^5.7.5",
+        "js-yaml": "^4.1.0",
+        "jsonpath-plus": "^7.2.0",
+        "node-fetch": "2.6.7",
+        "ramldt2jsonschema": "^1.2.3",
+        "webapi-parser": "^0.5.0"
+      }
+    },
+    "node_modules/parserv2/node_modules/@asyncapi/specs": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-5.1.0.tgz",
+      "integrity": "sha512-yffhETqehkim43luMnPKOwzY0D0YtU4bKpORIXIaid6p5Y5kDLrMGJaEPkNieQp03HMjhjFrnUPtT8kvqe0+aQ==",
+      "dependencies": {
+        "@types/json-schema": "^7.0.11"
+      }
+    },
+    "node_modules/parserv2/node_modules/@stoplight/json": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@stoplight/json/-/json-3.21.0.tgz",
+      "integrity": "sha512-5O0apqJ/t4sIevXCO3SBN9AHCEKKR/Zb4gaj7wYe5863jme9g02Q0n/GhM7ZCALkL+vGPTe4ZzTETP8TFtsw3g==",
+      "dependencies": {
+        "@stoplight/ordered-object-literal": "^1.0.3",
+        "@stoplight/path": "^1.3.2",
+        "@stoplight/types": "^13.6.0",
+        "jsonc-parser": "~2.2.1",
+        "lodash": "^4.17.21",
+        "safe-stable-stringify": "^1.1"
+      },
+      "engines": {
+        "node": ">=8.3.0"
+      }
+    },
+    "node_modules/parserv2/node_modules/safe-stable-stringify": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-1.1.1.tgz",
+      "integrity": "sha512-ERq4hUjKDbJfE4+XtZLFPCDi8Vb1JqaxAPTxWFLBx8XcAlf9Bda/ZJdVezs/NAfsMQScyIlUMx+Yeu7P7rx5jw=="
+    },
+    "node_modules/parserv3": {
+      "name": "@asyncapi/parser",
+      "version": "3.0.0-next-major-spec.7",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.0-next-major-spec.7.tgz",
+      "integrity": "sha512-iCVCd66h6NXrIVu7aK5RwGuJ4g1j+qD88xxejUwczbpGbhJkuZUzF5jReWNNAizETJttnAwW0rBKjZF4HVqOiQ==",
+      "dependencies": {
+        "@asyncapi/specs": "^6.0.0-next-major-spec.9",
+        "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
+        "@stoplight/json-ref-resolver": "^3.1.5",
+        "@stoplight/spectral-core": "^1.16.1",
+        "@stoplight/spectral-functions": "^1.7.2",
+        "@stoplight/spectral-parsers": "^1.0.2",
+        "@types/json-schema": "^7.0.11",
+        "@types/urijs": "^1.19.19",
+        "ajv": "^8.11.0",
+        "ajv-errors": "^3.0.0",
+        "ajv-formats": "^2.1.1",
+        "avsc": "^5.7.5",
+        "js-yaml": "^4.1.0",
+        "jsonpath-plus": "^7.2.0",
+        "node-fetch": "2.6.7",
+        "ramldt2jsonschema": "^1.2.3",
+        "webapi-parser": "^0.5.0"
+      }
+    },
+    "node_modules/parserv3/node_modules/@asyncapi/specs": {
+      "version": "6.0.0-next-major-spec.10",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.0.0-next-major-spec.10.tgz",
+      "integrity": "sha512-flxUofPHdLDfbnfkLzqMPjbCj4EJTxg8q9Xxkt9hsO7BDRUDQk5C7RRBfe+HxAstl0LghX1DAQcof3+GPEXuFA==",
+      "dependencies": {
+        "@types/json-schema": "^7.0.11"
+      }
+    },
     "node_modules/pascal-case": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
@@ -9708,6 +9828,11 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/protocol-buffers-schema": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
+      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw=="
     },
     "node_modules/psl": {
       "version": "1.8.0",

--- a/package.json
+++ b/package.json
@@ -37,10 +37,8 @@
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^9.0.9",
     "@apidevtools/swagger-parser": "^10.0.3",
-    "@asyncapi/avro-schema-parser": "^3.0.2",
-    "@asyncapi/openapi-schema-parser": "^3.0.5",
+    "@smoya/multi-parser": "^4.0.0",
     "@asyncapi/parser": "^2.1.0",
-    "@asyncapi/raml-dt-schema-parser": "^4.0.4",
     "@swc/core": "^1.3.5",
     "@swc/jest": "^0.2.23",
     "@types/node": "^20.3.3",

--- a/src/processors/AsyncAPIInputProcessor.ts
+++ b/src/processors/AsyncAPIInputProcessor.ts
@@ -1,38 +1,27 @@
 /* eslint-disable no-undef */
 /* eslint-disable @typescript-eslint/no-var-requires */
 import {
-  createAsyncAPIDocument,
   isAsyncAPIDocument,
   isOldAsyncAPIDocument,
-  Parser,
   AsyncAPIDocumentInterface,
   SchemaInterface as AsyncAPISchemaInterface,
-  SchemaV2 as AsyncAPISchema
+  SchemaV2 as AsyncAPISchema,
+  createAsyncAPIDocument
 } from '@asyncapi/parser';
-import { AsyncAPISchemaObject } from '@asyncapi/parser/cjs/spec-types/v2';
-import { AvroSchemaParser } from '@asyncapi/avro-schema-parser';
-import { OpenAPISchemaParser } from '@asyncapi/openapi-schema-parser';
-import { RamlDTSchemaParser } from '@asyncapi/raml-dt-schema-parser';
-import { createDetailedAsyncAPI } from '@asyncapi/parser/cjs/utils';
+
 import { AbstractInputProcessor } from './AbstractInputProcessor';
 import { JsonSchemaInputProcessor } from './JsonSchemaInputProcessor';
 import { InputMetaModel, ProcessorOptions, UnionModel } from '../models';
 import { Logger } from '../utils';
 import { AsyncapiV2Schema } from '../models/AsyncapiV2Schema';
 import { convertToMetaModel } from '../helpers';
+import { NewParser } from '@smoya/multi-parser';
+import { createDetailedAsyncAPI } from '@asyncapi/parser/cjs/utils';
 
 /**
  * Class for processing AsyncAPI inputs
  */
 export class AsyncAPIInputProcessor extends AbstractInputProcessor {
-  private parser = new Parser();
-  constructor() {
-    super();
-    this.parser.registerSchemaParser(AvroSchemaParser());
-    this.parser.registerSchemaParser(OpenAPISchemaParser());
-    this.parser.registerSchemaParser(RamlDTSchemaParser());
-  }
-
   static supportedVersions = [
     '2.0.0',
     '2.1.0',
@@ -60,15 +49,25 @@ export class AsyncAPIInputProcessor extends AbstractInputProcessor {
     }
 
     Logger.debug('Processing input as an AsyncAPI document');
-    let doc: AsyncAPIDocumentInterface;
+    let doc: AsyncAPIDocumentInterface | undefined;
     const inputModel = new InputMetaModel();
-    if (!AsyncAPIInputProcessor.isFromParser(input)) {
-      const { document, diagnostics } = await this.parser.parse(
-        input as any,
-        options?.asyncapi || {}
+    if (isOldAsyncAPIDocument(input)) {
+      // Is from old parser
+      const parsedJSON = input.json();
+      const detailed = createDetailedAsyncAPI(parsedJSON, parsedJSON);
+      doc = createAsyncAPIDocument(detailed);
+    } else {
+      const parserOptions = options?.asyncapi || {};
+      const parser = NewParser(1, {
+        parserOptions,
+        includeSchemaParsers: true
+      });
+      const { document, diagnostics } = await parser.parse(
+        input,
+        parserOptions
       );
       if (document) {
-        doc = document;
+        doc = document as AsyncAPIDocumentInterface;
       } else {
         const err = new Error(
           'Input is not an correct AsyncAPI document so it cannot be processed.'
@@ -76,13 +75,9 @@ export class AsyncAPIInputProcessor extends AbstractInputProcessor {
         (err as any).diagnostics = diagnostics;
         throw err;
       }
-    } else if (AsyncAPIInputProcessor.isFromNewParser(input)) {
-      doc = input as AsyncAPIDocumentInterface;
-    } else {
-      // Is from old parser
-      const parsedJSON = input.json();
-      const detailed = createDetailedAsyncAPI(parsedJSON, parsedJSON);
-      doc = createAsyncAPIDocument(detailed);
+    }
+    if (!doc) {
+      throw new Error('Could not parse input as AsyncAPI document');
     }
 
     inputModel.originalInput = doc;
@@ -134,7 +129,7 @@ export class AsyncAPIInputProcessor extends AbstractInputProcessor {
 
           // treat multiple messages as oneOf
           if (operationMessages.length > 1) {
-            const oneOf: AsyncAPISchemaObject[] = [];
+            const oneOf: any[] = [];
 
             for (const message of operationMessages) {
               const payload = message.payload();
@@ -226,21 +221,21 @@ export class AsyncAPIInputProcessor extends AbstractInputProcessor {
     if (schema.allOf()) {
       convertedSchema.allOf = schema
         .allOf()!
-        .map((item) =>
+        .map((item: any) =>
           this.convertToInternalSchema(item, alreadyIteratedSchemas)
         );
     }
     if (schema.oneOf()) {
       convertedSchema.oneOf = schema
         .oneOf()!
-        .map((item) =>
+        .map((item: any) =>
           this.convertToInternalSchema(item, alreadyIteratedSchemas)
         );
     }
     if (schema.anyOf()) {
       convertedSchema.anyOf = schema
         .anyOf()!
-        .map((item) =>
+        .map((item: any) =>
           this.convertToInternalSchema(item, alreadyIteratedSchemas)
         );
     }


### PR DESCRIPTION
**Description**
This prepares modelina to be able to handle multiple parser versions. At some point in the future, I will update the underlying parser API we use to v2 instead of v1, so we automatically support v3.

I am marking this as a breaking change, ONLY because there might be edge cases, however, as you see I did not change any tests and still they pass.

**Related issue(s)**
Fixes https://github.com/asyncapi/modelina/issues/1493