### PR TITLE
chore(website): add typescript map type option to the playground

### DIFF
--- a/modelina-website/src/components/contexts/PlaygroundContext.tsx
+++ b/modelina-website/src/components/contexts/PlaygroundContext.tsx
@@ -63,6 +63,7 @@ export const PlaygroundContextProvider: React.FC<{ children: React.ReactNode; }>
     tsMarshalling: false,
     tsModelType: 'class',
     tsEnumType: 'enum',
+    tsMapType: 'indexedObject',
     tsModuleSystem: 'CJS',
     tsIncludeDescriptions: false,
     tsIncludeExampleFunction: false,

--- a/modelina-website/src/components/contexts/PlaygroundContext.tsx
+++ b/modelina-website/src/components/contexts/PlaygroundContext.tsx
@@ -63,7 +63,7 @@ export const PlaygroundContextProvider: React.FC<{ children: React.ReactNode; }>
     tsMarshalling: false,
     tsModelType: 'class',
     tsEnumType: 'enum',
-    tsMapType: 'indexedObject',
+    tsMapType: 'map',
     tsModuleSystem: 'CJS',
     tsIncludeDescriptions: false,
     tsIncludeExampleFunction: false,

--- a/modelina-website/src/components/playground/Playground.tsx
+++ b/modelina-website/src/components/playground/Playground.tsx
@@ -86,6 +86,9 @@ const Playground: React.FC<ModelinaPlaygroundProps> = (props) => {
     if (query.tsEnumType !== undefined) {
       setConfig({ ...config, tsEnumType: query.tsEnumType as any });
     }
+    if (query.tsMapType !== undefined) {
+      setConfig({ ...config, tsMapType: query.tsMapType as any });
+    }
     if (query.tsIncludeDescriptions !== undefined) {
       setConfig({ ...config, tsIncludeDescriptions: query.tsIncludeDescriptions === 'true' });
     }

--- a/modelina-website/src/components/playground/options/TypeScriptGeneratorOptions.tsx
+++ b/modelina-website/src/components/playground/options/TypeScriptGeneratorOptions.tsx
@@ -35,6 +35,10 @@ const TypeScriptGeneratorOptions: React.FC<TypeScriptGeneratorOptionsProps> = ({
     setNewConfig && setNewConfig('tsEnumType', enumType);
   };
 
+  const onChangeMapType = (mapType: string) => {
+    setNewConfig && setNewConfig('tsMapType', mapType);
+  };
+
   const onChangeIncludeJsonBinPack = (event: React.ChangeEvent<HTMLInputElement>) => {
     if (setNewConfig) {
       const shouldIncludeMarshalling = context?.tsMarshalling === false && event.target.checked === true;
@@ -97,6 +101,30 @@ const TypeScriptGeneratorOptions: React.FC<TypeScriptGeneratorOptionsProps> = ({
             ]}
             value={context?.tsEnumType}
             onChange={onChangeEnumType}
+            className="shadow-outline-blue cursor-pointer"
+          />
+        </label>
+      </li>
+      <li className="flex gap-1 items-center">
+        <InfoModal text='TypeScript map type: ' >
+          <p>
+            It indicates which type should be rendered for some map type. Its value can be either indexedObject, map or record.
+            <br /> <br />
+            The default value is indexedObject.
+          </p>
+        </InfoModal>
+        <label className="flex flex-grow gap-1 items-center py-2 justify-between cursor-pointer">
+          <span className="mt-1 max-w-2xl text-sm text-gray-500">
+            TypeScript map type
+          </span>
+          <Select
+            options={[
+              { value: 'indexedObject', text: 'Indexed Object' },
+              { value: 'map', text: 'Map' },
+              { value: 'record', text: 'record' }
+            ]}
+            value={context?.tsMapType}
+            onChange={onChangeMapType}
             className="shadow-outline-blue cursor-pointer"
           />
         </label>

--- a/modelina-website/src/components/playground/options/TypeScriptGeneratorOptions.tsx
+++ b/modelina-website/src/components/playground/options/TypeScriptGeneratorOptions.tsx
@@ -108,9 +108,9 @@ const TypeScriptGeneratorOptions: React.FC<TypeScriptGeneratorOptionsProps> = ({
       <li className="flex gap-1 items-center">
         <InfoModal text='TypeScript map type: ' >
           <p>
-            It indicates which type should be rendered for some map type. Its value can be either indexedObject, map or record.
+            It indicates which type should be rendered for some map type. Its value can be either map, indexedObject, or record.
             <br /> <br />
-            The default value is indexedObject.
+            The default value is map.
           </p>
         </InfoModal>
         <label className="flex flex-grow gap-1 items-center py-2 justify-between cursor-pointer">
@@ -121,7 +121,7 @@ const TypeScriptGeneratorOptions: React.FC<TypeScriptGeneratorOptionsProps> = ({
             options={[
               { value: 'indexedObject', text: 'Indexed Object' },
               { value: 'map', text: 'Map' },
-              { value: 'record', text: 'record' }
+              { value: 'record', text: 'Record' }
             ]}
             value={context?.tsMapType}
             onChange={onChangeMapType}

--- a/modelina-website/src/helpers/GeneratorCode/TypeScriptGenerator.ts
+++ b/modelina-website/src/helpers/GeneratorCode/TypeScriptGenerator.ts
@@ -39,6 +39,10 @@ export function getTypeScriptGeneratorCode(
     optionString.push(`enumType: '${generatorOptions.tsEnumType}'`);
   }
 
+  if (generatorOptions.tsMapType) {
+    optionString.push(`mapType: '${generatorOptions.tsMapType}'`);
+  }
+
   if (generatorOptions.tsIncludeDescriptions === true) {
     optionStringPresets.push(`{
     preset: TS_DESCRIPTION_PRESET,

--- a/modelina-website/src/pages/api/functions/TypeScriptGenerator.ts
+++ b/modelina-website/src/pages/api/functions/TypeScriptGenerator.ts
@@ -66,6 +66,10 @@ export async function getTypeScriptModels(
     options.enumType = generatorOptions.tsEnumType as any;
   }
 
+  if (generatorOptions.tsMapType) {
+    options.mapType = generatorOptions.tsMapType as any;
+  }
+  
   if (generatorOptions.showTypeMappingExample) {
     options.typeMapping = {
       Integer: ({ dependencyManager }) => {

--- a/modelina-website/src/types/index.ts
+++ b/modelina-website/src/types/index.ts
@@ -163,6 +163,7 @@ export interface ModelinaTypeScriptQueryOptions {
   tsMarshalling?: string;
   tsModelType?: string;
   tsEnumType?: string;
+  tsMapType?: string;
   tsIncludeDescriptions?: string;
   tsIncludeJsonBinPack?: string;
   tsIncludeExampleFunction?: string;

--- a/modelina-website/src/types/index.ts
+++ b/modelina-website/src/types/index.ts
@@ -27,6 +27,7 @@ export interface ModelinaTypeScriptOptions extends ModelinaGeneralOptions {
   tsMarshalling: boolean;
   tsModelType: 'class' | 'interface' | undefined;
   tsEnumType: 'union' | 'enum' | undefined;
+  tsMapType: 'indexedObject' | 'map' | 'record' | undefined;
   tsModuleSystem: 'ESM' | 'CJS' | undefined;
   tsIncludeDescriptions: boolean;
   tsIncludeJsonBinPack: boolean;


### PR DESCRIPTION
## Description
Add TypeScript option for `mapType` to the playground.

## Related Issue
Fixes #1756 

## Checklist
- [x] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [x] Tests have been added or updated to cover the changes.
- [x] Documentation has been updated to reflect the changes.
- [x] All tests pass successfully locally.(`npm run test`).

## Additional Notes
<!-- Add any additional information or context that might be relevant to reviewers. -->
@jonaslagoni 
