### PR TITLE
fix!: handle edge case in toCamelCase FormatHelper

### DIFF
--- a/docs/migrations/version-3-to-4.md
+++ b/docs/migrations/version-3-to-4.md
@@ -1,0 +1,32 @@
+# Migration from v3 to v4
+This document contain all the breaking changes and migrations guidelines for adapting your code to the new version.
+
+## Property Naming changed for certain Edge Cases
+
+Object properties were formatted wrong when they contained a number followed by an underscore and a letter.
+This has been fixed in this version, which might means properties might be renamed. If you encounter errors, check for properties that were renamed.
+
+This example contains such a string:
+
+```yaml
+type: object
+properties:
+  aa_00_testAttribute:
+    type: string
+```
+
+This used to generate:
+
+```ts
+interface AnonymousSchema_1 {
+  aa_00TestAttribute?: string;
+}
+```
+
+but will now generate:
+
+```ts
+interface AnonymousSchema_1 {
+  aa_00_testAttribute?: string;
+}
+```

--- a/docs/migrations/version-3-to-4.md
+++ b/docs/migrations/version-3-to-4.md
@@ -1,10 +1,9 @@
 # Migration from v3 to v4
 This document contain all the breaking changes and migrations guidelines for adapting your code to the new version.
 
-## Property Naming changed for certain Edge Cases
+## Fixed edge cases for camel case names
 
-Object properties were formatted wrong when they contained a number followed by an underscore and a letter.
-This has been fixed in this version, which might means properties might be renamed. If you encounter errors, check for properties that were renamed.
+Naming such as object properties using camel case formatting had an edge case where if they contained a number followed by an underscore and a letter it would be incorrectly formatted. This has been fixed in this version, which might mean properties, model names, etc that use camel case might be renamed. 
 
 This example contains such a string:
 

--- a/src/helpers/FormatHelpers.ts
+++ b/src/helpers/FormatHelpers.ts
@@ -77,7 +77,20 @@ export class FormatHelpers {
    * @param {string} value to transform
    * @returns {string}
    */
-  static toCamelCase = camelCase;
+  static toCamelCase(renderName: string): string {
+    const splt = renderName.split(/([0-9]_)/g);
+    if (splt.length > 1) {
+      return splt
+        .map((part) => {
+          if (part.match(/[0-9]_/g)) {
+            return part;
+          }
+          return camelCase(part);
+        })
+        .join('');
+    }
+    return camelCase(renderName);
+  }
 
   /**
    * Transform into a string of capitalized words without separators.

--- a/test/generators/typescript/constrainer/PropertyKeyConstrainer.spec.ts
+++ b/test/generators/typescript/constrainer/PropertyKeyConstrainer.spec.ts
@@ -58,6 +58,10 @@ describe('PropertyKeyConstrainer', () => {
     const constrainedKey = constrainPropertyName('some weird_value!"#2');
     expect(constrainedKey).toEqual('someWeirdValueExclamationQuotationHash_2');
   });
+  test('should correctly handle casing with numbers', () => {
+    const constrainedKey = constrainPropertyName('aa_00_testAttribute');
+    expect(constrainedKey).toEqual('aa_00_testAttribute');
+  });
   test('should not contain duplicate properties', () => {
     const objectModel = new ObjectModel('test', undefined, {}, {});
     const constrainedObjectModel = new ConstrainedObjectModel(


### PR DESCRIPTION
## Description
The `toCamelCase` helper produced wrong outputs in some edge cases, where there was a numeric followed by "_" and a lowercase letter. This PR aims to fix that.

## Related Issue
Fixes #1503 

## Checklist
- [x] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [x] Tests have been added or updated to cover the changes.
- [ ] Documentation has been updated to reflect the changes.
- [ ] All tests pass successfully locally.(`npm run test`).
