### PR TITLE
fix: incorrect enum serializer generation for System.Text.Json

### DIFF
--- a/src/generators/csharp/presets/JsonSerializerPreset.ts
+++ b/src/generators/csharp/presets/JsonSerializerPreset.ts
@@ -20,7 +20,7 @@ function renderSerializeProperty(
     model.property instanceof ConstrainedReferenceModel &&
     model.property.ref instanceof ConstrainedEnumModel
   ) {
-    value = `value.${model.property.type}.GetValue()`;
+    value = `${modelInstanceVariable}?.GetValue()`;
   }
   return `JsonSerializer.Serialize(writer, ${value}, options);`;
 }

--- a/test/generators/csharp/presets/__snapshots__/JsonSerializerPreset.spec.ts.snap
+++ b/test/generators/csharp/presets/__snapshots__/JsonSerializerPreset.spec.ts.snap
@@ -127,7 +127,7 @@ internal class TestConverter : JsonConverter<Test>
     if(value.EnumProp != null) {
       // write property name and let the serializer serialize the value itself
       writer.WritePropertyName(\\"enumProp\\");
-      JsonSerializer.Serialize(writer, value.EnumTest?.GetValue(), options);
+      JsonSerializer.Serialize(writer, value.EnumProp?.GetValue(), options);
     }
     if(value.ObjectProp != null) {
       // write property name and let the serializer serialize the value itself

--- a/test/runtime/generic-input.json
+++ b/test/runtime/generic-input.json
@@ -47,6 +47,9 @@
     },
     "enumTest": {
       "enum": ["test", "test2"]
+    },
+    "houseType": {
+      "$ref": "#/$defs/housing-types"
     }
   },
   "patternProperties": {
@@ -57,5 +60,11 @@
   "required": [
     "house_number",
     "array_type"
-  ]
+  ],
+  "$defs": {
+    "housing-types": {
+      "$id": "HousingType",
+      "enum": ["detached", "terraced", "bungalow", "flat"]
+    }
+  }
 }

--- a/test/runtime/generic-input.json
+++ b/test/runtime/generic-input.json
@@ -50,6 +50,10 @@
     },
     "houseType": {
       "$ref": "#/$defs/housing-types"
+    },
+    "roofType": {
+      "$id": "TypeOfRoof",
+      "enum": ["tile", "straw", "wood", "metal"]
     }
   },
   "patternProperties": {

--- a/test/runtime/runtime-csharp/runtime-csharp/test/models/json_serializer/Address.cs
+++ b/test/runtime/runtime-csharp/runtime-csharp/test/models/json_serializer/Address.cs
@@ -1,5 +1,5 @@
-﻿using System.Text.Json;
-using com.mycompany.app.json_serializer;
+﻿using com.mycompany.app.json_serializer;
+using System.Text.Json;
 
 namespace runtime_csharp.json_serializer;
 
@@ -14,8 +14,8 @@ public class AddressTests
     [Test]
     public void TestSerializingFullModel()
     {
-        Address address = new Address();
-        NestedObject nestedObject = new NestedObject();
+        Address address = new();
+        NestedObject nestedObject = new();
         nestedObject.Test = "test";
         address.NestedObject = nestedObject;
         address.Marriage = true;
@@ -23,11 +23,12 @@ public class AddressTests
         address.HouseNumber = 1;
         address.ArrayType = new dynamic[] { 1, "test" };
         address.EnumTest = EnumTest.TEST;
+        address.HouseType = HousingType.FLAT;
         address.AdditionalProperties = new Dictionary<string, dynamic>();
         address.AdditionalProperties.Add("test_not_used", 2);
 
         string actualJsonString = JsonSerializer.Serialize(address);
-        string expectedJsonString = "{\"house_number\":1,\"marriage\":true,\"members\":2,\"array_type\":[1,\"test\"],\"nestedObject\":{\"test\":\"test\"},\"enumTest\":\"test\",\"test_not_used\":2}";
+        string expectedJsonString = "{\"house_number\":1,\"marriage\":true,\"members\":2,\"array_type\":[1,\"test\"],\"nestedObject\":{\"test\":\"test\"},\"enumTest\":\"test\",\"houseType\":\"flat\",\"test_not_used\":2}";
         Assert.That(actualJsonString, Is.EqualTo(expectedJsonString));
     }
 }

--- a/test/runtime/runtime-csharp/runtime-csharp/test/models/json_serializer/Address.cs
+++ b/test/runtime/runtime-csharp/runtime-csharp/test/models/json_serializer/Address.cs
@@ -24,11 +24,12 @@ public class AddressTests
         address.ArrayType = new dynamic[] { 1, "test" };
         address.EnumTest = EnumTest.TEST;
         address.HouseType = HousingType.FLAT;
