### PR TITLE
fix!: mapping for C# object date

### DIFF
--- a/docs/migrations/version-3-to-4.md
+++ b/docs/migrations/version-3-to-4.md
@@ -59,3 +59,29 @@ public class TestClass {
 ```
 
 Notice that `Property` no longer has a `set` method. This might break existing models.
+
+### DateTime and DateTimeOffset are now properly rendered based on specification format
+
+In the previous version, `date-time` and `date` formats were rendered as `DateTime` and `DateTimeOffset` respectively. 
+This has been changed to render `DateTimeOffset` for `date-time` and `DateTime` for `date` formats.
+
+This might break existing implementation and require manual changes.
+
+The best thing to do is to fix your specification and use what you really need. If you don't care about the time and time zone, use `date` instead of `date-time`.
+Otherwise, keep the `date-time` format and update your code to use `DateTimeOffset` instead of `DateTime`.
+That usually means doing this:
+
+```csharp
+var dateTime = new DateTime(2008, 6, 19, 7, 0, 0);
+
+// Set the DateTime property of the ModelinaModel
+var modelinaModel = new ModelinaModel();
+modelinaModel.DateTime = dateTime;
+Console.WriteLine(modelinaModel.DateTime);
+
+// Get the DateTime property from the ModelinaModel
+DateTime dateTime2 = modelinaModel.DateTime.LocalDateTime;
+Console.WriteLine(dateTime2);
+```
+
+

--- a/examples/generate-csharp-models/__snapshots__/index.spec.ts.snap
+++ b/examples/generate-csharp-models/__snapshots__/index.spec.ts.snap
@@ -15,7 +15,7 @@ Array [
     set { email = value; }
   }
 
-  public System.DateTimeOffset? Today
+  public System.DateTimeOffset? Today 
   {
     get { return today; }
     set { today = value; }

--- a/examples/generate-csharp-models/__snapshots__/index.spec.ts.snap
+++ b/examples/generate-csharp-models/__snapshots__/index.spec.ts.snap
@@ -5,7 +5,7 @@ Array [
   "public partial class Root
 {
   private string? email;
-  private System.DateTime? today;
+  private System.DateTimeOffset? today;
   private System.TimeSpan? duration;
   private System.Guid? userId;
 
@@ -15,7 +15,7 @@ Array [
     set { email = value; }
   }
 
-  public System.DateTime? Today 
+  public System.DateTimeOffset? Today
   {
     get { return today; }
     set { today = value; }

--- a/src/generators/csharp/CSharpConstrainer.ts
+++ b/src/generators/csharp/CSharpConstrainer.ts
@@ -59,9 +59,10 @@ export const CSharpDefaultTypeMapping: CSharpTypeMapping = {
       case 'time':
         return getFullTypeDefinition('System.TimeSpan', partOfProperty);
       case 'date':
+        return getFullTypeDefinition('System.DateTime', partOfProperty);
       case 'dateTime':
       case 'date-time':
-        return getFullTypeDefinition('System.DateTime', partOfProperty);
+        return getFullTypeDefinition('System.DateTimeOffset', partOfProperty);
       case 'uuid':
         return getFullTypeDefinition('System.Guid', partOfProperty);
       default:

--- a/test/generators/csharp/CSharpConstrainer.spec.ts
+++ b/test/generators/csharp/CSharpConstrainer.spec.ts
@@ -97,7 +97,7 @@ describe('CSharpConstrainer', () => {
       const model = new ConstrainedStringModel(
         'test',
         undefined,
-        { format: 'date-time' },
+        { format: 'date' },
         ''
       );
       const type = CSharpDefaultTypeMapping.String({
@@ -105,6 +105,19 @@ describe('CSharpConstrainer', () => {
         ...defaultOptions
       });
       expect(type).toEqual('System.DateTime');
+    });
+    test('should render System.DateTimeOffset', () => {
+      const model = new ConstrainedStringModel(
+        'test',
+        undefined,
+        { format: 'date-time' },
+        ''
+      );
+      const type = CSharpDefaultTypeMapping.String({
+        constrainedModel: model,
+        ...defaultOptions
+      });
+      expect(type).toEqual('System.DateTimeOffset');
     });
     test('should render TimeSpan', () => {
       const model = new ConstrainedStringModel(


### PR DESCRIPTION
## Description

There was a problem in the recent addition of mapping for `date` and `date-time` field to C#.

Following AsyncAPI documentation:
![image](https://github.com/asyncapi/modelina/assets/14336900/9e4aaf2e-85ed-4c25-923d-e1f48a2516d5)

And the RFC documentation:
![image](https://github.com/asyncapi/modelina/assets/14336900/a45d748f-1bf3-47e3-a140-13dfa98ab35a)

My simple change rectify this situation.

## Checklist
- [x] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [x] Tests have been added or updated to cover the changes.
- [x] Documentation has been updated to reflect the changes. (**not required**)
- [x] All tests pass successfully locally.(`npm run test`).
