### PR TITLE
docs: add python constraint docs

### DIFF
--- a/docs/constraints/Python.md
+++ b/docs/constraints/Python.md
@@ -3,7 +3,7 @@
 These are the Python specific constraints applied to the MetaModel before reaching the presets. [Read here to get a more general idea on the overall process](../input-processing.md) of converting a MetaModel to a ConstrainedMetaModel.
 
 ## Model Naming
-These are the constraints that is applied to model naming. The `Rule key` is what you can use in the options to overwrite the default behavior. See [constraint customization](../constraints.md#Customization).
+These are the constraints that is applied to model naming. The `Rule key` is what you can use in the options to overwrite the default behavior. See [constraint customization](./README.md#Customization).
 
 |Rule key|Rule|Resolution|
 |---|---|---|
@@ -14,7 +14,7 @@ These are the constraints that is applied to model naming. The `Rule key` is wha
 |NAMING_FORMATTER|Must be formatted equally|Model name is formatted using pascal case|
 
 ## Property naming
-These are the constraints that is applied to object properties and the naming of them. The `Rule key` is what you can use in the options to overwrite the default behavior. See [constraint customization](../constraints.md#Customization).
+These are the constraints that is applied to object properties and the naming of them. The `Rule key` is what you can use in the options to overwrite the default behavior. See [constraint customization](./README.md#Customization).
 |Rule key|Rule|Resolution|
 |---|---|---|
 |NO_SPECIAL_CHAR|No special characters| Special characters are replaced by their name, for example `!` is replaced with `exclamation`. For python `_` is an exception to this rule. |
@@ -26,7 +26,7 @@ These are the constraints that is applied to object properties and the naming of
 
 
 ## Enum key constraints
-These are the constraints that is applied to enum keys. The `Rule key` is what you can use in the options to overwrite the default behavior. See [constraint customization](../constraints.md#Customization).
+These are the constraints that is applied to enum keys. The `Rule key` is what you can use in the options to overwrite the default behavior. See [constraint customization](./README.md#Customization).
 
 |Rule key|Rule|Resolution|
 |---|---|---|

--- a/docs/constraints/Python.md
+++ b/docs/constraints/Python.md
@@ -1,0 +1,41 @@
+# Python Constraints
+
+These are the Python specific constraints applied to the MetaModel before reaching the presets. [Read here to get a more general idea on the overall process](../input-processing.md) of converting a MetaModel to a ConstrainedMetaModel.
+
+## Model Naming
+These are the constraints that is applied to model naming. The `Rule key` is what you can use in the options to overwrite the default behavior. See [constraint customization](../constraints.md#Customization).
+
+|Rule key|Rule|Resolution|
+|---|---|---|
+|NO_SPECIAL_CHAR|No special characters| Special characters are replaced by their name, for example `!` is replaced with `exclamation`. For python `_` is an exception to this rule. |
+|NO_NUMBER_START_CHAR|No numbers as starting characters|Default behavior is pre pending `number_` in front of the first character|
+|NO_EMPTY_VALUE|No empty values|Default behavior is to use `empty` as name. |
+|NO_RESERVED_KEYWORDS|No reserved keywords|Python has a list of reserved keywords ([see the full list here](../../src/generators/python/Constants.ts))|
+|NAMING_FORMATTER|Must be formatted equally|Model name is formatted using pascal case|
+
+## Property naming
+These are the constraints that is applied to object properties and the naming of them. The `Rule key` is what you can use in the options to overwrite the default behavior. See [constraint customization](../constraints.md#Customization).
+|Rule key|Rule|Resolution|
+|---|---|---|
+|NO_SPECIAL_CHAR|No special characters| Special characters are replaced by their name, for example `!` is replaced with `exclamation`. For python `_` is an exception to this rule. |
+|NO_NUMBER_START_CHAR|No numbers as starting characters|Default behavior is pre pending `number_` in front of the first character|
+|NO_EMPTY_VALUE|No empty values|Default behavior is to use `empty` as name. |
+|NO_RESERVED_KEYWORDS|No reserved keywords|Python has a list of reserved keywords ([see the full list here](../../src/generators/python/Constants.ts))|
+|NAMING_FORMATTER|Must be formatted equally|Property name is formatted using camel case|
+|NO_DUPLICATE_PROPERTIES|No duplicate properties|If any of the above constraints changes the property name, we must make sure that no duplicates exist within the same object. If any is encountered `reserved_` is pre-pended. This is done recursively until no duplicates are found.| 
+
+
+## Enum key constraints
+These are the constraints that is applied to enum keys. The `Rule key` is what you can use in the options to overwrite the default behavior. See [constraint customization](../constraints.md#Customization).
+
+|Rule key|Rule|Resolution|
+|---|---|---|
+|NO_SPECIAL_CHAR|No special characters| Special characters are replaced by their name, for example `!` is replaced with `exclamation`. For python `_` is an exception to this rule. |
+|NO_NUMBER_START_CHAR|No numbers as starting characters|Default behavior is pre pending `number_` in front of the first character|
+|NO_EMPTY_VALUE|No empty values|Default behavior is to use `empty` as name. |
+|NO_RESERVED_KEYWORDS|No reserved keywords|Python has a list of reserved keywords ([see the full list here](../../src/generators/python/Constants.ts))|
+|NAMING_FORMATTER|Must be formatted equally|Enum name is formatted using constant case|
+|NO_DUPLICATE_KEYS|No duplicate enum keys|If any of the above constraints changes the enum key, we must make sure that no duplicates exist within the same enum. If any is encountered `reserved_` is pre-pended. This is done recursively until no duplicates are found.| 
+
+## Constant
+These are the constraints that are applied to constants. Currently, there are no hooks one can overwrite inside it.

--- a/docs/constraints/README.md
+++ b/docs/constraints/README.md
@@ -21,6 +21,7 @@ There are many rules as such, but to get the full description about the default 
 - [JavaScript](./constraints/JavaScript.md)
 - [Rust](./constraints/Rust.md)
 - [TypeScript](./constraints/TypeScript.md)
+- [Python](./constraints/Python.md)
 
 Even though there are many of these constraints, there might be reasons you want to customize the behavior to make it suit your use-case. Therefore each of the constraint rules can be overwritten completely and allow for you to implement your own behavior.
 


### PR DESCRIPTION
**Description**
This PR adds documentation for explaining the constraint rules in python

**Related issue(s)**
Fixes #1674
