### PR TITLE
fix: make number default type instead of double for float in java

### DIFF
--- a/examples/java-from-typescript-type/__snapshots__/index.spec.ts.snap
+++ b/examples/java-from-typescript-type/__snapshots__/index.spec.ts.snap
@@ -3,13 +3,13 @@
 exports[`Should be able to generate Java model from a TypeScript type file and should log expected output to console 1`] = `
 Array [
   "public class InnerData {
-  private number age;
+  private Number age;
   private String name;
   private boolean free;
   private Map<String, Object> additionalProperties;
 
-  public number getAge() { return this.age; }
-  public void setAge(number age) { this.age = age; }
+  public Number getAge() { return this.age; }
+  public void setAge(Number age) { this.age = age; }
 
   public String getName() { return this.name; }
   public void setName(String name) { this.name = name; }

--- a/examples/java-from-typescript-type/__snapshots__/index.spec.ts.snap
+++ b/examples/java-from-typescript-type/__snapshots__/index.spec.ts.snap
@@ -3,13 +3,13 @@
 exports[`Should be able to generate Java model from a TypeScript type file and should log expected output to console 1`] = `
 Array [
   "public class InnerData {
-  private double age;
+  private number age;
   private String name;
   private boolean free;
   private Map<String, Object> additionalProperties;
 
-  public double getAge() { return this.age; }
-  public void setAge(double age) { this.age = age; }
+  public number getAge() { return this.age; }
+  public void setAge(number age) { this.age = age; }
 
   public String getName() { return this.name; }
   public void setName(String name) { this.name = name; }

--- a/examples/java-generate-jackson-annotation/__snapshots__/index.spec.ts.snap
+++ b/examples/java-generate-jackson-annotation/__snapshots__/index.spec.ts.snap
@@ -5,18 +5,18 @@ Array [
   "public class Root {
   @JsonProperty(\\"min_number_prop\\")
   @JsonInclude(JsonInclude.Include.NON_NULL)
-  private Double minNumberProp;
+  private Number minNumberProp;
   @JsonProperty(\\"max_number_prop\\")
   @JsonInclude(JsonInclude.Include.NON_NULL)
-  private Double maxNumberProp;
+  private Number maxNumberProp;
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Map<String, Object> additionalProperties;
 
-  public Double getMinNumberProp() { return this.minNumberProp; }
-  public void setMinNumberProp(Double minNumberProp) { this.minNumberProp = minNumberProp; }
+  public Number getMinNumberProp() { return this.minNumberProp; }
+  public void setMinNumberProp(Number minNumberProp) { this.minNumberProp = minNumberProp; }
 
-  public Double getMaxNumberProp() { return this.maxNumberProp; }
-  public void setMaxNumberProp(Double maxNumberProp) { this.maxNumberProp = maxNumberProp; }
+  public Number getMaxNumberProp() { return this.maxNumberProp; }
+  public void setMaxNumberProp(Number maxNumberProp) { this.maxNumberProp = maxNumberProp; }
 
   public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
   public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }

--- a/examples/java-generate-javax-constraint-annotation/__snapshots__/index.spec.ts.snap
+++ b/examples/java-generate-javax-constraint-annotation/__snapshots__/index.spec.ts.snap
@@ -5,10 +5,10 @@ Array [
   "public class JavaxAnnotation {
   @NotNull
   @Min(0)
-  private double minNumberProp;
+  private number minNumberProp;
   @NotNull
   @Max(99)
-  private double maxNumberProp;
+  private number maxNumberProp;
   @Size(min=2, max=3)
   private Object[] arrayProp;
   @Pattern(regexp=\\"^I_\\")
@@ -16,11 +16,11 @@ Array [
   private String stringProp;
   private Map<String, Object> additionalProperties;
 
-  public double getMinNumberProp() { return this.minNumberProp; }
-  public void setMinNumberProp(double minNumberProp) { this.minNumberProp = minNumberProp; }
+  public number getMinNumberProp() { return this.minNumberProp; }
+  public void setMinNumberProp(number minNumberProp) { this.minNumberProp = minNumberProp; }
 
-  public double getMaxNumberProp() { return this.maxNumberProp; }
-  public void setMaxNumberProp(double maxNumberProp) { this.maxNumberProp = maxNumberProp; }
+  public number getMaxNumberProp() { return this.maxNumberProp; }
+  public void setMaxNumberProp(number maxNumberProp) { this.maxNumberProp = maxNumberProp; }
 
   public Object[] getArrayProp() { return this.arrayProp; }
   public void setArrayProp(Object[] arrayProp) { this.arrayProp = arrayProp; }

--- a/examples/java-generate-javax-constraint-annotation/__snapshots__/index.spec.ts.snap
+++ b/examples/java-generate-javax-constraint-annotation/__snapshots__/index.spec.ts.snap
@@ -5,10 +5,10 @@ Array [
   "public class JavaxAnnotation {
   @NotNull
   @Min(0)
-  private number minNumberProp;
+  private Number minNumberProp;
   @NotNull
   @Max(99)
-  private number maxNumberProp;
+  private Number maxNumberProp;
   @Size(min=2, max=3)
   private Object[] arrayProp;
   @Pattern(regexp=\\"^I_\\")
@@ -16,11 +16,11 @@ Array [
   private String stringProp;
   private Map<String, Object> additionalProperties;
 
-  public number getMinNumberProp() { return this.minNumberProp; }
-  public void setMinNumberProp(number minNumberProp) { this.minNumberProp = minNumberProp; }
+  public Number getMinNumberProp() { return this.minNumberProp; }
+  public void setMinNumberProp(Number minNumberProp) { this.minNumberProp = minNumberProp; }
 
-  public number getMaxNumberProp() { return this.maxNumberProp; }
-  public void setMaxNumberProp(number maxNumberProp) { this.maxNumberProp = maxNumberProp; }
+  public Number getMaxNumberProp() { return this.maxNumberProp; }
+  public void setMaxNumberProp(Number maxNumberProp) { this.maxNumberProp = maxNumberProp; }
 
   public Object[] getArrayProp() { return this.arrayProp; }
   public void setArrayProp(Object[] arrayProp) { this.arrayProp = arrayProp; }

--- a/src/generators/java/JavaConstrainer.ts
+++ b/src/generators/java/JavaConstrainer.ts
@@ -149,7 +149,7 @@ export const JavaDefaultTypeMapping: JavaTypeMapping = {
           constrainedModel,
           partOfProperty,
           typeWhenNullableOrOptional: 'Number',
-          type: 'number'
+          type: 'Number'
         });
     }
   },

--- a/src/generators/java/JavaConstrainer.ts
+++ b/src/generators/java/JavaConstrainer.ts
@@ -137,12 +137,19 @@ export const JavaDefaultTypeMapping: JavaTypeMapping = {
           typeWhenNullableOrOptional: 'Float',
           type: 'float'
         });
-      default:
+      case 'double':
         return getType({
           constrainedModel,
           partOfProperty,
           typeWhenNullableOrOptional: 'Double',
           type: 'double'
+        });
+      default:
+        return getType({
+          constrainedModel,
+          partOfProperty,
+          typeWhenNullableOrOptional: 'Number',
+          type: 'number'
         });
     }
   },