+        address.RoofType = TypeOfRoof.STRAW;
         address.AdditionalProperties = new Dictionary<string, dynamic>();
         address.AdditionalProperties.Add("test_not_used", 2);
 
         string actualJsonString = JsonSerializer.Serialize(address);
-        string expectedJsonString = "{\"house_number\":1,\"marriage\":true,\"members\":2,\"array_type\":[1,\"test\"],\"nestedObject\":{\"test\":\"test\"},\"enumTest\":\"test\",\"houseType\":\"flat\",\"test_not_used\":2}";
+        string expectedJsonString = "{\"house_number\":1,\"marriage\":true,\"members\":2,\"array_type\":[1,\"test\"],\"nestedObject\":{\"test\":\"test\"},\"enumTest\":\"test\",\"houseType\":\"flat\",\"roofType\":\"straw\",\"test_not_used\":2}";
         Assert.That(actualJsonString, Is.EqualTo(expectedJsonString));
     }
 }

--- a/test/runtime/runtime-csharp/runtime-csharp/test/models/newtonsoft/Address.cs
+++ b/test/runtime/runtime-csharp/runtime-csharp/test/models/newtonsoft/Address.cs
@@ -24,11 +24,12 @@ public class AddressTests
         address.ArrayType = new dynamic[] { 1, "test" };
         address.EnumTest = EnumTest.TEST;
         address.HouseType = HousingType.FLAT;
+        address.RoofType = TypeOfRoof.STRAW;
         address.AdditionalProperties = new Dictionary<string, dynamic>();
         address.AdditionalProperties.Add("test_not_used", 2);
 
         string actualJsonString = JsonConvert.SerializeObject(address);
-        string expectedJsonString = "{\"house_number\":1.0,\"marriage\":true,\"members\":2,\"array_type\":[1,\"test\"],\"nestedObject\":{\"test\":\"test\"},\"enumTest\":\"test\",\"houseType\":\"flat\",\"test_not_used\":2}";
+        string expectedJsonString = "{\"house_number\":1.0,\"marriage\":true,\"members\":2,\"array_type\":[1,\"test\"],\"nestedObject\":{\"test\":\"test\"},\"enumTest\":\"test\",\"houseType\":\"flat\",\"roofType\":\"straw\",\"test_not_used\":2}";
         Assert.That(actualJsonString, Is.EqualTo(expectedJsonString));
     }
 }

--- a/test/runtime/runtime-csharp/runtime-csharp/test/models/newtonsoft/Address.cs
+++ b/test/runtime/runtime-csharp/runtime-csharp/test/models/newtonsoft/Address.cs
@@ -1,5 +1,4 @@
-﻿using System.Text.Json;
-using com.mycompany.app.newtonsoft;
+﻿using com.mycompany.app.newtonsoft;
 using Newtonsoft.Json;
 
 namespace runtime_csharp.newtonsoft;
@@ -15,8 +14,8 @@ public class AddressTests
     [Test]
     public void TestSerializingFullModel()
     {
-        Address address = new Address();
-        NestedObject nestedObject = new NestedObject();
+        Address address = new();
+        NestedObject nestedObject = new();
         nestedObject.Test = "test";
         address.NestedObject = nestedObject;
         address.Marriage = true;
@@ -24,11 +23,12 @@ public class AddressTests
         address.HouseNumber = 1;
         address.ArrayType = new dynamic[] { 1, "test" };
         address.EnumTest = EnumTest.TEST;
+        address.HouseType = HousingType.FLAT;
         address.AdditionalProperties = new Dictionary<string, dynamic>();
         address.AdditionalProperties.Add("test_not_used", 2);
 
         string actualJsonString = JsonConvert.SerializeObject(address);
-        string expectedJsonString = "{\"house_number\":1.0,\"marriage\":true,\"members\":2,\"array_type\":[1,\"test\"],\"nestedObject\":{\"test\":\"test\"},\"enumTest\":\"test\",\"test_not_used\":2}";
+        string expectedJsonString = "{\"house_number\":1.0,\"marriage\":true,\"members\":2,\"array_type\":[1,\"test\"],\"nestedObject\":{\"test\":\"test\"},\"enumTest\":\"test\",\"houseType\":\"flat\",\"test_not_used\":2}";
         Assert.That(actualJsonString, Is.EqualTo(expectedJsonString));
     }
 }


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes introduced by this pull request. -->
Ensures enums with a different name to the property are correctly serialized by `System.Text.Json`. 

## Related Issue
<!-- If this pull request is related to any existing issue, mention it here. -->
Fixes #1783 

## Checklist
- [x] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [x] Tests have been added or updated to cover the changes.
- [ ] Documentation has been updated to reflect the changes.
   No documentation change required
- [x] All tests pass successfully locally.(`npm run test`).

## Additional Notes
<!-- Add any additional information or context that might be relevant to reviewers. -->
