### PR TITLE
fix: only self hook was called in Go enums

### DIFF
--- a/docs/presets.md
+++ b/docs/presets.md
@@ -416,6 +416,14 @@ This preset is a generator for the meta model `ConstrainedObjectModel` and [can 
 |---|---|---|
 | `field` | A method to extend rendered given field. | `field` object as a [`ConstrainedObjectPropertyModel`](./internal-model.md#the-constrained-meta-model) instance. |
 
+#### **Enum**
+
+This preset is a generator for the meta model `ConstrainedEnumModel` and [can be accessed through the `model` argument](#presets-shape).
+
+| Method | Description | Additional arguments |
+|---|---|---|
+| `item` | A method to extend rendering the enum items. | `item` object as a [`ConstrainedEnumValueModel`](./internal-model.md#the-constrained-meta-model) instance. `index` as `number`, the current enum item being rendered. |
+
 ### C#
 
 #### **Class**

--- a/examples/generate-go-enums/__snapshots__/index.spec.ts.snap
+++ b/examples/generate-go-enums/__snapshots__/index.spec.ts.snap
@@ -34,8 +34,7 @@ var ValuesToCities = map[any]Cities{
   CitiesValues[CitiesLondon]: CitiesLondon,
   CitiesValues[CitiesRome]: CitiesRome,
   CitiesValues[CitiesBrussels]: CitiesBrussels,
-}
-",
+}",
 ]
 `;
 
@@ -65,7 +64,6 @@ var ValuesToOptions = map[any]Options{
   OptionsValues[OptionsNumber_213]: OptionsNumber_213,
   OptionsValues[OptionsTrue]: OptionsTrue,
   OptionsValues[OptionsRun]: OptionsRun,
-}
-",
+}",
 ]
 `;

--- a/examples/generate-go-enums/__snapshots__/index.spec.ts.snap
+++ b/examples/generate-go-enums/__snapshots__/index.spec.ts.snap
@@ -34,7 +34,8 @@ var ValuesToCities = map[any]Cities{
   CitiesValues[CitiesLondon]: CitiesLondon,
   CitiesValues[CitiesRome]: CitiesRome,
   CitiesValues[CitiesBrussels]: CitiesBrussels,
-}",
+}
+",
 ]
 `;
 
@@ -64,6 +65,7 @@ var ValuesToOptions = map[any]Options{
   OptionsValues[OptionsNumber_213]: OptionsNumber_213,
   OptionsValues[OptionsTrue]: OptionsTrue,
   OptionsValues[OptionsRun]: OptionsRun,
-}",
+}
+",
 ]
 `;

--- a/src/generators/go/GoPreset.ts
+++ b/src/generators/go/GoPreset.ts
@@ -3,9 +3,10 @@ import {
   Preset,
   CommonPreset,
   PresetArgs,
-  EnumPreset,
   ConstrainedObjectModel,
-  ConstrainedObjectPropertyModel
+  ConstrainedObjectPropertyModel,
+  ConstrainedEnumModel,
+  EnumArgs
 } from '../../models';
 import {
   StructRenderer,
@@ -23,6 +24,12 @@ export interface StructPreset<R extends AbstractRenderer, O>
   field?: (
     args: PresetArgs<R, O, ConstrainedObjectModel> & FieldArgs
   ) => Promise<string> | string;
+}
+interface EnumPreset<R extends AbstractRenderer, O>
+  extends CommonPreset<R, O, ConstrainedEnumModel> {
+  item?: (
+    args: PresetArgs<R, O, ConstrainedEnumModel> & EnumArgs & { index: number }
+  ) => string;
 }
 export type StructPresetType<O> = StructPreset<StructRenderer, O>;
 export type EnumPresetType<O> = EnumPreset<EnumRenderer, O>;

--- a/src/generators/go/renderers/EnumRenderer.ts
+++ b/src/generators/go/renderers/EnumRenderer.ts
@@ -23,9 +23,7 @@ export class EnumRenderer extends GoRenderer<ConstrainedEnumModel> {
     });
     const additionalContent = await this.runAdditionalContentPreset();
     const renderedAdditionalContent = additionalContent
