### PR TITLE
fix: dont render unmarshal for property with const

### DIFF
--- a/src/generators/typescript/presets/utils/UnmarshalFunction.ts
+++ b/src/generators/typescript/presets/utils/UnmarshalFunction.ts
@@ -29,6 +29,10 @@ function renderUnmarshalProperty(
  * Render the code for unmarshalling of regular properties
  */
 function unmarshalRegularProperty(propModel: ConstrainedObjectPropertyModel) {
+  if (propModel.property.options.const) {
+    return undefined;
+  }
+
   const modelInstanceVariable = `obj["${propModel.unconstrainedPropertyName}"]`;
   const unmarshalCode = renderUnmarshalProperty(
     modelInstanceVariable,

--- a/test/generators/typescript/preset/MarshallingPreset.spec.ts
+++ b/test/generators/typescript/preset/MarshallingPreset.spec.ts
@@ -68,6 +68,10 @@ const doc = {
           type: 'string'
         }
       ]
+    },
+    constTest: {
+      type: 'string',
+      const: 'TEST'
     }
   }
 };

--- a/test/generators/typescript/preset/__snapshots__/MarshallingPreset.spec.ts.snap
+++ b/test/generators/typescript/preset/__snapshots__/MarshallingPreset.spec.ts.snap
@@ -10,6 +10,7 @@ exports[`Marshalling preset should render un/marshal code 1`] = `
   private _unionArrayTest?: (NestedTest | string)[];
   private _arrayTest?: NestedTest[];
   private _tupleTest?: [NestedTest, string];
+  private _constTest?: 'TEST' = 'TEST';
   private _additionalProperties?: Map<string, NestedTest | string>;
 
   constructor(input: {
@@ -57,6 +58,8 @@ exports[`Marshalling preset should render un/marshal code 1`] = `
 
   get tupleTest(): [NestedTest, string] | undefined { return this._tupleTest; }
   set tupleTest(tupleTest: [NestedTest, string] | undefined) { this._tupleTest = tupleTest; }
+
+  get constTest(): 'TEST' | undefined { return this._constTest; }
 
   get additionalProperties(): Map<string, NestedTest | string> | undefined { return this._additionalProperties; }
   set additionalProperties(additionalProperties: Map<string, NestedTest | string> | undefined) { this._additionalProperties = additionalProperties; }
@@ -114,10 +117,13 @@ exports[`Marshalling preset should render un/marshal code 1`] = `
     }
     json += \`\\"tupleTest\\": [\${serializedTuple.join(',')}],\`;
     }
+    if(this.constTest !== undefined) {
+      json += \`\\"constTest\\": \${typeof this.constTest === 'number' || typeof this.constTest === 'boolean' ? this.constTest : JSON.stringify(this.constTest)},\`;
+    }
     if(this.additionalProperties !== undefined) { 
       for (const [key, value] of this.additionalProperties.entries()) {
         //Only unwrap those that are not already a property in the JSON object
-        if([\\"string prop\\",\\"enumProp\\",\\"numberProp\\",\\"nestedObject\\",\\"unionTest\\",\\"unionArrayTest\\",\\"arrayTest\\",\\"tupleTest\\",\\"additionalProperties\\"].includes(String(key))) continue;
+        if([\\"string prop\\",\\"enumProp\\",\\"numberProp\\",\\"nestedObject\\",\\"unionTest\\",\\"unionArrayTest\\",\\"arrayTest\\",\\"tupleTest\\",\\"constTest\\",\\"additionalProperties\\"].includes(String(key))) continue;
         if(value instanceof NestedTest) {
           json += \`\\"\${key}\\": \${value.marshal()},\`;
         } else {
@@ -157,9 +163,10 @@ exports[`Marshalling preset should render un/marshal code 1`] = `
     if (obj[\\"tupleTest\\"] !== undefined) {
       instance.tupleTest = obj[\\"tupleTest\\"];
     }
+
   
     instance.additionalProperties = new Map();
-    const propsToCheck = Object.entries(obj).filter((([key,]) => {return ![\\"string prop\\",\\"enumProp\\",\\"numberProp\\",\\"nestedObject\\",\\"unionTest\\",\\"unionArrayTest\\",\\"arrayTest\\",\\"tupleTest\\",\\"additionalProperties\\"].includes(key);}));
+    const propsToCheck = Object.entries(obj).filter((([key,]) => {return ![\\"string prop\\",\\"enumProp\\",\\"numberProp\\",\\"nestedObject\\",\\"unionTest\\",\\"unionArrayTest\\",\\"arrayTest\\",\\"tupleTest\\",\\"constTest\\",\\"additionalProperties\\"].includes(key);}));
     for (const [key, value] of propsToCheck) {
       instance.additionalProperties.set(key, value as any);
     }


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes introduced by this pull request. -->

There seems to be a bug introduced in https://github.com/asyncapi/modelina/pull/1717/files. Properties that have `const` set are read-only, and can't be set when unmarshaling. If this is not fixed, then the TS compiler fails on the generated code.

## Related Issue
<!-- If this pull request is related to any existing issue, mention it here. -->

## Checklist
- [x] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [x] Tests have been added or updated to cover the changes.
- [x] Documentation has been updated to reflect the changes.
- [x] All tests pass successfully locally.(`npm run test`).

## Additional Notes
<!-- Add any additional information or context that might be relevant to reviewers. -->
