### PR TITLE
fix: set default to None for pydantic generator

### DIFF
--- a/examples/generate-python-pydantic-models/__snapshots__/index.spec.ts.snap
+++ b/examples/generate-python-pydantic-models/__snapshots__/index.spec.ts.snap
@@ -3,10 +3,10 @@
 exports[`Should be able to render python models and should log expected output to console: class-model 1`] = `
 Array [
   "class Root(BaseModel): 
-  optionalField: Optional[str] = Field(alias='''this field is optional''')
+  optionalField: Optional[str] = Field(alias='''this field is optional''', default=None)
   requiredField: str = Field(alias='''this field is required''')
-  noDescription: Optional[str] = Field()
-  options: Optional[Options] = Field()
+  noDescription: Optional[str] = Field(default=None)
+  options: Optional[Options] = Field(default=None)
 ",
 ]
 `;

--- a/src/generators/python/presets/Pydantic.ts
+++ b/src/generators/python/presets/Pydantic.ts
@@ -18,14 +18,18 @@ const PYTHON_PYDANTIC_CLASS_PRESET: ClassPresetType<PythonOptions> = {
     );
   },
   property(params) {
-    const type = params.property.required
-      ? params.property.property.type
-      : `Optional[${params.property.property.type}]`;
-    const alias = params.property.property.originalInput['description']
-      ? `alias='''${params.property.property.originalInput['description']}'''`
-      : '';
+    const { propertyName, required, property } = params.property;
+    const type = required ? property.type : `Optional[${property.type}]`;
+    const description = property.originalInput['description'];
+    const alias = description ? `alias='''${description}'''` : '';
+    const defaultValue = required ? '' : 'default=None';
 
-    return `${params.property.propertyName}: ${type} = Field(${alias})`;
+    if (alias && defaultValue) {
+      return `${propertyName}: ${type} = Field(${alias}, ${defaultValue})`;
+    } else if (alias) {
+      return `${propertyName}: ${type} = Field(${alias})`;
+    }
+    return `${propertyName}: ${type} = Field(${defaultValue})`;
   },
   ctor: () => '',
   getter: () => '',

--- a/test/generators/python/presets/__snapshots__/Pydantic.spec.ts.snap
+++ b/test/generators/python/presets/__snapshots__/Pydantic.spec.ts.snap
@@ -5,7 +5,7 @@ exports[`PYTHON_PYDANTIC_PRESET should render pydantic for class 1`] = `
   prop: Optional[str] = Field(alias='''test
     multi
     line
-    description''')
-  additionalProperties: Optional[dict[Any, Any]] = Field()
+    description''', default=None)
+  additionalProperties: Optional[dict[Any, Any]] = Field(default=None)
 "
 `;


### PR DESCRIPTION
In pydantic based python generator, when the optional values are passed, they need to be passed with an `default=None` argument in Field().

![image](https://github.com/asyncapi/modelina/assets/79367883/24fa0638-6b1e-459f-9ae1-d0e88a02f4b1)


**Related issue(s)**
 Fixes #1644 

