### PR TITLE
fix: multi line descriptions for the pydantic preset in python

### DIFF
--- a/examples/generate-python-pydantic-models/__snapshots__/index.spec.ts.snap
+++ b/examples/generate-python-pydantic-models/__snapshots__/index.spec.ts.snap
@@ -3,8 +3,8 @@
 exports[`Should be able to render python models and should log expected output to console: class-model 1`] = `
 Array [
   "class Root(BaseModel): 
-  optionalField: Optional[str] = Field(alias='this field is optional')
-  requiredField: str = Field(alias='this field is required')
+  optionalField: Optional[str] = Field(alias='''this field is optional''')
+  requiredField: str = Field(alias='''this field is required''')
   noDescription: Optional[str] = Field()
   options: Optional[Options] = Field()
 ",

--- a/src/generators/python/presets/Pydantic.ts
+++ b/src/generators/python/presets/Pydantic.ts
@@ -22,7 +22,7 @@ const PYTHON_PYDANTIC_CLASS_PRESET: ClassPresetType<PythonOptions> = {
       ? params.property.property.type
       : `Optional[${params.property.property.type}]`;
     const alias = params.property.property.originalInput['description']
-      ? `alias='${params.property.property.originalInput['description']}'`
+      ? `alias='''${params.property.property.originalInput['description']}'''`
       : '';
 
     return `${params.property.propertyName}: ${type} = Field(${alias})`;

--- a/test/generators/python/presets/Pydantic.spec.ts
+++ b/test/generators/python/presets/Pydantic.spec.ts
@@ -1,0 +1,34 @@
+import {
+  PythonGenerator,
+  PYTHON_PYDANTIC_PRESET
+} from '../../../../src/generators/python';
+
+describe('PYTHON_PYDANTIC_PRESET', () => {
+  let generator: PythonGenerator;
+
+  beforeEach(() => {
+    generator = new PythonGenerator({
+      presets: [PYTHON_PYDANTIC_PRESET]
+    });
+  });
+
+  test('should render pydantic for class', async () => {
+    const doc = {
+      title: 'Test',
+      type: 'object',
+      properties: {
+        prop: {
+          description: `test
+  multi
+  line
+  description`,
+          type: 'string'
+        }
+      }
+    };
+
+    const models = await generator.generate(doc);
+    expect(models).toHaveLength(1);
+    expect(models[0].result).toMatchSnapshot();
+  });
+});

--- a/test/generators/python/presets/__snapshots__/Pydantic.spec.ts.snap
+++ b/test/generators/python/presets/__snapshots__/Pydantic.spec.ts.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PYTHON_PYDANTIC_PRESET should render pydantic for class 1`] = `
+"class Test(BaseModel): 
+  prop: Optional[str] = Field(alias='''test
+    multi
+    line
+    description''')
+  additionalProperties: Optional[dict[Any, Any]] = Field()
+"
+`;


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- fixes multi-line descriptions for the Pydantic preset in Python

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->
Fixes #1058 