### PR TITLE
fix: generate doc for getters

### DIFF
--- a/src/generators/typescript/presets/DescriptionPreset.ts
+++ b/src/generators/typescript/presets/DescriptionPreset.ts
@@ -37,7 +37,7 @@ export const TS_DESCRIPTION_PRESET: TypeScriptPreset = {
     self({ renderer, model, content }) {
       return renderDescription({ renderer, content, item: model });
     },
-    property({ renderer, property, content }) {
+    getter({ renderer, property, content }) {
       return renderDescription({ renderer, content, item: property.property });
     }
   },

--- a/test/generators/typescript/preset/__snapshots__/DescriptionPreset.spec.ts.snap
+++ b/test/generators/typescript/preset/__snapshots__/DescriptionPreset.spec.ts.snap
@@ -6,14 +6,7 @@ exports[`Description generation should render example function for model 1`] = `
  */
 class Test {
   private _stringProp: string;
-  /**
-   * Description
-   * @example Example
-   */
   private _numberProp?: number;
-  /**
-   * @example Example 1, Example 2
-   */
   private _objectProp?: NestedTest;
   private _additionalProperties?: Map<string, any>;
 
@@ -32,9 +25,16 @@ class Test {
   get stringProp(): string { return this._stringProp; }
   set stringProp(stringProp: string) { this._stringProp = stringProp; }
 
+  /**
+   * Description
+   * @example Example
+   */
   get numberProp(): number | undefined { return this._numberProp; }
   set numberProp(numberProp: number | undefined) { this._numberProp = numberProp; }
 
+  /**
+   * @example Example 1, Example 2
+   */
   get objectProp(): NestedTest | undefined { return this._objectProp; }
   set objectProp(objectProp: NestedTest | undefined) { this._objectProp = objectProp; }
 


### PR DESCRIPTION
## Description
This pull request corrects the generated code docs to their expected position.

| Earlier | Now |
| --- | --- |
| ![Screenshot-1](https://github.com/asyncapi/modelina/assets/96991785/148c9d75-45f5-4214-a74d-7f32e29b2f39)|![Screenshot-2](https://github.com/asyncapi/modelina/assets/96991785/b8e2dbae-227a-4389-a7b3-a77981bc395f)|

## Related Issue 
Fixes #1548 

## Checklist
- [x] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [x] Tests have been added or updated to cover the changes.
- [x] Documentation has been updated to reflect the changes.
- [x] All tests pass successfully locally.(`npm run test`).