### PR TITLE
feat!: adds extend in common, meta, and constrained models

### DIFF
--- a/docs/migrations/version-2-to-3.md
+++ b/docs/migrations/version-2-to-3.md
@@ -2,6 +2,22 @@
 
 This document contains all the breaking changes and migrations guidelines for adapting your code to the new version.
 
+## allowInheritance set to true will enable inheritance
+
+This feature introduces a new option called `allowInheritance` in the interpreter options, which controls whether the generated models should inherit when the schema includes an `allOf`. By default, this option is set to false, which means that you'll not be affected if this property is not set. In the `MetaModel` and the `ConstrainedMetaModel` options, there is now an `extend` property (a list of models) and an `isExtended` property (boolean).
+
+Here is an example of how to use the new feature and the `allowInheritance` option in your code:
+
+```ts
+const generator = new JavaFileGenerator({
+  processorOptions: {
+    interpreter: {
+      allowInheritance: true
+    }
+  }
+});
+```
+
 ### TypeScript
 
 Is not affected by this change.

--- a/src/helpers/CommonModelToMetaModel.ts
+++ b/src/helpers/CommonModelToMetaModel.ts
@@ -514,6 +514,16 @@ export function convertToObjectModel(
     metaModel.properties[String(propertyName)] = propertyModel;
   }
 