--- a/test/generators/java/JavaConstrainer.spec.ts
+++ b/test/generators/java/JavaConstrainer.spec.ts
@@ -120,7 +120,7 @@ describe('JavaConstrainer', () => {
         ),
         ...defaultOptions
       });
-      expect(type).toEqual('double');
+      expect(type).toEqual('number');
     });
     test('should render optional type', () => {
       const model = new ConstrainedFloatModel('test', undefined, {}, '');
@@ -134,7 +134,7 @@ describe('JavaConstrainer', () => {
         ),
         ...defaultOptions
       });
-      expect(type).toEqual('Double');
+      expect(type).toEqual('Number');
     });
     test('should render nullable type', () => {
       const model = new ConstrainedFloatModel(
@@ -147,9 +147,9 @@ describe('JavaConstrainer', () => {
         constrainedModel: model,
         ...defaultOptions
       });
-      expect(type).toEqual('Double');
+      expect(type).toEqual('Number');
     });
-    test('should render double when format has number format', () => {
+    test('should render float when format has float format', () => {
       const model = new ConstrainedFloatModel(
         'test',
         {},
@@ -167,6 +167,25 @@ describe('JavaConstrainer', () => {
         ...defaultOptions
       });
       expect(type).toEqual('float');
+    });
+    test('should render double when format has double format', () => {
+      const model = new ConstrainedFloatModel(
+        'test',
+        {},
+        { format: 'double' },
+        ''
+      );
+      const type = JavaDefaultTypeMapping.Float({
+        constrainedModel: model,
+        partOfProperty: new ConstrainedObjectPropertyModel(
+          'test',
+          'test',
+          true,
+          model
+        ),
+        ...defaultOptions
+      });
+      expect(type).toEqual('double');
     });
   });
   describe('Integer', () => {

--- a/test/generators/java/JavaConstrainer.spec.ts
+++ b/test/generators/java/JavaConstrainer.spec.ts
@@ -120,7 +120,7 @@ describe('JavaConstrainer', () => {
         ),
         ...defaultOptions
       });
-      expect(type).toEqual('number');
+      expect(type).toEqual('Number');
     });
     test('should render optional type', () => {
       const model = new ConstrainedFloatModel('test', undefined, {}, '');

--- a/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
+++ b/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
@@ -856,7 +856,7 @@ Array [
   private String streetName;
   private String city;
   private String state;
-  private double houseNumber;
+  private number houseNumber;
   private Boolean marriage;
   private Object members;
   private Object[] arrayType;
@@ -871,8 +871,8 @@ Array [
   public String getState() { return this.state; }
   public void setState(String state) { this.state = state; }
 
-  public double getHouseNumber() { return this.houseNumber; }
-  public void setHouseNumber(double houseNumber) { this.houseNumber = houseNumber; }
+  public number getHouseNumber() { return this.houseNumber; }
+  public void setHouseNumber(number houseNumber) { this.houseNumber = houseNumber; }
 
   public Boolean getMarriage() { return this.marriage; }
   public void setMarriage(Boolean marriage) { this.marriage = marriage; }
@@ -1070,7 +1070,7 @@ public class Address {
   private String streetName;
   private String city;
   private String state;
-  private double houseNumber;
+  private number houseNumber;
   private Boolean marriage;
   private Object members;
   private Object[] arrayType;
@@ -1086,8 +1086,8 @@ public class Address {
   public String getState() { return this.state; }
   public void setState(String state) { this.state = state; }
 
-  public double getHouseNumber() { return this.houseNumber; }
-  public void setHouseNumber(double houseNumber) { this.houseNumber = houseNumber; }
+  public number getHouseNumber() { return this.houseNumber; }
+  public void setHouseNumber(number houseNumber) { this.houseNumber = houseNumber; }
 
   public Boolean getMarriage() { return this.marriage; }
   public void setMarriage(Boolean marriage) { this.marriage = marriage; }

--- a/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
+++ b/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
@@ -856,7 +856,7 @@ Array [
   private String streetName;
   private String city;
   private String state;
-  private number houseNumber;
+  private Number houseNumber;
   private Boolean marriage;
   private Object members;
   private Object[] arrayType;
@@ -871,8 +871,8 @@ Array [
   public String getState() { return this.state; }
   public void setState(String state) { this.state = state; }
 
-  public number getHouseNumber() { return this.houseNumber; }
-  public void setHouseNumber(number houseNumber) { this.houseNumber = houseNumber; }
+  public Number getHouseNumber() { return this.houseNumber; }
+  public void setHouseNumber(Number houseNumber) { this.houseNumber = houseNumber; }
 
   public Boolean getMarriage() { return this.marriage; }
   public void setMarriage(Boolean marriage) { this.marriage = marriage; }
@@ -1070,7 +1070,7 @@ public class Address {
   private String streetName;
   private String city;
   private String state;
-  private number houseNumber;
+  private Number houseNumber;
   private Boolean marriage;
   private Object members;
   private Object[] arrayType;
@@ -1086,8 +1086,8 @@ public class Address {
   public String getState() { return this.state; }
   public void setState(String state) { this.state = state; }
 
-  public number getHouseNumber() { return this.houseNumber; }
-  public void setHouseNumber(number houseNumber) { this.houseNumber = houseNumber; }
+  public Number getHouseNumber() { return this.houseNumber; }
+  public void setHouseNumber(Number houseNumber) { this.houseNumber = houseNumber; }
 
   public Boolean getMarriage() { return this.marriage; }
   public void setMarriage(Boolean marriage) { this.marriage = marriage; }

--- a/test/generators/java/presets/__snapshots__/CommonPreset.spec.ts.snap
+++ b/test/generators/java/presets/__snapshots__/CommonPreset.spec.ts.snap
@@ -4,7 +4,7 @@ exports[`JAVA_COMMON_PRESET should render accurately when there is no additional
 "public class Clazz {
   private boolean requiredProp;
   private String stringProp;
-  private Double numberProp;
+  private Number numberProp;
   private Boolean booleanProp;
   private String[] arrayProp;
 
@@ -14,8 +14,8 @@ exports[`JAVA_COMMON_PRESET should render accurately when there is no additional
   public String getStringProp() { return this.stringProp; }
   public void setStringProp(String stringProp) { this.stringProp = stringProp; }
 
-  public Double getNumberProp() { return this.numberProp; }
-  public void setNumberProp(Double numberProp) { this.numberProp = numberProp; }
+  public Number getNumberProp() { return this.numberProp; }
+  public void setNumberProp(Number numberProp) { this.numberProp = numberProp; }
 
   public Boolean getBooleanProp() { return this.booleanProp; }
   public void setBooleanProp(Boolean booleanProp) { this.booleanProp = booleanProp; }
@@ -73,7 +73,7 @@ exports[`JAVA_COMMON_PRESET should render common function in class by common pre
 "public class Clazz {
   private boolean requiredProp;
   private String stringProp;
-  private Double numberProp;
+  private Number numberProp;
   private Boolean booleanProp;
   private String[] arrayProp;
   private Map<String, Object> additionalProperties;
@@ -84,8 +84,8 @@ exports[`JAVA_COMMON_PRESET should render common function in class by common pre
   public String getStringProp() { return this.stringProp; }
   public void setStringProp(String stringProp) { this.stringProp = stringProp; }
 
-  public Double getNumberProp() { return this.numberProp; }
-  public void setNumberProp(Double numberProp) { this.numberProp = numberProp; }
+  public Number getNumberProp() { return this.numberProp; }
+  public void setNumberProp(Number numberProp) { this.numberProp = numberProp; }
 
   public Boolean getBooleanProp() { return this.booleanProp; }
   public void setBooleanProp(Boolean booleanProp) { this.booleanProp = booleanProp; }
@@ -148,7 +148,7 @@ exports[`JAVA_COMMON_PRESET with option should not render any functions when all
 "public class Clazz {
   private boolean requiredProp;
   private String stringProp;
-  private Double numberProp;
+  private Number numberProp;
   private Boolean booleanProp;
   private String[] arrayProp;
   private Map<String, Object> additionalProperties;
@@ -159,8 +159,8 @@ exports[`JAVA_COMMON_PRESET with option should not render any functions when all
   public String getStringProp() { return this.stringProp; }
   public void setStringProp(String stringProp) { this.stringProp = stringProp; }
 
-  public Double getNumberProp() { return this.numberProp; }
-  public void setNumberProp(Double numberProp) { this.numberProp = numberProp; }
+  public Number getNumberProp() { return this.numberProp; }
+  public void setNumberProp(Number numberProp) { this.numberProp = numberProp; }
 
   public Boolean getBooleanProp() { return this.booleanProp; }
   public void setBooleanProp(Boolean booleanProp) { this.booleanProp = booleanProp; }
@@ -177,7 +177,7 @@ exports[`JAVA_COMMON_PRESET with option should render all functions 1`] = `
 "public class Clazz {
   private boolean requiredProp;
   private String stringProp;
-  private Double numberProp;
+  private Number numberProp;
   private Boolean booleanProp;
   private String[] arrayProp;
   private Map<String, Object> additionalProperties;
@@ -188,8 +188,8 @@ exports[`JAVA_COMMON_PRESET with option should render all functions 1`] = `
   public String getStringProp() { return this.stringProp; }
   public void setStringProp(String stringProp) { this.stringProp = stringProp; }
 
-  public Double getNumberProp() { return this.numberProp; }
-  public void setNumberProp(Double numberProp) { this.numberProp = numberProp; }
+  public Number getNumberProp() { return this.numberProp; }
+  public void setNumberProp(Number numberProp) { this.numberProp = numberProp; }
 
   public Boolean getBooleanProp() { return this.booleanProp; }
   public void setBooleanProp(Boolean booleanProp) { this.booleanProp = booleanProp; }
@@ -252,7 +252,7 @@ exports[`JAVA_COMMON_PRESET with option should render classToString 1`] = `
 "public class Clazz {
   private boolean requiredProp;
   private String stringProp;
-  private Double numberProp;
+  private Number numberProp;
   private Boolean booleanProp;
   private String[] arrayProp;
   private Map<String, Object> additionalProperties;
@@ -263,8 +263,8 @@ exports[`JAVA_COMMON_PRESET with option should render classToString 1`] = `
   public String getStringProp() { return this.stringProp; }
   public void setStringProp(String stringProp) { this.stringProp = stringProp; }
 
-  public Double getNumberProp() { return this.numberProp; }
-  public void setNumberProp(Double numberProp) { this.numberProp = numberProp; }
+  public Number getNumberProp() { return this.numberProp; }
+  public void setNumberProp(Number numberProp) { this.numberProp = numberProp; }
 
   public Boolean getBooleanProp() { return this.booleanProp; }
   public void setBooleanProp(Boolean booleanProp) { this.booleanProp = booleanProp; }
@@ -304,7 +304,7 @@ exports[`JAVA_COMMON_PRESET with option should render equals 1`] = `
 "public class Clazz {
   private boolean requiredProp;
   private String stringProp;
-  private Double numberProp;
+  private Number numberProp;
   private Boolean booleanProp;
   private String[] arrayProp;
   private Map<String, Object> additionalProperties;
@@ -315,8 +315,8 @@ exports[`JAVA_COMMON_PRESET with option should render equals 1`] = `
   public String getStringProp() { return this.stringProp; }
   public void setStringProp(String stringProp) { this.stringProp = stringProp; }
 
-  public Double getNumberProp() { return this.numberProp; }
-  public void setNumberProp(Double numberProp) { this.numberProp = numberProp; }
+  public Number getNumberProp() { return this.numberProp; }
+  public void setNumberProp(Number numberProp) { this.numberProp = numberProp; }
 
   public Boolean getBooleanProp() { return this.booleanProp; }
   public void setBooleanProp(Boolean booleanProp) { this.booleanProp = booleanProp; }
@@ -351,7 +351,7 @@ exports[`JAVA_COMMON_PRESET with option should render hashCode 1`] = `
 "public class Clazz {
   private boolean requiredProp;
   private String stringProp;
-  private Double numberProp;
+  private Number numberProp;
   private Boolean booleanProp;
   private String[] arrayProp;
   private Map<String, Object> additionalProperties;
@@ -362,8 +362,8 @@ exports[`JAVA_COMMON_PRESET with option should render hashCode 1`] = `
   public String getStringProp() { return this.stringProp; }
   public void setStringProp(String stringProp) { this.stringProp = stringProp; }
 
-  public Double getNumberProp() { return this.numberProp; }
-  public void setNumberProp(Double numberProp) { this.numberProp = numberProp; }
+  public Number getNumberProp() { return this.numberProp; }
+  public void setNumberProp(Number numberProp) { this.numberProp = numberProp; }
 
   public Boolean getBooleanProp() { return this.booleanProp; }
   public void setBooleanProp(Boolean booleanProp) { this.booleanProp = booleanProp; }
@@ -385,7 +385,7 @@ exports[`JAVA_COMMON_PRESET with option should render un/marshal 1`] = `
 "public class Clazz {
   private boolean requiredProp;
   private String stringProp;
-  private Double numberProp;
+  private Number numberProp;
   private Boolean booleanProp;
   private String[] arrayProp;
   private Map<String, Object> additionalProperties;
@@ -396,8 +396,8 @@ exports[`JAVA_COMMON_PRESET with option should render un/marshal 1`] = `
   public String getStringProp() { return this.stringProp; }
   public void setStringProp(String stringProp) { this.stringProp = stringProp; }
 
-  public Double getNumberProp() { return this.numberProp; }
-  public void setNumberProp(Double numberProp) { this.numberProp = numberProp; }
+  public Number getNumberProp() { return this.numberProp; }
+  public void setNumberProp(Number numberProp) { this.numberProp = numberProp; }
 
   public Boolean getBooleanProp() { return this.booleanProp; }
   public void setBooleanProp(Boolean booleanProp) { this.booleanProp = booleanProp; }
@@ -441,7 +441,7 @@ exports[`JAVA_COMMON_PRESET with option should render un/marshal 1`] = `
             result.setStringProp(jsonObject.getString(\\"stringProp\\"));
           }
     if(jsonObject.has(\\"numberProp\\")) {
-            result.setNumberProp(jsonObject.getDouble(\\"numberProp\\"));
+            result.setNumberProp(jsonObject.getNumber(\\"numberProp\\"));
           }
     if(jsonObject.has(\\"booleanProp\\")) {
             result.setBooleanProp(jsonObject.getBoolean(\\"booleanProp\\"));

--- a/test/generators/java/presets/__snapshots__/ConstraintsPreset.spec.ts.snap
+++ b/test/generators/java/presets/__snapshots__/ConstraintsPreset.spec.ts.snap
@@ -4,10 +4,10 @@ exports[`JAVA_CONSTRAINTS_PRESET should render constraints annotations 1`] = `
 "public class Clazz {
   @NotNull
   @Min(0)
-  private number minNumberProp;
+  private Number minNumberProp;
   @NotNull
   @Max(99)
-  private number maxNumberProp;
+  private Number maxNumberProp;
   @Size(min=2, max=3)
   private Object[] arrayProp;
   @Pattern(regexp=\\"^\\\\\\\\w+(\\\\\\"\\\\\\\\.\\\\\\\\w+)*$\\")
@@ -15,11 +15,11 @@ exports[`JAVA_CONSTRAINTS_PRESET should render constraints annotations 1`] = `
   private String stringProp;
   private Map<String, Object> additionalProperties;
 
-  public number getMinNumberProp() { return this.minNumberProp; }
-  public void setMinNumberProp(number minNumberProp) { this.minNumberProp = minNumberProp; }
+  public Number getMinNumberProp() { return this.minNumberProp; }
+  public void setMinNumberProp(Number minNumberProp) { this.minNumberProp = minNumberProp; }
 
-  public number getMaxNumberProp() { return this.maxNumberProp; }
-  public void setMaxNumberProp(number maxNumberProp) { this.maxNumberProp = maxNumberProp; }
+  public Number getMaxNumberProp() { return this.maxNumberProp; }
+  public void setMaxNumberProp(Number maxNumberProp) { this.maxNumberProp = maxNumberProp; }
 
   public Object[] getArrayProp() { return this.arrayProp; }
   public void setArrayProp(Object[] arrayProp) { this.arrayProp = arrayProp; }

--- a/test/generators/java/presets/__snapshots__/ConstraintsPreset.spec.ts.snap
+++ b/test/generators/java/presets/__snapshots__/ConstraintsPreset.spec.ts.snap
@@ -4,10 +4,10 @@ exports[`JAVA_CONSTRAINTS_PRESET should render constraints annotations 1`] = `
 "public class Clazz {
   @NotNull
   @Min(0)
-  private double minNumberProp;
+  private number minNumberProp;
   @NotNull
   @Max(99)
-  private double maxNumberProp;
+  private number maxNumberProp;
   @Size(min=2, max=3)
   private Object[] arrayProp;
   @Pattern(regexp=\\"^\\\\\\\\w+(\\\\\\"\\\\\\\\.\\\\\\\\w+)*$\\")
@@ -15,11 +15,11 @@ exports[`JAVA_CONSTRAINTS_PRESET should render constraints annotations 1`] = `
   private String stringProp;
   private Map<String, Object> additionalProperties;
 
-  public double getMinNumberProp() { return this.minNumberProp; }
-  public void setMinNumberProp(double minNumberProp) { this.minNumberProp = minNumberProp; }
+  public number getMinNumberProp() { return this.minNumberProp; }
+  public void setMinNumberProp(number minNumberProp) { this.minNumberProp = minNumberProp; }
 
-  public double getMaxNumberProp() { return this.maxNumberProp; }
-  public void setMaxNumberProp(double maxNumberProp) { this.maxNumberProp = maxNumberProp; }
+  public number getMaxNumberProp() { return this.maxNumberProp; }
+  public void setMaxNumberProp(number maxNumberProp) { this.maxNumberProp = maxNumberProp; }
 
   public Object[] getArrayProp() { return this.arrayProp; }
   public void setArrayProp(Object[] arrayProp) { this.arrayProp = arrayProp; }

--- a/test/generators/java/presets/__snapshots__/JacksonPreset.spec.ts.snap
+++ b/test/generators/java/presets/__snapshots__/JacksonPreset.spec.ts.snap
@@ -3,15 +3,15 @@
 exports[`JAVA_JACKSON_PRESET should render Jackson annotations for class 1`] = `
 "public class Clazz {
   @JsonProperty(\\"min_number_prop\\")
-  private number minNumberProp;
+  private Number minNumberProp;
   @JsonProperty(\\"max_number_prop\\")
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Number maxNumberProp;
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Map<String, Object> additionalProperties;
 
-  public number getMinNumberProp() { return this.minNumberProp; }
-  public void setMinNumberProp(number minNumberProp) { this.minNumberProp = minNumberProp; }
+  public Number getMinNumberProp() { return this.minNumberProp; }
+  public void setMinNumberProp(Number minNumberProp) { this.minNumberProp = minNumberProp; }
 
   public Number getMaxNumberProp() { return this.maxNumberProp; }
   public void setMaxNumberProp(Number maxNumberProp) { this.maxNumberProp = maxNumberProp; }

--- a/test/generators/java/presets/__snapshots__/JacksonPreset.spec.ts.snap
+++ b/test/generators/java/presets/__snapshots__/JacksonPreset.spec.ts.snap
@@ -3,18 +3,18 @@
 exports[`JAVA_JACKSON_PRESET should render Jackson annotations for class 1`] = `
 "public class Clazz {
   @JsonProperty(\\"min_number_prop\\")
-  private double minNumberProp;
+  private number minNumberProp;
   @JsonProperty(\\"max_number_prop\\")
   @JsonInclude(JsonInclude.Include.NON_NULL)
-  private Double maxNumberProp;
+  private Number maxNumberProp;
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Map<String, Object> additionalProperties;
 
-  public double getMinNumberProp() { return this.minNumberProp; }
-  public void setMinNumberProp(double minNumberProp) { this.minNumberProp = minNumberProp; }
+  public number getMinNumberProp() { return this.minNumberProp; }
+  public void setMinNumberProp(number minNumberProp) { this.minNumberProp = minNumberProp; }
 
-  public Double getMaxNumberProp() { return this.maxNumberProp; }
-  public void setMaxNumberProp(Double maxNumberProp) { this.maxNumberProp = maxNumberProp; }
+  public Number getMaxNumberProp() { return this.maxNumberProp; }
+  public void setMaxNumberProp(Number maxNumberProp) { this.maxNumberProp = maxNumberProp; }
 
   public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
   public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- This PR makes `Number` the default type instead of `Double` for the Float constrainer in Java. If the format is not specified when the type is `number`, it should allow for both float and double formats. 

I believe this is a fix because this is technically a bug in Modelina today.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->