### PR TITLE
fix!: add csharp support for DateTime, TimeSpan, Guid

### DIFF
--- a/docs/migrations/version-2-to-3.md
+++ b/docs/migrations/version-2-to-3.md
@@ -12,7 +12,68 @@ Is not affected by this change.
 
 ### C#
 
-Is not affected by this change.
+#### System.TimeSpan is used when format is time
+
+This example used to generate a `string`, but is now instead using `System.TimeSpan`.
+
+```yaml
+type: object
+properties:
+  duration:
+    type: string
+    format: time
+```
+
+will generate
+
+```csharp
+public class TestClass {
+  private System.TimeSpan duration;
+  ...
+}
+```
+
+#### System.DateTime is used when format is date-time
+
+This example used to generate a `string`, but is now instead using `System.DateTime`.
+
+```yaml
+type: object
+properties:
+  dob:
+    type: string
+    format: date-time
+```
+
+will generate
+
+```csharp
+public class TestClass {
+  private System.DateTime dob;
+  ...
+}
+```
+
+#### System.Guid is used when format is uuid
+
+This example used to generate a `string`, but is now instead using `System.Guid`.
+
+```yaml
+type: object
+properties:
+  uniqueId:
+    type: string
+    format: uuid
+```
+
+will generate
+
+```csharp
+public class TestClass {
+  private System.Guid uniqueId;
+  ...
+}
+```
 
 ### Java
 

--- a/examples/generate-csharp-models/__snapshots__/index.spec.ts.snap
+++ b/examples/generate-csharp-models/__snapshots__/index.spec.ts.snap
@@ -5,8 +5,9 @@ Array [
   "public class Root
 {
   private string? email;
-  private System.DateTime? dateTime;
-  private System.TimeSpan? timeSpan;
+  private System.DateTime? today;
+  private System.TimeSpan? duration;
+  private System.Guid? userId;
 
   public string? Email 
   {
@@ -14,16 +15,22 @@ Array [
     set { email = value; }
   }
 
-  public System.DateTime? DateTime 
+  public System.DateTime? Today 
   {
-    get { return dateTime; }
-    set { dateTime = value; }
+    get { return today; }
+    set { today = value; }
   }
 
-  public System.TimeSpan? TimeSpan 
+  public System.TimeSpan? Duration 
   {
-    get { return timeSpan; }
-    set { timeSpan = value; }
+    get { return duration; }
+    set { duration = value; }
+  }
+
+  public System.Guid? UserId 
+  {
+    get { return userId; }
+    set { userId = value; }
   }
 }",
 ]

--- a/examples/generate-csharp-models/__snapshots__/index.spec.ts.snap
+++ b/examples/generate-csharp-models/__snapshots__/index.spec.ts.snap
@@ -5,11 +5,25 @@ Array [
   "public class Root
 {
   private string? email;
+  private System.DateTime? dateTime;
+  private System.TimeSpan? timeSpan;
 
   public string? Email 
   {
     get { return email; }
     set { email = value; }
+  }
+
+  public System.DateTime? DateTime 
+  {
+    get { return dateTime; }
+    set { dateTime = value; }
+  }
+
+  public System.TimeSpan? TimeSpan 
+  {
+    get { return timeSpan; }
+    set { timeSpan = value; }
   }
 }",
 ]

--- a/examples/generate-csharp-models/index.ts
+++ b/examples/generate-csharp-models/index.ts
@@ -10,13 +10,17 @@ const jsonSchemaDraft7 = {
       type: 'string',
       format: 'email'
     },
-    dateTime: {
+    today: {
       type: 'string',
       format: 'date-time'
     },
-    timeSpan: {
+    duration: {
       type: 'string',
       format: 'time'
+    },
+    userId: {
+      type: 'string',
+      format: 'uuid'
     }
   }
 };

--- a/examples/generate-csharp-models/index.ts
+++ b/examples/generate-csharp-models/index.ts
@@ -9,6 +9,14 @@ const jsonSchemaDraft7 = {
     email: {
       type: 'string',
       format: 'email'
+    },
+    dateTime: {
+      type: 'string',
+      format: 'date-time'
+    },
+    timeSpan: {
+      type: 'string',
+      format: 'time'
     }
   }
 };

--- a/examples/generate-csharp-models/package-lock.json
+++ b/examples/generate-csharp-models/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "typescript-interface",
+  "name": "generate-csharp-models",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/src/generators/csharp/CSharpConstrainer.ts
+++ b/src/generators/csharp/CSharpConstrainer.ts
@@ -63,6 +63,8 @@ export const CSharpDefaultTypeMapping: CSharpTypeMapping = {
       case 'dateTime':
       case 'date-time':
         return getFullTypeDefinition('System.DateTime', partOfProperty);
+      case 'uuid':
+        return getFullTypeDefinition('System.Guid', partOfProperty);
       default:
         return getFullTypeDefinition('string', partOfProperty);
     }

