### PR TITLE
fix: recursion bug for get nearest dependencies

### DIFF
--- a/src/generators/typescript/TypeScriptConstrainer.ts
+++ b/src/generators/typescript/TypeScriptConstrainer.ts
@@ -55,13 +55,18 @@ export const TypeScriptDefaultTypeMapping: TypeScriptTypeMapping = {
     return constrainedModel.name;
   },
   Union(args): string {
-    const unionTypes = args.constrainedModel.union.map((unionModel) => {
+    const unionTypes = [];
+    for (const unionModel of args.constrainedModel.union) {
       if (unionModel.options.const?.value) {
-        return `${unionModel.options.const.value}`;
+        unionTypes.push(`${unionModel.options.const.value}`);
       }
 
-      return unionModel.type;
-    });
+      // Ignore union model that don't have a type yet i.e. self-reference
+      if (unionModel.type === '') {
+        continue;
+      }
+      unionTypes.push(unionModel.type);
+    }
     return applyNullable(args.constrainedModel, unionTypes.join(' | '));
   },
   Dictionary({ constrainedModel, options }): string {

--- a/src/generators/typescript/TypeScriptConstrainer.ts
+++ b/src/generators/typescript/TypeScriptConstrainer.ts
@@ -55,18 +55,13 @@ export const TypeScriptDefaultTypeMapping: TypeScriptTypeMapping = {
     return constrainedModel.name;
   },
   Union(args): string {
-    const unionTypes = [];
-    for (const unionModel of args.constrainedModel.union) {
+    const unionTypes = args.constrainedModel.union.map((unionModel) => {
       if (unionModel.options.const?.value) {
-        unionTypes.push(`${unionModel.options.const.value}`);
+        return `${unionModel.options.const.value}`;
       }
 
-      // Ignore union model that don't have a type yet i.e. self-reference
-      if (unionModel.type === '') {
-        continue;
-      }
-      unionTypes.push(unionModel.type);
-    }
+      return unionModel.type;
+    });
     return applyNullable(args.constrainedModel, unionTypes.join(' | '));
   },
   Dictionary({ constrainedModel, options }): string {

--- a/src/models/ConstrainedMetaModel.ts
+++ b/src/models/ConstrainedMetaModel.ts
@@ -28,6 +28,7 @@ export class ConstrainedMetaModelOptions extends MetaModelOptions {
 export interface GetNearestDependenciesArgument {
   alreadyVisitedNodes: any[];
 }
+
 const defaultGetNearestDependenciesArgument: GetNearestDependenciesArgument = {
   alreadyVisitedNodes: []
 };
@@ -119,7 +120,6 @@ export class ConstrainedTupleModel extends ConstrainedMetaModel {
       } else if (
         !argumentsToUse.alreadyVisitedNodes.includes(tupleModel.value)
       ) {
-        argumentsToUse.alreadyVisitedNodes.push(tupleModel.value);
         //Lets check the non-reference model for dependencies
         dependencyModels = [
           ...dependencyModels,
@@ -163,9 +163,10 @@ export class ConstrainedArrayModel extends ConstrainedMetaModel {
     argumentsToUse.alreadyVisitedNodes.push(this);
     if (this.valueModel instanceof ConstrainedReferenceModel) {
       return [this.valueModel];
+    } else if (!argumentsToUse.alreadyVisitedNodes.includes(this.valueModel)) {
+      return this.valueModel.getNearestDependencies(argumentsToUse);
     }
-
-    return this.valueModel.getNearestDependencies(argumentsToUse);
+    return [];
   }
 }
 export class ConstrainedUnionModel extends ConstrainedMetaModel {

--- a/src/models/ConstrainedMetaModel.ts
+++ b/src/models/ConstrainedMetaModel.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { DeepPartial, mergePartialAndDefault } from '../utils';
 import { makeUnique } from '../helpers/DependencyHelpers';
 import {
   MetaModel,
@@ -22,6 +24,13 @@ export class ConstrainedMetaModelOptions extends MetaModelOptions {
   parents?: ConstrainedMetaModel[];
   extend?: ConstrainedMetaModel[];
 }
+
+export interface GetNearestDependenciesArgument {
+  alreadyVisitedNodes: any[];
+}
+const defaultGetNearestDependenciesArgument: GetNearestDependenciesArgument = {
+  alreadyVisitedNodes: []
+};
 
 export abstract class ConstrainedMetaModel extends MetaModel {
   public options: ConstrainedMetaModelOptions;
@@ -55,7 +64,9 @@ export abstract class ConstrainedMetaModel extends MetaModel {
    *
    * This is often used when you want to know which other models you are referencing.
    */
-  getNearestDependencies(): ConstrainedMetaModel[] {
+  getNearestDependencies(
+    arg?: DeepPartial<GetNearestDependenciesArgument>
+  ): ConstrainedMetaModel[] {
     return [];
   }
 }
@@ -93,16 +104,26 @@ export class ConstrainedTupleModel extends ConstrainedMetaModel {
     super(name, originalInput, options, type);
   }
 
-  getNearestDependencies(): ConstrainedMetaModel[] {
+  getNearestDependencies(
+    arg?: DeepPartial<GetNearestDependenciesArgument>
+  ): ConstrainedMetaModel[] {
+    const argumentsToUse = mergePartialAndDefault(
+      defaultGetNearestDependenciesArgument,
+      arg
+    ) as GetNearestDependenciesArgument;
+    argumentsToUse.alreadyVisitedNodes.push(this);
     let dependencyModels: ConstrainedMetaModel[] = [];
     for (const tupleModel of Object.values(this.tuple)) {
       if (tupleModel.value instanceof ConstrainedReferenceModel) {
         dependencyModels.push(tupleModel.value);
-      } else {
+      } else if (
+        !argumentsToUse.alreadyVisitedNodes.includes(tupleModel.value)
+      ) {
+        argumentsToUse.alreadyVisitedNodes.push(tupleModel.value);
         //Lets check the non-reference model for dependencies
         dependencyModels = [
           ...dependencyModels,
-          ...tupleModel.value.getNearestDependencies()
+          ...tupleModel.value.getNearestDependencies(argumentsToUse)
         ];
       }
     }
@@ -132,11 +153,19 @@ export class ConstrainedArrayModel extends ConstrainedMetaModel {
     super(name, originalInput, options, type);
   }
 
-  getNearestDependencies(): ConstrainedMetaModel[] {
+  getNearestDependencies(
+    arg?: DeepPartial<GetNearestDependenciesArgument>
+  ): ConstrainedMetaModel[] {
+    const argumentsToUse = mergePartialAndDefault(
+      defaultGetNearestDependenciesArgument,
+      arg
+    ) as GetNearestDependenciesArgument;
+    argumentsToUse.alreadyVisitedNodes.push(this);
     if (this.valueModel instanceof ConstrainedReferenceModel) {
       return [this.valueModel];
     }
-    return this.valueModel.getNearestDependencies();
+
+    return this.valueModel.getNearestDependencies(argumentsToUse);
   }
 }
 export class ConstrainedUnionModel extends ConstrainedMetaModel {
@@ -150,16 +179,23 @@ export class ConstrainedUnionModel extends ConstrainedMetaModel {
     super(name, originalInput, options, type);
   }
 
-  getNearestDependencies(): ConstrainedMetaModel[] {
+  getNearestDependencies(
+    arg?: DeepPartial<GetNearestDependenciesArgument>
+  ): ConstrainedMetaModel[] {
+    const argumentsToUse = mergePartialAndDefault(
+      defaultGetNearestDependenciesArgument,
+      arg
+    ) as GetNearestDependenciesArgument;
+    argumentsToUse.alreadyVisitedNodes.push(this);
     let dependencyModels: ConstrainedMetaModel[] = [];
     for (const unionModel of Object.values(this.union)) {
       if (unionModel instanceof ConstrainedReferenceModel) {
         dependencyModels.push(unionModel);
-      } else {
+      } else if (!argumentsToUse.alreadyVisitedNodes.includes(unionModel)) {
         //Lets check the non-reference model for dependencies
         dependencyModels = [
           ...dependencyModels,
-          ...unionModel.getNearestDependencies()
+          ...unionModel.getNearestDependencies(argumentsToUse)
         ];
       }
     }
@@ -201,17 +237,24 @@ export class ConstrainedDictionaryModel extends ConstrainedMetaModel {
     super(name, originalInput, options, type);
   }
 
-  getNearestDependencies(): ConstrainedMetaModel[] {
+  getNearestDependencies(
+    arg?: DeepPartial<GetNearestDependenciesArgument>
+  ): ConstrainedMetaModel[] {
+    const argumentsToUse = mergePartialAndDefault(
+      defaultGetNearestDependenciesArgument,
+      arg
+    ) as GetNearestDependenciesArgument;
+    argumentsToUse.alreadyVisitedNodes.push(this);
     const dependencies = [this.key, this.value];
     let dependencyModels: ConstrainedMetaModel[] = [];
     for (const model of dependencies) {
       if (model instanceof ConstrainedReferenceModel) {
         dependencyModels.push(model);
-      } else {
+      } else if (!argumentsToUse.alreadyVisitedNodes.includes(model)) {
         //Lets check the non-reference model for dependencies
         dependencyModels = [
           ...dependencyModels,
-          ...model.getNearestDependencies()
+          ...model.getNearestDependencies(argumentsToUse)
         ];
       }
     }
@@ -234,16 +277,25 @@ export class ConstrainedObjectModel extends ConstrainedMetaModel {
     super(name, originalInput, options, type);
   }
 
-  getNearestDependencies(): ConstrainedMetaModel[] {
+  getNearestDependencies(
+    arg?: DeepPartial<GetNearestDependenciesArgument>
+  ): ConstrainedMetaModel[] {
+    const argumentsToUse = mergePartialAndDefault(
+      defaultGetNearestDependenciesArgument,
+      arg
+    ) as GetNearestDependenciesArgument;
+    argumentsToUse.alreadyVisitedNodes.push(this);
     let dependencyModels: ConstrainedMetaModel[] = [];
     for (const modelProperty of Object.values(this.properties)) {
       if (modelProperty.property instanceof ConstrainedReferenceModel) {
         dependencyModels.push(modelProperty.property);
-      } else {
+      } else if (
+        !argumentsToUse.alreadyVisitedNodes.includes(modelProperty.property)
+      ) {
         //Lets check the non-reference model for dependencies
         dependencyModels = [
           ...dependencyModels,
-          ...modelProperty.property.getNearestDependencies()
+          ...modelProperty.property.getNearestDependencies(argumentsToUse)
         ];
       }
     }

--- a/src/utils/Partials.ts
+++ b/src/utils/Partials.ts
@@ -36,7 +36,7 @@ export function mergePartialAndDefault<T extends Record<string, any>>(
   customOptional?: DeepPartial<T>
 ): T {
   if (customOptional === undefined) {
-    return defaultNonOptional;
+    return { ...defaultNonOptional };
   }
   // create a new object
   const target = { ...defaultNonOptional } as Record<string, any>;
@@ -46,6 +46,7 @@ export function mergePartialAndDefault<T extends Record<string, any>>(
     const isObjectOrClass =
       typeof prop === 'object' && target[propName] !== undefined;
     const isRegularObject = !isClass(prop);
+
     if (isObjectOrClass && isRegularObject) {
       target[propName] = mergePartialAndDefault(target[propName], prop);
     } else if (prop) {

--- a/src/utils/Partials.ts
+++ b/src/utils/Partials.ts
@@ -36,18 +36,24 @@ export function mergePartialAndDefault<T extends Record<string, any>>(
   customOptional?: DeepPartial<T>
 ): T {
   if (customOptional === undefined) {
-    return { ...defaultNonOptional };
+    return Object.assign({}, defaultNonOptional);
   }
   // create a new object
-  const target = { ...defaultNonOptional } as Record<string, any>;
+  const target = Object.assign({}, defaultNonOptional) as Record<string, any>;
 
   // deep merge the object into the target object
   for (const [propName, prop] of Object.entries(customOptional)) {
     const isObjectOrClass =
       typeof prop === 'object' && target[propName] !== undefined;
     const isRegularObject = !isClass(prop);
-
-    if (isObjectOrClass && isRegularObject) {
+    const isArray = Array.isArray(prop);
+    if (isArray) {
+      // merge array into target with a new array instance so we dont touch the default value
+      target[propName] = Array(target[propName]);
+      for (const [index, value] of prop.entries()) {
+        target[propName][index] = value;
+      }
+    } else if (isObjectOrClass && isRegularObject) {
       target[propName] = mergePartialAndDefault(target[propName], prop);
     } else if (prop) {
       target[propName] = prop;

--- a/test/utils/Partials.spec.ts
+++ b/test/utils/Partials.spec.ts
@@ -100,4 +100,22 @@ describe('mergePartialAndDefault', () => {
     expect(realizedOptions.nestedObject instanceof TestClass).toEqual(true);
     expect(realizedOptions.nestedObject.test()).toEqual(true);
   });
+
+  test('should not return default options instance', () => {
+    interface TestType {
+      array: string[];
+    }
+    const defaultOptions: TestType = {
+      array: []
+    };
+    const partialOptions: DeepPartial<TestType> = {
+      array: ['test']
+    };
+    const realizedOptions = mergePartialAndDefault(
+      defaultOptions,
+      partialOptions
+    ) as TestType;
+    expect(defaultOptions).toEqual({ array: [] });
+    expect(realizedOptions).toEqual({ array: ['test'] });
+  });
 });


### PR DESCRIPTION
## Description
This PR fixes a problem where `getNearestDependencies` could not handle circular dependencies. 

I had to fix a few other problems as well:
- Fixed a problem with `partials` where the default value is returned as is instead of returning a new instance.

## Related Issue
Fixes https://github.com/asyncapi/modelina/issues/1479