-      ? `
-    ${this.indent(additionalContent)}    
-`
+      ? this.indent(additionalContent)
       : '';
     const values = this.model.values
       .map((value) => {
@@ -51,7 +49,8 @@ func (op ${this.model.name}) Value() any {
 var ${this.model.name}Values = []any{${values}}
 var ValuesTo${this.model.name} = map[any]${this.model.name}{
 ${this.indent(this.renderBlock(valuesToEnumMap))}
-}${renderedAdditionalContent}`;
+}
+${renderedAdditionalContent}`;
   }
 
   async renderItems(): Promise<string> {

--- a/src/generators/go/renderers/EnumRenderer.ts
+++ b/src/generators/go/renderers/EnumRenderer.ts
@@ -22,6 +22,11 @@ export class EnumRenderer extends GoRenderer<ConstrainedEnumModel> {
       return `${this.model.name}Values[${value.key}]: ${value.key},`;
     });
     const additionalContent = await this.runAdditionalContentPreset();
+    const renderedAdditionalContent = additionalContent
+      ? `
+    ${this.indent(additionalContent)}    
+`
+      : '';
     const values = this.model.values
       .map((value) => {
         return value.value;
@@ -46,10 +51,7 @@ func (op ${this.model.name}) Value() any {
 var ${this.model.name}Values = []any{${values}}
 var ValuesTo${this.model.name} = map[any]${this.model.name}{
 ${this.indent(this.renderBlock(valuesToEnumMap))}
-}
-
-${this.indent(additionalContent)}
-`;
+}${renderedAdditionalContent}`;
   }
 
   async renderItems(): Promise<string> {

--- a/src/generators/go/renderers/EnumRenderer.ts
+++ b/src/generators/go/renderers/EnumRenderer.ts
@@ -1,5 +1,8 @@
 import { GoRenderer } from '../GoRenderer';
-import { ConstrainedEnumModel } from '../../../models';
+import {
+  ConstrainedEnumModel,
+  ConstrainedEnumValueModel
+} from '../../../models';
 import { EnumPresetType } from '../GoPreset';
 import { GoOptions } from '../GoGenerator';
 
@@ -12,12 +15,13 @@ import { GoOptions } from '../GoGenerator';
  * @extends GoRenderer
  */
 export class EnumRenderer extends GoRenderer<ConstrainedEnumModel> {
-  public defaultSelf(): string {
+  public async defaultSelf(): Promise<string> {
     const doc = this.renderCommentForEnumType(this.model.name, this.model.type);
-    const enumValues = this.renderConstValuesForEnumType();
-    const temp = this.model.values.map((value) => {
+    const enumValues = await this.renderItems();
+    const valuesToEnumMap = this.model.values.map((value) => {
       return `${this.model.name}Values[${value.key}]: ${value.key},`;
     });
+    const additionalContent = await this.runAdditionalContentPreset();
     const values = this.model.values
       .map((value) => {
         return value.value;
@@ -28,7 +32,7 @@ export class EnumRenderer extends GoRenderer<ConstrainedEnumModel> {
 type ${this.model.name} uint
 
 const (
-${this.indent(this.renderBlock(enumValues))}
+${this.indent(enumValues)}
 )
 
 // Value returns the value of the enum.
@@ -41,9 +45,23 @@ func (op ${this.model.name}) Value() any {
 
 var ${this.model.name}Values = []any{${values}}
 var ValuesTo${this.model.name} = map[any]${this.model.name}{
-${this.indent(this.renderBlock(temp))}
+${this.indent(this.renderBlock(valuesToEnumMap))}
 }
+
+${this.indent(additionalContent)}
 `;
+  }
+
+  async renderItems(): Promise<string> {
+    const enums = this.model.values || [];
+    const items: string[] = [];
+
+    for (const [index, item] of enums.entries()) {
+      const renderedItem = await this.runItemPreset(item, index);
+      items.push(renderedItem);
+    }
+
+    return this.renderBlock(items);
   }
 
   renderCommentForEnumType(name: string, type: string): string {
@@ -51,21 +69,25 @@ ${this.indent(this.renderBlock(temp))}
     return this.renderComments(`${name} represents an enum of ${globalType}.`);
   }
 
-  renderConstValuesForEnumType(): string[] {
-    return this.model.values.map((enumValue, index) => {
-      if (index === 0) {
-        return `${enumValue.key} ${this.model.name} = iota`;
-      }
-      if (typeof enumValue.value === 'string') {
-        return enumValue.key;
-      }
-      return enumValue.key;
-    });
+  runItemPreset(
+    item: ConstrainedEnumValueModel,
+    index: number
+  ): Promise<string> {
+    return this.runPreset('item', { item, index });
   }
 }
 
 export const GO_DEFAULT_ENUM_PRESET: EnumPresetType<GoOptions> = {
   self({ renderer }) {
     return renderer.defaultSelf();
+  },
+  item({ model, item, index }) {
+    if (index === 0) {
+      return `${item.key} ${model.name} = iota`;
+    }
+    if (typeof item.value === 'string') {
+      return item.key;
+    }
+    return item.key;
   }
 };

--- a/test/generators/go/GoGenerator.spec.ts
+++ b/test/generators/go/GoGenerator.spec.ts
@@ -59,7 +59,10 @@ describe('GoGenerator', () => {
         {
           struct: {
             field({ field }) {
-              return `${field.propertyName} ${field.property.type}`; // private fields
+              return `field ${field.propertyName}`;
+            },
+            additionalContent() {
+              return 'additionalContent';
             }
           }
         }
@@ -92,8 +95,11 @@ describe('GoGenerator', () => {
       presets: [
         {
           enum: {
-            self({ content }) {
-              return content;
+            item({ index }) {
+              return `test ${index}`;
+            },
+            additionalContent() {
+              return 'additionalContent';
             }
           }
         }

--- a/test/generators/go/__snapshots__/GoGenerator.spec.ts.snap
+++ b/test/generators/go/__snapshots__/GoGenerator.spec.ts.snap
@@ -89,8 +89,7 @@ var ValuesToThings = map[any]Things{
   ThingsValues[ThingsReservedNumber_1]: ThingsReservedNumber_1,
   ThingsValues[ThingsFalse]: ThingsFalse,
   ThingsValues[ThingsCurlyleftQuotationTestQuotationColonQuotationTestQuotationCurlyright]: ThingsCurlyleftQuotationTestQuotationColonQuotationTestQuotationCurlyright,
-}
-"
+}"
 `;
 
 exports[`GoGenerator should render \`struct\` type 1`] = `
@@ -131,8 +130,7 @@ var ValuesToCustomEnum = map[any]CustomEnum{
   CustomEnumValues[CustomEnumTexas]: CustomEnumTexas,
   CustomEnumValues[CustomEnumAlabama]: CustomEnumAlabama,
   CustomEnumValues[CustomEnumCalifornia]: CustomEnumCalifornia,
-}
-"
+}"
 `;
 
 exports[`GoGenerator should work custom preset for \`struct\` type 1`] = `

--- a/test/generators/go/__snapshots__/GoGenerator.spec.ts.snap
+++ b/test/generators/go/__snapshots__/GoGenerator.spec.ts.snap
@@ -89,7 +89,8 @@ var ValuesToThings = map[any]Things{
   ThingsValues[ThingsReservedNumber_1]: ThingsReservedNumber_1,
   ThingsValues[ThingsFalse]: ThingsFalse,
   ThingsValues[ThingsCurlyleftQuotationTestQuotationColonQuotationTestQuotationCurlyright]: ThingsCurlyleftQuotationTestQuotationColonQuotationTestQuotationCurlyright,
-}"
+}
+"
 `;
 
 exports[`GoGenerator should render \`struct\` type 1`] = `
@@ -112,9 +113,9 @@ exports[`GoGenerator should work custom preset for \`enum\` type 1`] = `
 type CustomEnum uint
 
 const (
-  CustomEnumTexas CustomEnum = iota
-  CustomEnumAlabama
-  CustomEnumCalifornia
+  test 0
+  test 1
+  test 2
 )
 
 // Value returns the value of the enum.
@@ -130,13 +131,16 @@ var ValuesToCustomEnum = map[any]CustomEnum{
   CustomEnumValues[CustomEnumTexas]: CustomEnumTexas,
   CustomEnumValues[CustomEnumAlabama]: CustomEnumAlabama,
   CustomEnumValues[CustomEnumCalifornia]: CustomEnumCalifornia,
-}"
+}
+  additionalContent"
 `;
 
 exports[`GoGenerator should work custom preset for \`struct\` type 1`] = `
 "// CustomStruct represents a CustomStruct model.
 type CustomStruct struct {
-  Property string
-  AdditionalProperties map[string]string
+  field Property
+  field AdditionalProperties
+
+  additionalContent
 }"
 `;


### PR DESCRIPTION
## Description
This PR fixes multiple bugs with the Go enum rendering, where only the `self` hook was called. Now both `item` and `additionalContent` are called.

## Related Issue
Fixes https://github.com/asyncapi/modelina/issues/1847