--- a/src/generators/csharp/CSharpConstrainer.ts
+++ b/src/generators/csharp/CSharpConstrainer.ts
@@ -55,8 +55,17 @@ export const CSharpDefaultTypeMapping: CSharpTypeMapping = {
   Integer({ partOfProperty }): string {
     return getFullTypeDefinition('int', partOfProperty);
   },
-  String({ partOfProperty }): string {
-    return getFullTypeDefinition('string', partOfProperty);
+  String({ constrainedModel, partOfProperty }): string {
+    switch (constrainedModel.options.format) {
+      case 'time':
+        return getFullTypeDefinition('System.TimeSpan', partOfProperty);
+      case 'date':
+      case 'dateTime':
+      case 'date-time':
+        return getFullTypeDefinition('System.DateTime', partOfProperty);
+      default:
+        return getFullTypeDefinition('string', partOfProperty);
+    }
   },
   Boolean({ partOfProperty }): string {
     return getFullTypeDefinition('bool', partOfProperty);

--- a/test/blackbox/docs/AsyncAPI-2_6/dummy.json
+++ b/test/blackbox/docs/AsyncAPI-2_6/dummy.json
@@ -58,6 +58,21 @@
               "type": "string",
               "format": "email",
               "description": "Email of the user"
+            },
+            "signedUpAt": {
+              "type": "string",
+              "format": "date-time",
+              "description": "Sign-up processed date and time"
+            },
+            "sessionDuration": {
+              "type": "string",
+              "format": "time",
+              "description": "Maximum session duration"
+            },
+            "uniqueUserId": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Unique user id"
             }
           }
         }

--- a/test/generators/csharp/CSharpConstrainer.spec.ts
+++ b/test/generators/csharp/CSharpConstrainer.spec.ts
@@ -94,7 +94,7 @@ describe('CSharpConstrainer', () => {
       expect(type).toEqual('string');
     });
     test('should render System.DateTime', () => {
-      const model = new ConstrainedStringModel('test', undefined, {}, '');
+      const model = new ConstrainedStringModel('test', undefined, { format: 'date-time' }, '');
       const type = CSharpDefaultTypeMapping.String({
         constrainedModel: model,
         ...defaultOptions
@@ -102,12 +102,20 @@ describe('CSharpConstrainer', () => {
       expect(type).toEqual('System.DateTime');
     });
     test('should render TimeSpan', () => {
-      const model = new ConstrainedStringModel('test', undefined, {}, '');
+      const model = new ConstrainedStringModel('test', undefined, { format: 'time' }, '');
       const type = CSharpDefaultTypeMapping.String({
         constrainedModel: model,
         ...defaultOptions
       });
       expect(type).toEqual('System.TimeSpan');
+    });
+    test('should render Guid', () => {
+      const model = new ConstrainedStringModel('test', undefined, { format: 'uuid' }, '');
+      const type = CSharpDefaultTypeMapping.String({
+        constrainedModel: model,
+        ...defaultOptions
+      });
+      expect(type).toEqual('System.Guid');
     });
   });
   describe('Boolean', () => {

--- a/test/generators/csharp/CSharpConstrainer.spec.ts
+++ b/test/generators/csharp/CSharpConstrainer.spec.ts
@@ -94,7 +94,12 @@ describe('CSharpConstrainer', () => {
       expect(type).toEqual('string');
     });
     test('should render System.DateTime', () => {
-      const model = new ConstrainedStringModel('test', undefined, { format: 'date-time' }, '');
+      const model = new ConstrainedStringModel(
+        'test',
+        undefined,
+        { format: 'date-time' },
+        ''
+      );
       const type = CSharpDefaultTypeMapping.String({
         constrainedModel: model,
         ...defaultOptions
@@ -102,7 +107,12 @@ describe('CSharpConstrainer', () => {
       expect(type).toEqual('System.DateTime');
     });
     test('should render TimeSpan', () => {
-      const model = new ConstrainedStringModel('test', undefined, { format: 'time' }, '');
+      const model = new ConstrainedStringModel(
+        'test',
+        undefined,
+        { format: 'time' },
+        ''
+      );
       const type = CSharpDefaultTypeMapping.String({
         constrainedModel: model,
         ...defaultOptions
@@ -110,7 +120,12 @@ describe('CSharpConstrainer', () => {
       expect(type).toEqual('System.TimeSpan');
     });
     test('should render Guid', () => {
-      const model = new ConstrainedStringModel('test', undefined, { format: 'uuid' }, '');
+      const model = new ConstrainedStringModel(
+        'test',
+        undefined,
+        { format: 'uuid' },
+        ''
+      );
       const type = CSharpDefaultTypeMapping.String({
         constrainedModel: model,
         ...defaultOptions

--- a/test/generators/csharp/CSharpConstrainer.spec.ts
+++ b/test/generators/csharp/CSharpConstrainer.spec.ts
@@ -93,6 +93,22 @@ describe('CSharpConstrainer', () => {
       });
       expect(type).toEqual('string');
     });
+    test('should render System.DateTime', () => {
+      const model = new ConstrainedStringModel('test', undefined, {}, '');
+      const type = CSharpDefaultTypeMapping.String({
+        constrainedModel: model,
+        ...defaultOptions
+      });
+      expect(type).toEqual('System.DateTime');
+    });
+    test('should render TimeSpan', () => {
+      const model = new ConstrainedStringModel('test', undefined, {}, '');
+      const type = CSharpDefaultTypeMapping.String({
+        constrainedModel: model,
+        ...defaultOptions
+      });
+      expect(type).toEqual('System.TimeSpan');
+    });
   });
   describe('Boolean', () => {
     test('should render type', () => {


### PR DESCRIPTION
**Description**

Extending supported string formats for C#:

- format: 'date-time' will be rendered as DateTime in C#
- format: 'time' will be rendered as TimeStamp in C#
- format: 'uuid' will be rendered as Guid in C#

Added relevant tests and extended existing examples where relevant

**Related issue(s)**
Resolves #1607 