### PR TITLE
fix: partial and playground

### DIFF
--- a/src/models/ConstrainedMetaModel.ts
+++ b/src/models/ConstrainedMetaModel.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { DeepPartial, mergePartialAndDefault } from '../utils';
+import { DeepPartial } from '../utils';
 import { makeUnique } from '../helpers/DependencyHelpers';
 import {
   MetaModel,
@@ -108,10 +108,10 @@ export class ConstrainedTupleModel extends ConstrainedMetaModel {
   getNearestDependencies(
     arg?: DeepPartial<GetNearestDependenciesArgument>
   ): ConstrainedMetaModel[] {
-    const argumentsToUse = mergePartialAndDefault(
-      defaultGetNearestDependenciesArgument,
-      arg
-    ) as GetNearestDependenciesArgument;
+    const argumentsToUse = {
+      ...defaultGetNearestDependenciesArgument,
+      ...arg
+    };
     argumentsToUse.alreadyVisitedNodes.push(this);
     let dependencyModels: ConstrainedMetaModel[] = [];
     for (const tupleModel of Object.values(this.tuple)) {
@@ -156,10 +156,10 @@ export class ConstrainedArrayModel extends ConstrainedMetaModel {
   getNearestDependencies(
     arg?: DeepPartial<GetNearestDependenciesArgument>
   ): ConstrainedMetaModel[] {
-    const argumentsToUse = mergePartialAndDefault(
-      defaultGetNearestDependenciesArgument,
-      arg
-    ) as GetNearestDependenciesArgument;
+    const argumentsToUse = {
+      ...defaultGetNearestDependenciesArgument,
+      ...arg
+    };
     argumentsToUse.alreadyVisitedNodes.push(this);
     if (this.valueModel instanceof ConstrainedReferenceModel) {
       return [this.valueModel];
@@ -183,10 +183,10 @@ export class ConstrainedUnionModel extends ConstrainedMetaModel {
   getNearestDependencies(
     arg?: DeepPartial<GetNearestDependenciesArgument>
   ): ConstrainedMetaModel[] {
-    const argumentsToUse = mergePartialAndDefault(
-      defaultGetNearestDependenciesArgument,
-      arg
-    ) as GetNearestDependenciesArgument;
+    const argumentsToUse = {
+      ...defaultGetNearestDependenciesArgument,
+      ...arg
+    };
     argumentsToUse.alreadyVisitedNodes.push(this);
     let dependencyModels: ConstrainedMetaModel[] = [];
     for (const unionModel of Object.values(this.union)) {
@@ -241,10 +241,10 @@ export class ConstrainedDictionaryModel extends ConstrainedMetaModel {
   getNearestDependencies(
     arg?: DeepPartial<GetNearestDependenciesArgument>
   ): ConstrainedMetaModel[] {
-    const argumentsToUse = mergePartialAndDefault(
-      defaultGetNearestDependenciesArgument,
-      arg
-    ) as GetNearestDependenciesArgument;
+    const argumentsToUse = {
+      ...defaultGetNearestDependenciesArgument,
+      ...arg
+    };
     argumentsToUse.alreadyVisitedNodes.push(this);
     const dependencies = [this.key, this.value];
     let dependencyModels: ConstrainedMetaModel[] = [];
@@ -281,10 +281,10 @@ export class ConstrainedObjectModel extends ConstrainedMetaModel {
   getNearestDependencies(
     arg?: DeepPartial<GetNearestDependenciesArgument>
   ): ConstrainedMetaModel[] {
-    const argumentsToUse = mergePartialAndDefault(
-      defaultGetNearestDependenciesArgument,
-      arg
-    ) as GetNearestDependenciesArgument;
+    const argumentsToUse = {
+      ...defaultGetNearestDependenciesArgument,
+      ...arg
+    };
     argumentsToUse.alreadyVisitedNodes.push(this);
     let dependencyModels: ConstrainedMetaModel[] = [];
     for (const modelProperty of Object.values(this.properties)) {

--- a/src/models/ConstrainedMetaModel.ts
+++ b/src/models/ConstrainedMetaModel.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { DeepPartial } from '../utils';
+import { DeepPartial, mergePartialAndDefault } from '../utils';
 import { makeUnique } from '../helpers/DependencyHelpers';
 import {
   MetaModel,
@@ -108,10 +108,10 @@ export class ConstrainedTupleModel extends ConstrainedMetaModel {
   getNearestDependencies(
     arg?: DeepPartial<GetNearestDependenciesArgument>
   ): ConstrainedMetaModel[] {
-    const argumentsToUse = {
-      ...defaultGetNearestDependenciesArgument,
-      ...arg
-    };
+    const argumentsToUse = mergePartialAndDefault(
+      defaultGetNearestDependenciesArgument,
+      arg
+    ) as GetNearestDependenciesArgument;
     argumentsToUse.alreadyVisitedNodes.push(this);
     let dependencyModels: ConstrainedMetaModel[] = [];
     for (const tupleModel of Object.values(this.tuple)) {
@@ -156,10 +156,10 @@ export class ConstrainedArrayModel extends ConstrainedMetaModel {
   getNearestDependencies(
     arg?: DeepPartial<GetNearestDependenciesArgument>
   ): ConstrainedMetaModel[] {
-    const argumentsToUse = {
-      ...defaultGetNearestDependenciesArgument,
-      ...arg
-    };
+    const argumentsToUse = mergePartialAndDefault(
+      defaultGetNearestDependenciesArgument,
+      arg
+    ) as GetNearestDependenciesArgument;
     argumentsToUse.alreadyVisitedNodes.push(this);
     if (this.valueModel instanceof ConstrainedReferenceModel) {
       return [this.valueModel];
@@ -183,10 +183,10 @@ export class ConstrainedUnionModel extends ConstrainedMetaModel {
   getNearestDependencies(
     arg?: DeepPartial<GetNearestDependenciesArgument>
   ): ConstrainedMetaModel[] {
-    const argumentsToUse = {
-      ...defaultGetNearestDependenciesArgument,
-      ...arg
-    };
+    const argumentsToUse = mergePartialAndDefault(
+      defaultGetNearestDependenciesArgument,
+      arg
+    ) as GetNearestDependenciesArgument;
     argumentsToUse.alreadyVisitedNodes.push(this);
     let dependencyModels: ConstrainedMetaModel[] = [];
     for (const unionModel of Object.values(this.union)) {
@@ -241,10 +241,10 @@ export class ConstrainedDictionaryModel extends ConstrainedMetaModel {
   getNearestDependencies(
     arg?: DeepPartial<GetNearestDependenciesArgument>
   ): ConstrainedMetaModel[] {
-    const argumentsToUse = {
-      ...defaultGetNearestDependenciesArgument,
-      ...arg
-    };
+    const argumentsToUse = mergePartialAndDefault(
+      defaultGetNearestDependenciesArgument,
+      arg
+    ) as GetNearestDependenciesArgument;
     argumentsToUse.alreadyVisitedNodes.push(this);
     const dependencies = [this.key, this.value];
     let dependencyModels: ConstrainedMetaModel[] = [];
@@ -281,10 +281,10 @@ export class ConstrainedObjectModel extends ConstrainedMetaModel {
   getNearestDependencies(
     arg?: DeepPartial<GetNearestDependenciesArgument>
   ): ConstrainedMetaModel[] {
-    const argumentsToUse = {
-      ...defaultGetNearestDependenciesArgument,
-      ...arg
-    };
+    const argumentsToUse = mergePartialAndDefault(
+      defaultGetNearestDependenciesArgument,
+      arg
+    ) as GetNearestDependenciesArgument;
     argumentsToUse.alreadyVisitedNodes.push(this);
     let dependencyModels: ConstrainedMetaModel[] = [];
     for (const modelProperty of Object.values(this.properties)) {

--- a/src/utils/Partials.ts
+++ b/src/utils/Partials.ts
@@ -49,10 +49,7 @@ export function mergePartialAndDefault<T extends Record<string, any>>(
     const isArray = Array.isArray(prop);
     if (isArray) {
       // merge array into target with a new array instance so we dont touch the default value
-      target[propName] = Array(target[propName]);
-      for (const [index, value] of prop.entries()) {
-        target[propName][index] = value;
-      }
+      target[propName] = [...(target[propName] ?? []), ...(prop ?? [])];
     } else if (isObjectOrClass && isRegularObject) {
       target[propName] = mergePartialAndDefault(target[propName], prop);
     } else if (prop) {


### PR DESCRIPTION
## Description
This PR fixes the implementation for partial that incorrectly handles array values, and thereby fixing the playground and others that dependent on Modelina.

The problem arose when the array values contained instances of classes that would be re-created incorrectly. We only intend to merge the default and target together.