+  if (jsonSchemaModel.extend?.length) {
+    metaModel.options.extend = [];
+
+    for (const extend of jsonSchemaModel.extend) {
+      metaModel.options.extend.push(
+        convertToMetaModel(extend, alreadySeenModels)
+      );
+    }
+  }
+
   if (
     jsonSchemaModel.additionalProperties !== undefined ||
     jsonSchemaModel.patternProperties !== undefined

--- a/src/interpreter/InterpretAllOf.ts
+++ b/src/interpreter/InterpretAllOf.ts
@@ -45,31 +45,39 @@ export default function interpretAllOf(
 
   for (const allOfSchema of schema.allOf) {
     const allOfModel = interpreter.interpret(allOfSchema, interpreterOptions);
+
     if (allOfModel === undefined) {
       continue;
     }
-    if (
-      isModelObject(allOfModel) === true &&
-      interpreterOptions.allowInheritance === true
-    ) {
-      Logger.info(
-        `Processing allOf, inheritance is enabled, ${model.$id} inherits from ${allOfModel.$id}`,
-        model,
-        allOfModel
-      );
-      model.addExtendedModel(allOfModel);
-    } else {
-      Logger.info(
-        'Processing allOf, inheritance is not enabled. AllOf model is merged together with already interpreted model',
-        model,
-        allOfModel
-      );
-      interpreter.interpretAndCombineSchema(
-        allOfSchema,
-        model,
-        schema,
-        interpreterOptions
-      );
+
+    if (interpreterOptions.allowInheritance === true) {
+      const allOfModelWithoutCache = interpreter.interpret(allOfSchema, {
+        ...interpreterOptions,
+        disableCache: true
+      });
+
+      if (allOfModelWithoutCache && isModelObject(allOfModelWithoutCache)) {
+        Logger.info(
+          `Processing allOf, inheritance is enabled, ${model.$id} inherits from ${allOfModelWithoutCache.$id}`,
+          model,
+          allOfModel
+        );
+
+        model.addExtendedModel(allOfModelWithoutCache);
+      }
     }
+
+    Logger.info(
+      'Processing allOf, inheritance is not enabled. AllOf model is merged together with already interpreted model',
+      model,
+      allOfModel
+    );
+
+    interpreter.interpretAndCombineSchema(
+      allOfSchema,
+      model,
+      schema,
+      interpreterOptions
+    );
   }
 }

--- a/src/interpreter/Interpreter.ts
+++ b/src/interpreter/Interpreter.ts
@@ -51,7 +51,10 @@ export type InterpreterOptions = {
    */
   discriminator?: string;
   /**
-   * Use this option to disable cache when interpreting schemas. This will affect merging of schemas.
+   * This options disables the seenSchemas cache in the Interpreter.
+   * Use this option to disable the seenSchemas cache when interpreting schemas.
+   * This will affect merging of schemas, and should only be used by the internal interpreters when allowInheritance is set to true.
+   * This allows the internal interpreters to keep clean copies of the schemas as CommonModel's.
    */
   disableCache?: boolean;
 };

--- a/src/interpreter/Interpreter.ts
+++ b/src/interpreter/Interpreter.ts
@@ -50,6 +50,10 @@ export type InterpreterOptions = {
    * When interpreting a schema with discriminator set, this property will be set best by the individual interpreters to make sure the discriminator becomes an enum.
    */
   discriminator?: string;
+  /**
+   * Use this option to disable cache when interpreting schemas. This will affect merging of schemas.
+   */
+  disableCache?: boolean;
 };
 export type InterpreterSchemas =
   | Draft6Schema
@@ -64,7 +68,8 @@ export class Interpreter {
   static defaultInterpreterOptions: InterpreterOptions = {
     allowInheritance: false,
     ignoreAdditionalProperties: false,
-    ignoreAdditionalItems: false
+    ignoreAdditionalItems: false,
+    disableCache: false
   };
 
   private anonymCounter = 1;
@@ -80,7 +85,7 @@ export class Interpreter {
     schema: InterpreterSchemaType,
     options: InterpreterOptions = Interpreter.defaultInterpreterOptions
   ): CommonModel | undefined {
-    if (this.seenSchemas.has(schema)) {
+    if (!options.disableCache && this.seenSchemas.has(schema)) {
       const cachedModel = this.seenSchemas.get(schema);
       if (cachedModel !== undefined) {
         return cachedModel;
@@ -92,7 +97,9 @@ export class Interpreter {
     }
     const model = new CommonModel();
     model.originalInput = schema;
-    this.seenSchemas.set(schema, model);
+    if (!options.disableCache) {
+      this.seenSchemas.set(schema, model);
+    }
     this.interpretSchema(model, schema, options);
     return model;
   }

--- a/src/models/CommonModel.ts
+++ b/src/models/CommonModel.ts
@@ -15,7 +15,7 @@ export const defaultMergingOptions: MergingOptions = {
  * Common internal representation for a model.
  */
 export class CommonModel {
-  extend?: string[];
+  extend?: CommonModel[];
   originalInput?: any;
   $id?: string;
   type?: string | string[];
@@ -426,7 +426,10 @@ export class CommonModel {
    * @param extendedModel
    */
   addExtendedModel(extendedModel: CommonModel): void {
-    if (extendedModel.$id === undefined) {
+    if (
+      extendedModel.$id === undefined ||
+      CommonModel.idIncludesAnonymousSchema(extendedModel)
+    ) {
       Logger.error(
         'Found no $id for allOf model and cannot extend the existing model, this should never happen.',
         this,
@@ -434,8 +437,10 @@ export class CommonModel {
       );
       return;
     }
-    this.extend = this.extend || [];
-    if (this.extend.includes(extendedModel.$id)) {
+
+    if (
+      this.extend?.find((commonModel) => commonModel.$id === extendedModel.$id)
+    ) {
       Logger.info(
         `${this.$id} model already extends model ${extendedModel.$id}.`,
         this,
@@ -443,7 +448,8 @@ export class CommonModel {
       );
       return;
     }
-    this.extend.push(extendedModel.$id);
+    this.extend = this.extend ?? [];
+    this.extend.push(extendedModel);
   }
 
   /**

--- a/src/models/ConstrainedMetaModel.ts
+++ b/src/models/ConstrainedMetaModel.ts
@@ -20,6 +20,7 @@ export class ConstrainedMetaModelOptions extends MetaModelOptions {
   const?: ConstrainedMetaModelOptionsConst;
   discriminator?: ConstrainedMetaModelOptionsDiscriminator;
   parents?: ConstrainedMetaModel[];
+  extend?: ConstrainedMetaModel[];
 }
 
 export abstract class ConstrainedMetaModel extends MetaModel {

--- a/src/models/MetaModel.ts
+++ b/src/models/MetaModel.ts
@@ -11,6 +11,8 @@ export class MetaModelOptions {
   discriminator?: MetaModelOptionsDiscriminator;
   isNullable?: boolean = false;
   format?: string;
+  extend?: MetaModel[];
+  isExtended?: boolean;
 }
 
 export class MetaModel {

--- a/test/helpers/CommonModelToMetaModel.spec.ts
+++ b/test/helpers/CommonModelToMetaModel.spec.ts
@@ -263,6 +263,21 @@ describe('CommonModelToMetaModel', () => {
       (model as ObjectModel).properties['reserved_additionalProperties']
     ).not.toBeUndefined();
   });
+  test('should convert to object model and add extend model', () => {
+    const extend = new CommonModel();
+    extend.type = 'object';
+    extend.$id = 'extend';
+    const cm = new CommonModel();
+    cm.type = 'object';
+    cm.$id = 'test';
+    cm.extend = [extend];
+
+    const model = convertToMetaModel(cm);
+
+    expect(model instanceof ObjectModel).toEqual(true);
+    expect(model.options.extend?.length).toEqual(1);
+    expect(model.options.extend?.at(0) instanceof ObjectModel).toEqual(true);
+  });
 
   test('should merge both patternProperties and additionalProperties into one property', () => {
     const stringCM = new CommonModel();

--- a/test/helpers/ConstrainHelpers.spec.ts
+++ b/test/helpers/ConstrainHelpers.spec.ts
@@ -119,6 +119,35 @@ describe('ConstrainHelpers', () => {
       );
       expect(constrainedModel instanceof ConstrainedObjectModel).toEqual(true);
     });
+
+    test('should handle extend', () => {
+      const extendModel = new ObjectModel('extend', undefined, {}, {});
+      const metaModel = new ObjectModel(
+        'test',
+        undefined,
+        {
+          extend: [extendModel]
+        },
+        {}
+      );
+      const constrainedModel = constrainMetaModel(
+        mockedTypeMapping,
+        mockedConstraints,
+        {
+          metaModel,
+          options: {},
+          constrainedName: '',
+          dependencyManager: undefined as never
+        }
+      );
+      expect(constrainedModel instanceof ConstrainedObjectModel).toEqual(true);
+      expect(constrainedModel.options.extend?.length).toEqual(1);
+      expect(
+        constrainedModel.options.extend?.at(0) instanceof ConstrainedObjectModel
+      ).toEqual(true);
+      expect(mockedConstraints.modelName).toHaveBeenCalledTimes(2);
+      expect(mockedTypeMapping.Object).toHaveBeenCalledTimes(2);
+    });
   });
   describe('constrain ReferenceModel', () => {
     test('should constrain correctly', () => {

--- a/test/helpers/Splitter.spec.ts
+++ b/test/helpers/Splitter.spec.ts
@@ -174,4 +174,79 @@ describe('Splitter', () => {
     expect(splittedModels.length).toEqual(1);
     expect(splittedModels[0]).toEqual(model);
   });
+
+  describe('extend', () => {
+    test('should split models when extend exists in object model', () => {
+      const extendModel = new ObjectModel('extend', undefined, {}, {});
+      const model = new ObjectModel(
+        'testObj',
+        undefined,
+        {
+          extend: [extendModel]
+        },
+        {}
+      );
+
+      const options: SplitOptions = {
+        splitObject: true
+      };
+
+      const splittedModels = split(model, options);
+
+      expect(splittedModels.length).toEqual(2);
+      expect(splittedModels.at(0) instanceof ObjectModel).toEqual(true);
+      expect(splittedModels[0]).toEqual(model);
+      expect(splittedModels[0].options.extend).toEqual([
+        new ReferenceModel(
+          extendModel.name,
+          extendModel.originalInput,
+          {
+            isExtended: true
+          },
+          extendModel
+        )
+      ]);
+      expect(splittedModels.at(1) instanceof ObjectModel).toEqual(true);
+      expect(splittedModels[1]).toEqual(extendModel);
+      expect(splittedModels[1].options.extend).toBeUndefined();
+      expect(splittedModels[1].options.isExtended).toEqual(true);
+    });
+
+    test('should not set isExtended if a model with the same name is not extended somewhere', () => {
+      const extendModel = new ObjectModel('test', undefined, {}, {});
+      const model = new ObjectModel(
+        'model',
+        undefined,
+        {
+          extend: [extendModel]
+        },
+        {}
+      );
+
+      const options: SplitOptions = {
+        splitObject: true
+      };
+
+      const splittedModels = split(
+        new ObjectModel(
+          '',
+          undefined,
+          {},
+          {
+            model: new ObjectPropertyModel(model.name, true, model),
+            extendModel: new ObjectPropertyModel(
+              'test',
+              true,
+              new ObjectModel('test', undefined, {}, {})
+            )
+          }
+        ),
+        options
+      );
+
+      expect(splittedModels.length).toEqual(4);
+      expect(splittedModels.at(2)?.options.isExtended).toEqual(false);
+      expect(splittedModels.at(3)?.options.isExtended).toEqual(false);
+    });
+  });
 });

--- a/test/interpreter/unit/InterpretAllOf.spec.ts
+++ b/test/interpreter/unit/InterpretAllOf.spec.ts
@@ -107,7 +107,6 @@ describe('Interpretation of allOf', () => {
       interpreterOptionsAllowInheritance
     );
 
-    expect(interpreter.interpretAndCombineSchema).not.toHaveBeenCalled();
     expect(isModelObject).toHaveBeenCalled();
     expect(model.addExtendedModel).toHaveBeenCalledWith(interpretedModel);
   });

--- a/test/interpreter/unit/Interpreter.spec.ts
+++ b/test/interpreter/unit/Interpreter.spec.ts
@@ -313,4 +313,13 @@ describe('Interpreter', () => {
       expect(discriminator).toBe('OpenapiV3SchemaDiscriminatorPropertyName');
     });
   });
+  test('should not use cache if disableCache is set', () => {
+    const schema = { type: 'object' };
+    const interpreter = new Interpreter();
+    const model1 = interpreter.interpret(schema, { disableCache: false });
+    expect(model1).not.toBeUndefined();
+    const model2 = interpreter.interpret(schema, { disableCache: true });
+    expect(model2).not.toBeUndefined();
+    expect(model1).not.toBe(model2);
+  });
 });

--- a/test/models/CommonModel.spec.ts
+++ b/test/models/CommonModel.spec.ts
@@ -277,7 +277,7 @@ describe('CommonModel', () => {
         const doc = {};
         let doc1 = CommonModel.toCommonModel(doc);
         const doc2 = CommonModel.toCommonModel(doc);
-        doc2.extend = ['test'];
+        doc2.extend = [doc1];
         doc1 = CommonModel.mergeCommonModels(doc1, doc2, doc);
         expect(doc1.extend).toEqual(doc2.extend);
       });
@@ -895,7 +895,7 @@ describe('CommonModel', () => {
       extendedModel.$id = 'test';
       const model = new CommonModel();
       model.addExtendedModel(extendedModel);
-      expect(model.extend).toEqual(['test']);
+      expect(model.extend).toEqual([extendedModel]);
     });
     test('should ignore model if it has no $id', () => {
       const extendedModel = new CommonModel();
@@ -909,7 +909,7 @@ describe('CommonModel', () => {
       const model = new CommonModel();
       model.addExtendedModel(extendedModel);
       model.addExtendedModel(extendedModel);
-      expect(model.extend).toEqual(['test']);
+      expect(model.extend).toEqual([extendedModel]);
     });
   });
   describe('setTypes', () => {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

This is a preparation for adding inheritance with interfaces for Java in https://github.com/asyncapi/modelina/pull/1593

This PR finalizes what has been started regarding the `allowInheritance` option, and adds `extend` in the CommonModel, MetaModel, and ConstrainedMetaModel. It also adds logic in the Splitter to split our extended models and set `isExtended` in the options where this is needed.

**Related issue(s)**

See also https://github.com/asyncapi/modelina/issues/108. 