### PR TITLE
fix: python generator type safety

### DIFF
--- a/src/generators/python/PythonGenerator.ts
+++ b/src/generators/python/PythonGenerator.ts
@@ -35,11 +35,11 @@ import {
 import { DeepPartial, mergePartialAndDefault } from '../../utils/Partials';
 import { PythonDependencyManager } from './PythonDependencyManager';
 
-export interface PythonOptions extends CommonGeneratorOptions<PythonPreset> {
+export interface PythonOptions
+  extends CommonGeneratorOptions<PythonPreset, PythonDependencyManager> {
   typeMapping: TypeMapping<PythonOptions, PythonDependencyManager>;
   constraints: Constraints<PythonOptions>;
   importsStyle: 'explicit' | 'implicit';
-  dependencyManager?: (() => PythonDependencyManager) | PythonDependencyManager;
 }
 export type PythonConstantConstraint = ConstantConstraint<PythonOptions>;
 export type PythonEnumKeyConstraint = EnumKeyConstraint<PythonOptions>;

--- a/src/generators/python/PythonGenerator.ts
+++ b/src/generators/python/PythonGenerator.ts
@@ -39,6 +39,7 @@ export interface PythonOptions extends CommonGeneratorOptions<PythonPreset> {
   typeMapping: TypeMapping<PythonOptions, PythonDependencyManager>;
   constraints: Constraints<PythonOptions>;
   importsStyle: 'explicit' | 'implicit';
+  dependencyManager?: (() => PythonDependencyManager) | PythonDependencyManager;
 }
 export type PythonConstantConstraint = ConstantConstraint<PythonOptions>;
 export type PythonEnumKeyConstraint = EnumKeyConstraint<PythonOptions>;


### PR DESCRIPTION
## Description
Correctly type the dependencyManager option for the PythonGenerator

## Related Issue
Fixes #1810 

## Checklist
- [x] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [x] Tests have been added or updated to cover the changes.
- [x] Documentation has been updated to reflect the changes.
- [x] All tests pass successfully locally.(`npm run test`).
