### PR TITLE
feat: ensure C# types are generated with 'partial' modifier.

### DIFF
--- a/examples/adapting-input-and-output/__snapshots__/index.spec.ts.snap
+++ b/examples/adapting-input-and-output/__snapshots__/index.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`Should be able to generate a model with custom input and output and should log expected output to console 1`] = `
 Array [
-  "public class Address
+  "public partial class Address
 {
   public Dictionary<string, object> dictionaryProp;
 }",

--- a/examples/csharp-auto-implemented-properties/__snapshots__/index.spec.ts.snap
+++ b/examples/csharp-auto-implemented-properties/__snapshots__/index.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`Should be able to render auto-implemented properties in CSharp and should log expected output to console 1`] = `
 Array [
-  "public class Root
+  "public partial class Root
 {
   public string[]? Emails { get; set; }
   public string? StringProp { get; set; }

--- a/examples/csharp-change-collection-type/__snapshots__/index.spec.ts.snap
+++ b/examples/csharp-change-collection-type/__snapshots__/index.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`Should be able to render collections in C# as IEnumerable and should log expected output to console 1`] = `
 Array [
-  "public class Root
+  "public partial class Root
 {
   private IEnumerable<string>? email;
 

--- a/examples/csharp-generate-equals-and-hashcode/__snapshots__/index.spec.ts.snap
+++ b/examples/csharp-generate-equals-and-hashcode/__snapshots__/index.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`Should be able to generate a model to overwrite the Equal and GetHashCode methods and should log expected output to console 1`] = `
 Array [
-  "public class Root
+  "public partial class Root
 {
   private string? email;
 

--- a/examples/csharp-generate-handle-nullable/__snapshots__/index.spec.ts.snap
+++ b/examples/csharp-generate-handle-nullable/__snapshots__/index.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`Should be able to render a C# class with null warning removed with handleNullable option and should log expected output to console 1`] = `
 Array [
-  "public class Root
+  "public partial class Root
 {
   public string? Email { get; set; }
   public string Name { get; set; } = null!;

--- a/examples/csharp-generate-json-serializer/__snapshots__/index.spec.ts.snap
+++ b/examples/csharp-generate-json-serializer/__snapshots__/index.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`Should be able to generate a model with functions to serialize the data model into JSON and should log expected output to console 1`] = `
 Array [
   "[JsonConverter(typeof(RootConverter))]
-public class Root
+public partial class Root
 {
   private string? email;
 

--- a/examples/csharp-generate-newtonsoft-serializer/__snapshots__/index.spec.ts.snap
+++ b/examples/csharp-generate-newtonsoft-serializer/__snapshots__/index.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`Should be able to generate a model with functions to serialize the data model into JSON and should log expected output to console 1`] = `
 Array [
   "[JsonConverter(typeof(RootConverter))]
-public class Root
+public partial class Root
 {
   private string? email;
 

--- a/examples/csharp-generate-records/__snapshots__/index.spec.ts.snap
+++ b/examples/csharp-generate-records/__snapshots__/index.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`Should be able to render a C# record instead of a class using the modelType option and should log expected output to console 1`] = `
 Array [
-  "public record Root
+  "public partial record Root
 {
   public IEnumerable<string>? Email { get; init; }
   public required string Name { get; init; }

--- a/examples/csharp-generate-required-properties/__snapshots__/index.spec.ts.snap
+++ b/examples/csharp-generate-required-properties/__snapshots__/index.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`Should be able to render required properties without the question mark at the end if the type of it is not nullable and should log expected output to console 1`] = `
 Array [
-  "public class Root
+  "public partial class Root
 {
   private bool requiredBoolean;
   private bool? notRequiredBoolean;

--- a/examples/generate-csharp-models/__snapshots__/index.spec.ts.snap
+++ b/examples/generate-csharp-models/__snapshots__/index.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`Should be able to render C# models and should log expected output to console 1`] = `
 Array [
-  "public class Root
+  "public partial class Root
 {
   private string? email;
   private System.DateTime? today;

--- a/src/generators/csharp/renderers/ClassRenderer.ts
+++ b/src/generators/csharp/renderers/ClassRenderer.ts
@@ -30,7 +30,7 @@ export class ClassRenderer extends CSharpRenderer<ConstrainedObjectModel> {
       this.dependencyManager.addDependency('using System.Collections.Generic;');
     }
 
-    return `public class ${this.model.name}
+    return `public partial class ${this.model.name}
 {
 ${this.indent(this.renderBlock(content, 2))}
 }`;

--- a/src/generators/csharp/renderers/RecordRenderer.ts
+++ b/src/generators/csharp/renderers/RecordRenderer.ts
@@ -27,7 +27,7 @@ export class RecordRenderer extends CSharpRenderer<ConstrainedObjectModel> {
       this.dependencyManager.addDependency('using System.Collections.Generic;');
     }
 
-    return `public record ${this.model.name}
+    return `public partial record ${this.model.name}
 {
 ${this.indent(this.renderBlock(content, 2))}
 }`;

--- a/test/generators/csharp/__snapshots__/CSharpGenerator.spec.ts.snap
+++ b/test/generators/csharp/__snapshots__/CSharpGenerator.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CSharpGenerator class renderer should be able to overwrite accessor preset hook 1`] = `
-"public class CustomClass
+"public partial class CustomClass
 {
   private string? property;
   private Dictionary<string, string>? additionalProperties;
@@ -13,7 +13,7 @@ exports[`CSharpGenerator class renderer should be able to overwrite accessor pre
 `;
 
 exports[`CSharpGenerator class renderer should be able to overwrite property preset hook 1`] = `
-"public class CustomClass
+"public partial class CustomClass
 {
   my own property
   my own property
@@ -33,7 +33,7 @@ exports[`CSharpGenerator class renderer should be able to overwrite property pre
 `;
 
 exports[`CSharpGenerator should render \`class\` type 1`] = `
-"public class Address
+"public partial class Address
 {
   private string streetName;
   private string city;
@@ -143,7 +143,7 @@ public static class ThingsExtensions
 `;
 
 exports[`CSharpGenerator should render \`record\` type if chosen 1`] = `
-"public record Address
+"public partial record Address
 {
   public required string StreetName { get; init; }
   public required string City { get; init; }
@@ -203,7 +203,7 @@ exports[`CSharpGenerator should render models and their dependencies 1`] = `
 {
   using System.Collections.Generic;
 
-  public class Address
+  public partial class Address
   {
     private string streetName;
     private string city;
@@ -277,7 +277,7 @@ exports[`CSharpGenerator should render models and their dependencies 2`] = `
 {
   using System.Collections.Generic;
 
-  public class OtherModel
+  public partial class OtherModel
   {
     private string? streetName;
     private Dictionary<string, dynamic>? additionalProperties;
@@ -298,7 +298,7 @@ exports[`CSharpGenerator should render models and their dependencies 2`] = `
 `;
 
 exports[`CSharpGenerator should render null-forgiving operator if handleNullable is chosen 1`] = `
-"public class Address
+"public partial class Address
 {
   private string streetName = null!;
   private string city = null!;

--- a/test/generators/csharp/presets/__snapshots__/CommonPreset.spec.ts.snap
+++ b/test/generators/csharp/presets/__snapshots__/CommonPreset.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CSHARP_COMMON_PRESET should render Equals support function 1`] = `
-"public class Test
+"public partial class Test
 {
   private string stringProp;
   private double? numberProp;
@@ -59,7 +59,7 @@ exports[`CSHARP_COMMON_PRESET should render Equals support function 1`] = `
 `;
 
 exports[`CSHARP_COMMON_PRESET should render Equals support function 2`] = `
-"public class NestedTest
+"public partial class NestedTest
 {
   private string? stringProp;
   private Dictionary<string, dynamic>? additionalProperties;
@@ -99,7 +99,7 @@ exports[`CSHARP_COMMON_PRESET should render Equals support function 2`] = `
 `;
 
 exports[`CSHARP_COMMON_PRESET should render GetHashCode support function 1`] = `
-"public class Test
+"public partial class Test
 {
   private string stringProp;
   private double? numberProp;
@@ -143,7 +143,7 @@ exports[`CSHARP_COMMON_PRESET should render GetHashCode support function 1`] = `
 `;
 
 exports[`CSHARP_COMMON_PRESET should render GetHashCode support function 2`] = `
-"public class NestedTest
+"public partial class NestedTest
 {
   private string? stringProp;
   private Dictionary<string, dynamic>? additionalProperties;

--- a/test/generators/csharp/presets/__snapshots__/JsonSerializerPreset.spec.ts.snap
+++ b/test/generators/csharp/presets/__snapshots__/JsonSerializerPreset.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`JSON serializer preset should render serialize and deserialize converters 1`] = `
 "[JsonConverter(typeof(TestConverter))]
-public class Test
+public partial class Test
 {
   private string stringProp;
   private double? numberProp;
@@ -196,7 +196,7 @@ public static class EnumTestExtensions
 
 exports[`JSON serializer preset should render serialize and deserialize converters 3`] = `
 "[JsonConverter(typeof(NestedTestConverter))]
-public class NestedTest
+public partial class NestedTest
 {
   private string? stringProp;
   private Dictionary<string, dynamic>? additionalProperties;

--- a/test/generators/csharp/presets/__snapshots__/NewtonsoftSerializerPreset.spec.ts.snap
+++ b/test/generators/csharp/presets/__snapshots__/NewtonsoftSerializerPreset.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`Newtonsoft JSON serializer preset should render serialize and deserialize converters 1`] = `
 "[JsonConverter(typeof(TestConverter))]
-public class Test
+public partial class Test
 {
   private string stringProp;
   private double? numberProp;
@@ -152,7 +152,7 @@ public static class EnumTestExtensions
 
 exports[`Newtonsoft JSON serializer preset should render serialize and deserialize converters 3`] = `
 "[JsonConverter(typeof(NestedTestConverter))]
-public class NestedTest
+public partial class NestedTest
 {
   private string? stringProp;
   private Dictionary<string, dynamic>? additionalProperties;


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes introduced by this pull request. -->

Adds `partial` modifier to generated types.

## Related Issue
<!-- If this pull request is related to any existing issue, mention it here. -->
* Partial types in C#: https://github.com/asyncapi/modelina/issues/1776

## Checklist
- [x] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [x] Tests have been added or updated to cover the changes.
- [ ] Documentation has been updated to reflect the changes.
I don't think any documentation changes are required?

- [x] All tests pass successfully locally.(`npm run test`).

## Additional Notes
<!-- Add any additional information or context that might be relevant to reviewers. -->
