### PR TITLE
chore(website): wrong import directory for docs images

### DIFF
--- a/modelina-website/scripts/build-docs.js
+++ b/modelina-website/scripts/build-docs.js
@@ -28,7 +28,7 @@ function prepareContent(content) {
   content = content.replace('/examples?selectedExample=integrate-with-maven', 'https://github.com/asyncapi/modelina/tree/master/examples/integrate-with-maven');
 
   // Replace all references to local images for docs
-  content = content.replace(/"(.*?)\/img\/(.*?)"/g, '"/img/docs/img/$2"');
+  content = content.replace(/"(.*?)\/img\/(.*?)"/g, '"/img/docs/$2"');
 
   return content;
 }


### PR DESCRIPTION
## Description
The import directory in 'build-docs.js' did not match the one set in package.json (`"copy:docs:img": "cp -r ../docs/img public/img/docs"`)

## Related Issue
Fixes #1700 

## Checklist
- [x] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [x] Tests have been added or updated to cover the changes.
- [x] Documentation has been updated to reflect the changes.
- [x] All tests pass successfully locally.(`npm run test`).
