### PR TITLE
feat!: add useJavascriptReservedKeywords option for TS

### DIFF
--- a/docs/migrations/version-2-to-3.md
+++ b/docs/migrations/version-2-to-3.md
@@ -21,9 +21,52 @@ const generator = new JavaFileGenerator({
 ## TypeScript
 
 ### JS reserved keywords are no longer applied by default
+By default up until now, JS reserved keywords have been checked for TS as well. Which means that something like:
 
 ```
+{
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    location: {
+      type: 'string'
+    }
+  }
+}
+```
 
+Would be default be rendered as:
+```ts
+class Root {
+  private _reservedLocation?: string;
+
+  constructor(input: {
+    reservedLocation?: string,
+  }) {
+    this._reservedLocation = input.reservedLocation;
+  }
+
+  get reservedLocation(): string | undefined { return this._reservedLocation; }
+  set reservedLocation(reservedLocation: string | undefined) { this._reservedLocation = reservedLocation; }
+}
+```
+
+However, without setting `useJavascriptReservedKeywords: true` by default the following will be generated:
+
+```ts
+class Root {
+  private _location?: string;
+
+  constructor(input: {
+    location?: string,
+  }) {
+    this._location = input.location;
+  }
+
+  get location(): string | undefined { return this._location; }
+  set location(location: string | undefined) { this._location = location; }
+}
 ```
 
 ## JavaScript

--- a/docs/migrations/version-2-to-3.md
+++ b/docs/migrations/version-2-to-3.md
@@ -18,17 +18,21 @@ const generator = new JavaFileGenerator({
 });
 ```
 
-### TypeScript
+## TypeScript
+
+### JS reserved keywords are no longer applied by default
+
+```
+
+```
+
+## JavaScript
 
 Is not affected by this change.
 
-### JavaScript
+## C#
 
-Is not affected by this change.
-
-### C#
-
-#### System.TimeSpan is used when format is time
+### System.TimeSpan is used when format is time
 
 This example used to generate a `string`, but is now instead using `System.TimeSpan`.
 
@@ -49,7 +53,7 @@ public class TestClass {
 }
 ```
 
-#### System.DateTime is used when format is date-time
+### System.DateTime is used when format is date-time
 
 This example used to generate a `string`, but is now instead using `System.DateTime`.
 
@@ -70,7 +74,7 @@ public class TestClass {
 }
 ```
 
-#### System.Guid is used when format is uuid
+### System.Guid is used when format is uuid
 
 This example used to generate a `string`, but is now instead using `System.Guid`.
 
@@ -91,9 +95,9 @@ public class TestClass {
 }
 ```
 
-### Java
+## Java
 
-#### java.time.Duration is used when format is duration
+### java.time.Duration is used when format is duration
 
 This example used to generate a `String`, but is now instead using `java.time.Duration`.
 
@@ -114,7 +118,7 @@ public class TestClass {
 }
 ```
 
-#### inheritance will generate interfaces
+### inheritance will generate interfaces
 
 Please read the section about [allowInheritance](#allowinheritance-set-to-true-will-enable-inheritance) first. When `allowInheritance` is enabled, interfaces will be generated for schemas that uses `allOf`:
 
@@ -223,17 +227,17 @@ public class Truck implements NewVehicle, Vehicle {
 }
 ```
 
-### Kotlin
+## Kotlin
 
 Is not affected by this change.
 
-### Rust
+## Rust
 
 Is not affected by this change.
 
-### Python
+## Python
 
-#### Union type for the Pydantic preset supports Python pre 3.10
+### Union type for the Pydantic preset supports Python pre 3.10
 
 Modelina used to use the newer way of representing unions in Python by using the `|` operator. In the Pydantic preset, this is now adjusted to support Python pre 3.10 by using `Union[Model1, Model2]` instead:
 
@@ -271,19 +275,19 @@ class Union2(BaseModel):
   additionalProperties: Optional[dict[Any, Any]] = Field()
 ```
 
-### Go
+## Go
 
 Is not affected by this change.
 
-### Dart
+## Dart
 
 Is not affected by this change.
 
-### C++
+## C++
 
 Is not affected by this change.
 
-### Options in constraints
+## Options in constraints
 
 As part of https://github.com/asyncapi/modelina/issues/1475 we had the need to access options in the constraint logic, therefore all constraints now have direct access to the provided options.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -117,6 +117,8 @@ These are all specific examples only relevant to the TypeScript generator:
 - [typescript-use-esm](./typescript-use-esm) - A basic example that generate the models to use ESM module system.
 - [typescript-use-cjs](./typescript-use-cjs) - A basic example that generate the models to use CJS module system.
 - [typescript-generate-jsonbinpack](./typescript-generate-jsonbinpack) - A basic example showing how to generate models that include [jsonbinpack](https://github.com/sourcemeta/jsonbinpack) functionality.
+- [typescript-use-js-reserved-keyword](./typescript-use-js-reserved-keyword) - A basic example showing how you can generate the models that take reserved JS keywords into account for model names, properties or enum keys. 
+
 
 ## Kotlin
 These are all specific examples only relevant to the Kotlin generator:

--- a/examples/typescript-use-esm/__snapshots__/index.spec.ts.snap
+++ b/examples/typescript-use-esm/__snapshots__/index.spec.ts.snap
@@ -2,6 +2,26 @@
 
 exports[`Should be able to render models to ESM module system and should log expected output to console 1`] = `
 Array [
+  "import Person from './Person';
+class Root {
+  private _person?: Person;
+
+  constructor(input: {
+    person?: Person,
+  }) {
+    this._person = input.person;
+  }
+
+  get person(): Person | undefined { return this._person; }
+  set person(person: Person | undefined) { this._person = person; }
+}
+export default Root;
+",
+]
+`;
+
+exports[`Should be able to render models to ESM module system and should log expected output to console 2`] = `
+Array [
   "
 class Person {
   private _email?: string;

--- a/examples/typescript-use-esm/index.spec.ts
+++ b/examples/typescript-use-esm/index.spec.ts
@@ -10,6 +10,7 @@ describe('Should be able to render models to ESM module system', () => {
   test('and should log expected output to console', async () => {
     await generate();
     expect(spy.mock.calls.length).toEqual(2);
+    expect(spy.mock.calls[0]).toMatchSnapshot();
     expect(spy.mock.calls[1]).toMatchSnapshot();
   });
 });

--- a/examples/typescript-use-js-reserved-keyword/README.md
+++ b/examples/typescript-use-js-reserved-keyword/README.md
@@ -1,0 +1,17 @@
+# TypeScript use JS reserved keywords
+
+This example shows how you can generate the models that ensure reserved JS keywords are not used for model names, properties or enum keys. 
+
+## How to run this example
+
+Run this example using:
+
+```sh
+npm i && npm run start
+```
+
+If you are on Windows, use the `start:windows` script instead:
+
+```sh
+npm i && npm run start:windows
+```

--- a/examples/typescript-use-js-reserved-keyword/__snapshots__/index.spec.ts.snap
+++ b/examples/typescript-use-js-reserved-keyword/__snapshots__/index.spec.ts.snap
@@ -1,9 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Should be able to render models to ESM module system and should log expected output to console 1`] = `
+exports[`Should be able to render models to not use reserved keywords from JS and should log expected output to console 1`] = `
 Array [
-  "
-class Person {
+  "class Root {
   private _reservedLocation?: string;
 
   constructor(input: {
@@ -14,8 +13,6 @@ class Person {
 
   get reservedLocation(): string | undefined { return this._reservedLocation; }
   set reservedLocation(reservedLocation: string | undefined) { this._reservedLocation = reservedLocation; }
-}
-export default Person;
-",
+}",
 ]
 `;

--- a/examples/typescript-use-js-reserved-keyword/__snapshots__/index.spec.ts.snap
+++ b/examples/typescript-use-js-reserved-keyword/__snapshots__/index.spec.ts.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Should be able to render models to ESM module system and should log expected output to console 1`] = `
+Array [
+  "
+class Person {
+  private _reservedLocation?: string;
+
+  constructor(input: {
+    reservedLocation?: string,
+  }) {
+    this._reservedLocation = input.reservedLocation;
+  }
+
+  get reservedLocation(): string | undefined { return this._reservedLocation; }
+  set reservedLocation(reservedLocation: string | undefined) { this._reservedLocation = reservedLocation; }
+}
+export default Person;
+",
+]
+`;

--- a/examples/typescript-use-js-reserved-keyword/index.spec.ts
+++ b/examples/typescript-use-js-reserved-keyword/index.spec.ts
@@ -3,13 +3,13 @@ const spy = jest.spyOn(global.console, 'log').mockImplementation(() => {
 });
 import { generate } from './index';
 
-describe('Should be able to render models to ESM module system', () => {
+describe('Should be able to render models to not use reserved keywords from JS', () => {
   afterAll(() => {
     jest.restoreAllMocks();
   });
   test('and should log expected output to console', async () => {
     await generate();
-    expect(spy.mock.calls.length).toEqual(2);
-    expect(spy.mock.calls[1]).toMatchSnapshot();
+    expect(spy.mock.calls.length).toEqual(1);
+    expect(spy.mock.calls[0]).toMatchSnapshot();
   });
 });

--- a/examples/typescript-use-js-reserved-keyword/index.spec.ts
+++ b/examples/typescript-use-js-reserved-keyword/index.spec.ts
@@ -1,0 +1,15 @@
+const spy = jest.spyOn(global.console, 'log').mockImplementation(() => {
+  return;
+});
+import { generate } from './index';
+
+describe('Should be able to render models to ESM module system', () => {
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+  test('and should log expected output to console', async () => {
+    await generate();
+    expect(spy.mock.calls.length).toEqual(2);
+    expect(spy.mock.calls[1]).toMatchSnapshot();
+  });
+});

--- a/examples/typescript-use-js-reserved-keyword/index.ts
+++ b/examples/typescript-use-js-reserved-keyword/index.ts
@@ -1,0 +1,31 @@
+import { TypeScriptGenerator } from '../../src';
+
+const generator = new TypeScriptGenerator({
+  useJavascriptReservedKeywords: true
+});
+const jsonSchemaDraft7 = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    person: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        location: {
+          type: 'string'
+        }
+      }
+    }
+  }
+};
+
+export async function generate(): Promise<void> {
+  const models = await generator.generateCompleteModels(jsonSchemaDraft7, {});
+  for (const model of models) {
+    console.log(model.result);
+  }
+}
+if (require.main === module) {
+  generate();
+}

--- a/examples/typescript-use-js-reserved-keyword/index.ts
+++ b/examples/typescript-use-js-reserved-keyword/index.ts
@@ -8,20 +8,14 @@ const jsonSchemaDraft7 = {
   type: 'object',
   additionalProperties: false,
   properties: {
-    person: {
-      type: 'object',
-      additionalProperties: false,
-      properties: {
-        location: {
-          type: 'string'
-        }
-      }
+    location: {
+      type: 'string'
     }
   }
 };
 
 export async function generate(): Promise<void> {
-  const models = await generator.generateCompleteModels(jsonSchemaDraft7, {});
+  const models = await generator.generate(jsonSchemaDraft7);
   for (const model of models) {
     console.log(model.result);
   }

--- a/examples/typescript-use-js-reserved-keyword/package-lock.json
+++ b/examples/typescript-use-js-reserved-keyword/package-lock.json
@@ -1,0 +1,10 @@
+{
+  "name": "typescript-use-js-reserved-keyword",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "hasInstallScript": true
+    }
+  }
+}

--- a/examples/typescript-use-js-reserved-keyword/package.json
+++ b/examples/typescript-use-js-reserved-keyword/package.json
@@ -1,0 +1,10 @@
+{
+  "config" : { "example_name" : "typescript-use-js-reserved-keyword" },
+  "scripts": {
+    "install": "cd ../.. && npm i",
+    "start": "../../node_modules/.bin/ts-node --cwd ../../ ./examples/$npm_package_config_example_name/index.ts",
+    "start:windows": "..\\..\\node_modules\\.bin\\ts-node --cwd ..\\..\\ .\\examples\\%npm_package_config_example_name%\\index.ts",
+    "test": "../../node_modules/.bin/jest --config=../../jest.config.js ./examples/$npm_package_config_example_name/index.spec.ts",
+    "test:windows": "..\\..\\node_modules\\.bin\\jest --config=..\\..\\jest.config.js examples/%npm_package_config_example_name%/index.spec.ts"
+  }
+}

--- a/src/generators/typescript/Constants.ts
+++ b/src/generators/typescript/Constants.ts
@@ -80,6 +80,8 @@ export function isReservedTypeScriptKeyword(
     RESERVED_TYPESCRIPT_KEYWORDS,
     forceLowerCase
   );
-  const isJsReserved = options?.useJavascriptReservedKeywords ? isReservedJavaScriptKeyword(word) : false;
+  const isJsReserved = options?.useJavascriptReservedKeywords
+    ? isReservedJavaScriptKeyword(word)
+    : false;
   return isTsReserved || isJsReserved;
 }

--- a/src/generators/typescript/Constants.ts
+++ b/src/generators/typescript/Constants.ts
@@ -1,5 +1,6 @@
 import { checkForReservedKeyword } from '../../helpers';
 import { isReservedJavaScriptKeyword } from '../javascript/Constants';
+import { TypeScriptOptions } from './TypeScriptGenerator';
 export const RESERVED_TYPESCRIPT_KEYWORDS = [
   'break',
   'case',
@@ -71,13 +72,14 @@ export const RESERVED_TYPESCRIPT_KEYWORDS = [
  */
 export function isReservedTypeScriptKeyword(
   word: string,
-  forceLowerCase = true
+  forceLowerCase = true,
+  options: TypeScriptOptions | undefined
 ): boolean {
-  return (
-    checkForReservedKeyword(
-      word,
-      RESERVED_TYPESCRIPT_KEYWORDS,
-      forceLowerCase
-    ) || isReservedJavaScriptKeyword(word)
+  const isTsReserved = checkForReservedKeyword(
+    word,
+    RESERVED_TYPESCRIPT_KEYWORDS,
+    forceLowerCase
   );
+  const isJsReserved = options?.useJavascriptReservedKeywords ? isReservedJavaScriptKeyword(word) : false;
+  return isTsReserved || isJsReserved;
 }

--- a/src/generators/typescript/TypeScriptGenerator.ts
+++ b/src/generators/typescript/TypeScriptGenerator.ts
@@ -52,6 +52,10 @@ export interface TypeScriptOptions
   constraints: Constraints<TypeScriptOptions>;
   moduleSystem: TypeScriptModuleSystemType;
   /**
+   * Use JS reserved keywords so the TS output models can easily be transpiled to JS
+   */
+  useJavascriptReservedKeywords: boolean;
+  /**
    * Use raw property names instead of constrained ones,
    * where you most likely need to access them with obj["propertyName"] instead of obj.propertyName
    */
@@ -92,6 +96,7 @@ export class TypeScriptGenerator extends AbstractGenerator<
     constraints: TypeScriptDefaultConstraints,
     moduleSystem: 'ESM',
     rawPropertyNames: false,
+    useJavascriptReservedKeywords: true,
     // Temporarily set
     dependencyManager: () => {
       return {} as TypeScriptDependencyManager;

--- a/src/generators/typescript/constrainer/EnumConstrainer.ts
+++ b/src/generators/typescript/constrainer/EnumConstrainer.ts
@@ -9,7 +9,8 @@ import { FormatHelpers } from '../../../helpers';
 import { isReservedTypeScriptKeyword } from '../Constants';
 import {
   TypeScriptEnumKeyConstraint,
-  TypeScriptEnumValueConstraint
+  TypeScriptEnumValueConstraint,
+  TypeScriptOptions
 } from '../TypeScriptGenerator';
 
 export type ModelEnumKeyConstraints = {
@@ -23,7 +24,7 @@ export type ModelEnumKeyConstraints = {
   ) => string;
   NO_EMPTY_VALUE: (value: string) => string;
   NAMING_FORMATTER: (value: string) => string;
-  NO_RESERVED_KEYWORDS: (value: string) => string;
+  NO_RESERVED_KEYWORDS: (value: string, options: TypeScriptOptions) => string;
 };
 
 export const DefaultEnumKeyConstraints: ModelEnumKeyConstraints = {
@@ -38,8 +39,8 @@ export const DefaultEnumKeyConstraints: ModelEnumKeyConstraints = {
   NO_DUPLICATE_KEYS: NO_DUPLICATE_ENUM_KEYS,
   NO_EMPTY_VALUE,
   NAMING_FORMATTER: FormatHelpers.toConstantCase,
-  NO_RESERVED_KEYWORDS: (value: string) => {
-    return NO_RESERVED_KEYWORDS(value, isReservedTypeScriptKeyword);
+  NO_RESERVED_KEYWORDS: (value: string, options: TypeScriptOptions) => {
+    return NO_RESERVED_KEYWORDS(value, (word) => isReservedTypeScriptKeyword(word, true, options));
   }
 };
 
@@ -48,12 +49,12 @@ export function defaultEnumKeyConstraints(
 ): TypeScriptEnumKeyConstraint {
   const constraints = { ...DefaultEnumKeyConstraints, ...customConstraints };
 
-  return ({ enumKey, enumModel, constrainedEnumModel }) => {
+  return ({ enumKey, enumModel, constrainedEnumModel, options }) => {
     let constrainedEnumKey = enumKey;
     constrainedEnumKey = constraints.NO_SPECIAL_CHAR(constrainedEnumKey);
     constrainedEnumKey = constraints.NO_NUMBER_START_CHAR(constrainedEnumKey);
     constrainedEnumKey = constraints.NO_EMPTY_VALUE(constrainedEnumKey);
-    constrainedEnumKey = constraints.NO_RESERVED_KEYWORDS(constrainedEnumKey);
+    constrainedEnumKey = constraints.NO_RESERVED_KEYWORDS(constrainedEnumKey, options);
     //If the enum key has been manipulated, lets make sure it don't clash with existing keys
     if (constrainedEnumKey !== enumKey) {
       constrainedEnumKey = constraints.NO_DUPLICATE_KEYS(

--- a/src/generators/typescript/constrainer/EnumConstrainer.ts
+++ b/src/generators/typescript/constrainer/EnumConstrainer.ts
@@ -40,7 +40,9 @@ export const DefaultEnumKeyConstraints: ModelEnumKeyConstraints = {
   NO_EMPTY_VALUE,
   NAMING_FORMATTER: FormatHelpers.toConstantCase,
   NO_RESERVED_KEYWORDS: (value: string, options: TypeScriptOptions) => {
-    return NO_RESERVED_KEYWORDS(value, (word) => isReservedTypeScriptKeyword(word, true, options));
+    return NO_RESERVED_KEYWORDS(value, (word) =>
+      isReservedTypeScriptKeyword(word, true, options)
+    );
   }
 };
 
@@ -54,7 +56,10 @@ export function defaultEnumKeyConstraints(
     constrainedEnumKey = constraints.NO_SPECIAL_CHAR(constrainedEnumKey);
     constrainedEnumKey = constraints.NO_NUMBER_START_CHAR(constrainedEnumKey);
     constrainedEnumKey = constraints.NO_EMPTY_VALUE(constrainedEnumKey);
-    constrainedEnumKey = constraints.NO_RESERVED_KEYWORDS(constrainedEnumKey, options);
+    constrainedEnumKey = constraints.NO_RESERVED_KEYWORDS(
+      constrainedEnumKey,
+      options
+    );
     //If the enum key has been manipulated, lets make sure it don't clash with existing keys
     if (constrainedEnumKey !== enumKey) {
       constrainedEnumKey = constraints.NO_DUPLICATE_KEYS(

--- a/src/generators/typescript/constrainer/ModelNameConstrainer.ts
+++ b/src/generators/typescript/constrainer/ModelNameConstrainer.ts
@@ -5,18 +5,18 @@ import {
 } from '../../../helpers/Constraints';
 import { FormatHelpers } from '../../../helpers';
 import { isReservedTypeScriptKeyword } from '../Constants';
-import { TypeScriptModelNameConstraint } from '../TypeScriptGenerator';
+import { TypeScriptModelNameConstraint, TypeScriptOptions } from '../TypeScriptGenerator';
 
 export type ModelNameConstraints = {
   NO_SPECIAL_CHAR: (value: string) => string;
   NO_NUMBER_START_CHAR: (value: string) => string;
   NO_EMPTY_VALUE: (value: string) => string;
   NAMING_FORMATTER: (value: string) => string;
-  NO_RESERVED_KEYWORDS: (value: string) => string;
+  NO_RESERVED_KEYWORDS: (value: string, options: TypeScriptOptions) => string;
 };
 
 export const DefaultModelNameConstraints: ModelNameConstraints = {
-  NO_SPECIAL_CHAR: (value: string) => {
+  NO_SPECIAL_CHAR: (value) => {
     //Exclude ` ` because it gets formatted by NAMING_FORMATTER
     //Exclude '_', '$' because they are allowed
     return FormatHelpers.replaceSpecialCharacters(value, {
@@ -26,11 +26,11 @@ export const DefaultModelNameConstraints: ModelNameConstraints = {
   },
   NO_NUMBER_START_CHAR,
   NO_EMPTY_VALUE,
-  NAMING_FORMATTER: (value: string) => {
+  NAMING_FORMATTER: (value) => {
     return FormatHelpers.toPascalCase(value);
   },
-  NO_RESERVED_KEYWORDS: (value: string) => {
-    return NO_RESERVED_KEYWORDS(value, isReservedTypeScriptKeyword);
+  NO_RESERVED_KEYWORDS: (value, options) => {
+    return NO_RESERVED_KEYWORDS(value, (word) => isReservedTypeScriptKeyword(word, true, options));
   }
 };
 export function defaultModelNameConstraints(
@@ -38,12 +38,12 @@ export function defaultModelNameConstraints(
 ): TypeScriptModelNameConstraint {
   const constraints = { ...DefaultModelNameConstraints, ...customConstraints };
 
-  return ({ modelName }) => {
+  return ({ modelName, options }) => {
     let constrainedValue = modelName;
     constrainedValue = constraints.NO_SPECIAL_CHAR(constrainedValue);
     constrainedValue = constraints.NO_NUMBER_START_CHAR(constrainedValue);
     constrainedValue = constraints.NO_EMPTY_VALUE(constrainedValue);
-    constrainedValue = constraints.NO_RESERVED_KEYWORDS(constrainedValue);
+    constrainedValue = constraints.NO_RESERVED_KEYWORDS(constrainedValue, options);
     constrainedValue = constraints.NAMING_FORMATTER(constrainedValue);
     return constrainedValue;
   };

--- a/src/generators/typescript/constrainer/ModelNameConstrainer.ts
+++ b/src/generators/typescript/constrainer/ModelNameConstrainer.ts
@@ -5,7 +5,10 @@ import {
 } from '../../../helpers/Constraints';
 import { FormatHelpers } from '../../../helpers';
 import { isReservedTypeScriptKeyword } from '../Constants';
-import { TypeScriptModelNameConstraint, TypeScriptOptions } from '../TypeScriptGenerator';
+import {
+  TypeScriptModelNameConstraint,
+  TypeScriptOptions
+} from '../TypeScriptGenerator';
 
 export type ModelNameConstraints = {
   NO_SPECIAL_CHAR: (value: string) => string;
@@ -30,7 +33,9 @@ export const DefaultModelNameConstraints: ModelNameConstraints = {
     return FormatHelpers.toPascalCase(value);
   },
   NO_RESERVED_KEYWORDS: (value, options) => {
-    return NO_RESERVED_KEYWORDS(value, (word) => isReservedTypeScriptKeyword(word, true, options));
+    return NO_RESERVED_KEYWORDS(value, (word) =>
+      isReservedTypeScriptKeyword(word, true, options)
+    );
   }
 };
 export function defaultModelNameConstraints(
@@ -43,7 +48,10 @@ export function defaultModelNameConstraints(
     constrainedValue = constraints.NO_SPECIAL_CHAR(constrainedValue);
     constrainedValue = constraints.NO_NUMBER_START_CHAR(constrainedValue);
     constrainedValue = constraints.NO_EMPTY_VALUE(constrainedValue);
-    constrainedValue = constraints.NO_RESERVED_KEYWORDS(constrainedValue, options);
+    constrainedValue = constraints.NO_RESERVED_KEYWORDS(
+      constrainedValue,
+      options
+    );
     constrainedValue = constraints.NAMING_FORMATTER(constrainedValue);
     return constrainedValue;
   };

--- a/src/generators/typescript/constrainer/PropertyKeyConstrainer.ts
+++ b/src/generators/typescript/constrainer/PropertyKeyConstrainer.ts
@@ -7,7 +7,7 @@ import {
 } from '../../../helpers/Constraints';
 import { FormatHelpers } from '../../../helpers';
 import { isReservedTypeScriptKeyword } from '../Constants';
-import { TypeScriptPropertyKeyConstraint } from '../TypeScriptGenerator';
+import { TypeScriptOptions, TypeScriptPropertyKeyConstraint } from '../TypeScriptGenerator';
 
 export type PropertyKeyConstraintOptions = {
   NO_SPECIAL_CHAR: (value: string) => string;
@@ -20,11 +20,11 @@ export type PropertyKeyConstraintOptions = {
   ) => string;
   NO_EMPTY_VALUE: (value: string) => string;
   NAMING_FORMATTER: (value: string) => string;
-  NO_RESERVED_KEYWORDS: (value: string) => string;
+  NO_RESERVED_KEYWORDS: (value: string, options: TypeScriptOptions) => string;
 };
 
 export const DefaultPropertyKeyConstraints: PropertyKeyConstraintOptions = {
-  NO_SPECIAL_CHAR: (value: string) => {
+  NO_SPECIAL_CHAR: (value) => {
     //Exclude ` ` because it gets formatted by NAMING_FORMATTER
     //Exclude '_', '$' because they are allowed
     return FormatHelpers.replaceSpecialCharacters(value, {
@@ -36,8 +36,8 @@ export const DefaultPropertyKeyConstraints: PropertyKeyConstraintOptions = {
   NO_DUPLICATE_PROPERTIES,
   NO_EMPTY_VALUE,
   NAMING_FORMATTER: FormatHelpers.toCamelCase,
-  NO_RESERVED_KEYWORDS: (value: string) => {
-    return NO_RESERVED_KEYWORDS(value, isReservedTypeScriptKeyword);
+  NO_RESERVED_KEYWORDS: (value, options) => {
+    return NO_RESERVED_KEYWORDS(value, (word) => isReservedTypeScriptKeyword(word, true, options));
   }
 };
 export function defaultPropertyKeyConstraints(
@@ -48,7 +48,7 @@ export function defaultPropertyKeyConstraints(
     ...customConstraints
   };
 
-  return ({ objectPropertyModel, constrainedObjectModel, objectModel }) => {
+  return ({ objectPropertyModel, constrainedObjectModel, objectModel, options}) => {
     let constrainedPropertyKey = objectPropertyModel.propertyName;
 
     constrainedPropertyKey = constraints.NO_SPECIAL_CHAR(
@@ -59,7 +59,8 @@ export function defaultPropertyKeyConstraints(
     );
     constrainedPropertyKey = constraints.NO_EMPTY_VALUE(constrainedPropertyKey);
     constrainedPropertyKey = constraints.NO_RESERVED_KEYWORDS(
-      constrainedPropertyKey
+      constrainedPropertyKey,
+      options
     );
     //If the property name has been manipulated, lets make sure it don't clash with existing properties
     if (constrainedPropertyKey !== objectPropertyModel.propertyName) {

--- a/src/generators/typescript/constrainer/PropertyKeyConstrainer.ts
+++ b/src/generators/typescript/constrainer/PropertyKeyConstrainer.ts
@@ -7,7 +7,10 @@ import {
 } from '../../../helpers/Constraints';
 import { FormatHelpers } from '../../../helpers';
 import { isReservedTypeScriptKeyword } from '../Constants';
-import { TypeScriptOptions, TypeScriptPropertyKeyConstraint } from '../TypeScriptGenerator';
+import {
+  TypeScriptOptions,
+  TypeScriptPropertyKeyConstraint
+} from '../TypeScriptGenerator';
 
 export type PropertyKeyConstraintOptions = {
   NO_SPECIAL_CHAR: (value: string) => string;
@@ -37,7 +40,9 @@ export const DefaultPropertyKeyConstraints: PropertyKeyConstraintOptions = {
   NO_EMPTY_VALUE,
   NAMING_FORMATTER: FormatHelpers.toCamelCase,
   NO_RESERVED_KEYWORDS: (value, options) => {
-    return NO_RESERVED_KEYWORDS(value, (word) => isReservedTypeScriptKeyword(word, true, options));
+    return NO_RESERVED_KEYWORDS(value, (word) =>
+      isReservedTypeScriptKeyword(word, true, options)
+    );
   }
 };
 export function defaultPropertyKeyConstraints(
@@ -48,7 +53,12 @@ export function defaultPropertyKeyConstraints(
     ...customConstraints
   };
 
-  return ({ objectPropertyModel, constrainedObjectModel, objectModel, options}) => {
+  return ({
+    objectPropertyModel,
+    constrainedObjectModel,
+    objectModel,
+    options
+  }) => {
     let constrainedPropertyKey = objectPropertyModel.propertyName;
 
     constrainedPropertyKey = constraints.NO_SPECIAL_CHAR(

--- a/test/generators/typescript/constrainer/ModelNameConstrainer.spec.ts
+++ b/test/generators/typescript/constrainer/ModelNameConstrainer.spec.ts
@@ -40,7 +40,7 @@ describe('ModelNameConstrainer', () => {
       options: TypeScriptGenerator.defaultOptions
     });
     expect(constrainedKey).toEqual('ReservedReturn');
-  });  
+  });
   test('should never render reserved JS keywords by default', () => {
     const constrainedKey = TypeScriptDefaultConstraints.modelName({
       modelName: 'location',

--- a/test/generators/typescript/constrainer/ModelNameConstrainer.spec.ts
+++ b/test/generators/typescript/constrainer/ModelNameConstrainer.spec.ts
@@ -40,6 +40,16 @@ describe('ModelNameConstrainer', () => {
       options: TypeScriptGenerator.defaultOptions
     });
     expect(constrainedKey).toEqual('ReservedReturn');
+  });  
+  test('should never render reserved JS keywords by default', () => {
+    const constrainedKey = TypeScriptDefaultConstraints.modelName({
+      modelName: 'location',
+      options: {
+        ...TypeScriptGenerator.defaultOptions,
+        useJavascriptReservedKeywords: true
+      }
+    });
+    expect(constrainedKey).toEqual('ReservedLocation');
   });
   describe('custom constraints', () => {
     test('should be able to overwrite all hooks', () => {


### PR DESCRIPTION
## Description
Right now by default, we include JS keywords when checking for whether TS enum keys, properties, or model names can be a certain word. However, in most cases, people probably don't transpile their models into JS and so do not need that functionality. 

Introducing this option `useJavascriptReservedKeywords` makes it optional for people to include the list or not.

## Related Issue
Fixes https://github.com/asyncapi/modelina/issues/1206
Fixes https://github.com/asyncapi/modelina/issues/1053
