### PR TITLE
fix: inconsistent indentation for Python models

### DIFF
--- a/examples/generate-python-complete-models/__snapshots__/index.spec.ts.snap
+++ b/examples/generate-python-complete-models/__snapshots__/index.spec.ts.snap
@@ -16,14 +16,14 @@ class ObjProperty:
       return self._number
     @number.setter
     def number(self, number):
-    	self._number = number
+      self._number = number
 
     @property
     def additionalProperties(self):
       return self._additionalProperties
     @additionalProperties.setter
     def additionalProperties(self, additionalProperties):
-    	self._additionalProperties = additionalProperties
+      self._additionalProperties = additionalProperties
 ",
 ]
 `;
@@ -44,14 +44,14 @@ class ObjProperty:
       return self._number
     @number.setter
     def number(self, number):
-    	self._number = number
+      self._number = number
 
     @property
     def additionalProperties(self):
       return self._additionalProperties
     @additionalProperties.setter
     def additionalProperties(self, additionalProperties):
-    	self._additionalProperties = additionalProperties
+      self._additionalProperties = additionalProperties
 ",
 ]
 `;
@@ -72,14 +72,14 @@ class Root:
       return self._email
     @email.setter
     def email(self, email):
-    	self._email = email
+      self._email = email
 
     @property
     def objProperty(self):
       return self._objProperty
     @objProperty.setter
     def objProperty(self, objProperty):
-    	self._objProperty = objProperty
+      self._objProperty = objProperty
 ",
 ]
 `;
@@ -100,14 +100,14 @@ class Root:
       return self._email
     @email.setter
     def email(self, email):
-    	self._email = email
+      self._email = email
 
     @property
     def objProperty(self):
       return self._objProperty
     @objProperty.setter
     def objProperty(self, objProperty):
-    	self._objProperty = objProperty
+      self._objProperty = objProperty
 ",
 ]
 `;

--- a/examples/generate-python-complete-models/__snapshots__/index.spec.ts.snap
+++ b/examples/generate-python-complete-models/__snapshots__/index.spec.ts.snap
@@ -8,8 +8,8 @@ class ObjProperty:
   def __init__(self, input):
     if hasattr(input, 'number'):
       self._number = input.number
-    if hasattr(input, 'additionalProperties'):
-      self._additional_properties = input.additionalProperties
+    if hasattr(input, 'additional_properties'):
+      self._additional_properties = input.additional_properties
 
   @property
   def number(self):
@@ -20,10 +20,10 @@ class ObjProperty:
 
   @property
   def additional_properties(self):
-  	return self._additional_properties
+    return self._additional_properties
   @additional_properties.setter
   def additional_properties(self, additional_properties):
-  	self._additional_properties = additional_properties
+    self._additional_properties = additional_properties
 ",
 ]
 `;
@@ -35,9 +35,9 @@ Array [
 class ObjProperty: 
   def __init__(self, input):
     if hasattr(input, 'number'):
-    	self._number = input.number
+      self._number = input.number
     if hasattr(input, 'additional_properties'):
-    	self._additional_properties = input.additional_properties
+      self._additional_properties = input.additional_properties
 
   @property
   def number(self):
@@ -48,10 +48,10 @@ class ObjProperty:
 
   @property
   def additional_properties(self):
-  	return self._additional_properties
+    return self._additional_properties
   @additional_properties.setter
   def additional_properties(self, additional_properties):
-  	self._additional_properties = additional_properties
+    self._additional_properties = additional_properties
 ",
 ]
 `;
@@ -63,9 +63,9 @@ Array [
 class Root: 
   def __init__(self, input):
     if hasattr(input, 'email'):
-    	self._email = input.email
+      self._email = input.email
     if hasattr(input, 'obj_property'):
-    	self._obj_property = input.obj_property
+      self._obj_property = input.obj_property
 
   @property
   def email(self):
@@ -76,10 +76,10 @@ class Root:
 
   @property
   def obj_property(self):
-  	return self._obj_property
+    return self._obj_property
   @obj_property.setter
   def obj_property(self, obj_property):
-  	self._obj_property = obj_property
+    self._obj_property = obj_property
 ",
 ]
 `;
@@ -91,9 +91,9 @@ Array [
 class Root: 
   def __init__(self, input):
     if hasattr(input, 'email'):
-    	self._email = input.email
+      self._email = input.email
     if hasattr(input, 'obj_property'):
-    	self._obj_property = input.obj_property
+      self._obj_property = input.obj_property
 
   @property
   def email(self):
@@ -104,10 +104,10 @@ class Root:
 
   @property
   def obj_property(self):
-  	return self._obj_property
+    return self._obj_property
   @obj_property.setter
   def obj_property(self, obj_property):
-  	self._obj_property = obj_property
+    self._obj_property = obj_property
 ",
 ]
 `;

--- a/examples/generate-python-complete-models/__snapshots__/index.spec.ts.snap
+++ b/examples/generate-python-complete-models/__snapshots__/index.spec.ts.snap
@@ -7,23 +7,23 @@ Array [
 class ObjProperty: 
   def __init__(self, input):
     if hasattr(input, 'number'):
-    	self._number = input.number
+      self._number = input.number
     if hasattr(input, 'additionalProperties'):
-    	self._additionalProperties = input.additionalProperties
+      self._additionalProperties = input.additionalProperties
 
-  @property
-  def number(self):
-  	return self._number
-  @number.setter
-  def number(self, number):
-  	self._number = number
+    @property
+    def number(self):
+      return self._number
+    @number.setter
+    def number(self, number):
+    	self._number = number
 
-  @property
-  def additionalProperties(self):
-  	return self._additionalProperties
-  @additionalProperties.setter
-  def additionalProperties(self, additionalProperties):
-  	self._additionalProperties = additionalProperties
+    @property
+    def additionalProperties(self):
+      return self._additionalProperties
+    @additionalProperties.setter
+    def additionalProperties(self, additionalProperties):
+    	self._additionalProperties = additionalProperties
 ",
 ]
 `;
@@ -35,23 +35,23 @@ Array [
 class ObjProperty: 
   def __init__(self, input):
     if hasattr(input, 'number'):
-    	self._number = input.number
+      self._number = input.number
     if hasattr(input, 'additionalProperties'):
-    	self._additionalProperties = input.additionalProperties
+      self._additionalProperties = input.additionalProperties
 
-  @property
-  def number(self):
-  	return self._number
-  @number.setter
-  def number(self, number):
-  	self._number = number
+    @property
+    def number(self):
+      return self._number
+    @number.setter
+    def number(self, number):
+    	self._number = number
 
-  @property
-  def additionalProperties(self):
-  	return self._additionalProperties
-  @additionalProperties.setter
-  def additionalProperties(self, additionalProperties):
-  	self._additionalProperties = additionalProperties
+    @property
+    def additionalProperties(self):
+      return self._additionalProperties
+    @additionalProperties.setter
+    def additionalProperties(self, additionalProperties):
+    	self._additionalProperties = additionalProperties
 ",
 ]
 `;
@@ -63,23 +63,23 @@ Array [
 class Root: 
   def __init__(self, input):
     if hasattr(input, 'email'):
-    	self._email = input.email
+      self._email = input.email
     if hasattr(input, 'objProperty'):
-    	self._objProperty = input.objProperty
+      self._objProperty = input.objProperty
 
-  @property
-  def email(self):
-  	return self._email
-  @email.setter
-  def email(self, email):
-  	self._email = email
+    @property
+    def email(self):
+      return self._email
+    @email.setter
+    def email(self, email):
+    	self._email = email
 
-  @property
-  def objProperty(self):
-  	return self._objProperty
-  @objProperty.setter
-  def objProperty(self, objProperty):
-  	self._objProperty = objProperty
+    @property
+    def objProperty(self):
+      return self._objProperty
+    @objProperty.setter
+    def objProperty(self, objProperty):
+    	self._objProperty = objProperty
 ",
 ]
 `;
@@ -91,23 +91,23 @@ Array [
 class Root: 
   def __init__(self, input):
     if hasattr(input, 'email'):
-    	self._email = input.email
+      self._email = input.email
     if hasattr(input, 'objProperty'):
-    	self._objProperty = input.objProperty
+      self._objProperty = input.objProperty
 
-  @property
-  def email(self):
-  	return self._email
-  @email.setter
-  def email(self, email):
-  	self._email = email
+    @property
+    def email(self):
+      return self._email
+    @email.setter
+    def email(self, email):
+    	self._email = email
 
-  @property
-  def objProperty(self):
-  	return self._objProperty
-  @objProperty.setter
-  def objProperty(self, objProperty):
-  	self._objProperty = objProperty
+    @property
+    def objProperty(self):
+      return self._objProperty
+    @objProperty.setter
+    def objProperty(self, objProperty):
+    	self._objProperty = objProperty
 ",
 ]
 `;

--- a/examples/generate-python-complete-models/__snapshots__/index.spec.ts.snap
+++ b/examples/generate-python-complete-models/__snapshots__/index.spec.ts.snap
@@ -11,19 +11,19 @@ class ObjProperty:
     if hasattr(input, 'additionalProperties'):
       self._additionalProperties = input.additionalProperties
 
-    @property
-    def number(self):
-      return self._number
-    @number.setter
-    def number(self, number):
-      self._number = number
+  @property
+  def number(self):
+    return self._number
+  @number.setter
+  def number(self, number):
+    self._number = number
 
-    @property
-    def additionalProperties(self):
-      return self._additionalProperties
-    @additionalProperties.setter
-    def additionalProperties(self, additionalProperties):
-      self._additionalProperties = additionalProperties
+  @property
+  def additionalProperties(self):
+    return self._additionalProperties
+  @additionalProperties.setter
+  def additionalProperties(self, additionalProperties):
+    self._additionalProperties = additionalProperties
 ",
 ]
 `;
@@ -39,19 +39,19 @@ class ObjProperty:
     if hasattr(input, 'additionalProperties'):
       self._additionalProperties = input.additionalProperties
 
-    @property
-    def number(self):
-      return self._number
-    @number.setter
-    def number(self, number):
-      self._number = number
+  @property
+  def number(self):
+    return self._number
+  @number.setter
+  def number(self, number):
+    self._number = number
 
-    @property
-    def additionalProperties(self):
-      return self._additionalProperties
-    @additionalProperties.setter
-    def additionalProperties(self, additionalProperties):
-      self._additionalProperties = additionalProperties
+  @property
+  def additionalProperties(self):
+    return self._additionalProperties
+  @additionalProperties.setter
+  def additionalProperties(self, additionalProperties):
+    self._additionalProperties = additionalProperties
 ",
 ]
 `;
@@ -67,19 +67,19 @@ class Root:
     if hasattr(input, 'objProperty'):
       self._objProperty = input.objProperty
 
-    @property
-    def email(self):
-      return self._email
-    @email.setter
-    def email(self, email):
-      self._email = email
+  @property
+  def email(self):
+    return self._email
+  @email.setter
+  def email(self, email):
+    self._email = email
 
-    @property
-    def objProperty(self):
-      return self._objProperty
-    @objProperty.setter
-    def objProperty(self, objProperty):
-      self._objProperty = objProperty
+  @property
+  def objProperty(self):
+    return self._objProperty
+  @objProperty.setter
+  def objProperty(self, objProperty):
+    self._objProperty = objProperty
 ",
 ]
 `;
@@ -95,19 +95,19 @@ class Root:
     if hasattr(input, 'objProperty'):
       self._objProperty = input.objProperty
 
-    @property
-    def email(self):
-      return self._email
-    @email.setter
-    def email(self, email):
-      self._email = email
+  @property
+  def email(self):
+    return self._email
+  @email.setter
+  def email(self, email):
+    self._email = email
 
-    @property
-    def objProperty(self):
-      return self._objProperty
-    @objProperty.setter
-    def objProperty(self, objProperty):
-      self._objProperty = objProperty
+  @property
+  def objProperty(self):
+    return self._objProperty
+  @objProperty.setter
+  def objProperty(self, objProperty):
+    self._objProperty = objProperty
 ",
 ]
 `;

--- a/examples/generate-python-models/__snapshots__/index.spec.ts.snap
+++ b/examples/generate-python-models/__snapshots__/index.spec.ts.snap
@@ -12,7 +12,7 @@ Array [
       return self._email
     @email.setter
     def email(self, email):
-    	self._email = email
+      self._email = email
 ",
 ]
 `;

--- a/examples/generate-python-models/__snapshots__/index.spec.ts.snap
+++ b/examples/generate-python-models/__snapshots__/index.spec.ts.snap
@@ -7,12 +7,12 @@ Array [
     if hasattr(input, 'email'):
       self._email = input.email
 
-    @property
-    def email(self):
-      return self._email
-    @email.setter
-    def email(self, email):
-      self._email = email
+  @property
+  def email(self):
+    return self._email
+  @email.setter
+  def email(self, email):
+    self._email = email
 ",
 ]
 `;

--- a/examples/generate-python-models/__snapshots__/index.spec.ts.snap
+++ b/examples/generate-python-models/__snapshots__/index.spec.ts.snap
@@ -5,14 +5,14 @@ Array [
   "class Root: 
   def __init__(self, input):
     if hasattr(input, 'email'):
-    	self._email = input.email
+      self._email = input.email
 
-  @property
-  def email(self):
-  	return self._email
-  @email.setter
-  def email(self, email):
-  	self._email = email
+    @property
+    def email(self):
+      return self._email
+    @email.setter
+    def email(self, email):
+    	self._email = email
 ",
 ]
 `;

--- a/examples/python-generate-json-serializer-and-deserializer/__snapshots__/index.spec.ts.snap
+++ b/examples/python-generate-json-serializer-and-deserializer/__snapshots__/index.spec.ts.snap
@@ -5,9 +5,9 @@ Array [
   "class Root: 
   def __init__(self, input):
     if hasattr(input, 'email'):
-    	self._email = input.email
+      self._email = input.email
     if hasattr(input, 'additional_properties'):
-    	self._additional_properties = input.additional_properties
+      self._additional_properties = input.additional_properties
 
   @property
   def email(self):
@@ -18,10 +18,10 @@ Array [
 
   @property
   def additional_properties(self):
-  	return self._additional_properties
+    return self._additional_properties
   @additional_properties.setter
   def additional_properties(self, additional_properties):
-  	self._additional_properties = additional_properties
+    self._additional_properties = additional_properties
 
   def serialize_to_json(self):
     return json.dumps(self.__dict__, default=lambda o: o.__dict__, indent=2)

--- a/examples/python-generate-json-serializer-and-deserializer/__snapshots__/index.spec.ts.snap
+++ b/examples/python-generate-json-serializer-and-deserializer/__snapshots__/index.spec.ts.snap
@@ -14,14 +14,14 @@ Array [
       return self._email
     @email.setter
     def email(self, email):
-    	self._email = email
+      self._email = email
 
     @property
     def additionalProperties(self):
       return self._additionalProperties
     @additionalProperties.setter
     def additionalProperties(self, additionalProperties):
-    	self._additionalProperties = additionalProperties
+      self._additionalProperties = additionalProperties
 
   def serializeToJson(self):
     return json.dumps(self.__dict__, default=lambda o: o.__dict__, indent=2)

--- a/examples/python-generate-json-serializer-and-deserializer/__snapshots__/index.spec.ts.snap
+++ b/examples/python-generate-json-serializer-and-deserializer/__snapshots__/index.spec.ts.snap
@@ -9,19 +9,19 @@ Array [
     if hasattr(input, 'additionalProperties'):
       self._additionalProperties = input.additionalProperties
 
-    @property
-    def email(self):
-      return self._email
-    @email.setter
-    def email(self, email):
-      self._email = email
+  @property
+  def email(self):
+    return self._email
+  @email.setter
+  def email(self, email):
+    self._email = email
 
-    @property
-    def additionalProperties(self):
-      return self._additionalProperties
-    @additionalProperties.setter
-    def additionalProperties(self, additionalProperties):
-      self._additionalProperties = additionalProperties
+  @property
+  def additionalProperties(self):
+    return self._additionalProperties
+  @additionalProperties.setter
+  def additionalProperties(self, additionalProperties):
+    self._additionalProperties = additionalProperties
 
   def serializeToJson(self):
     return json.dumps(self.__dict__, default=lambda o: o.__dict__, indent=2)

--- a/examples/python-generate-json-serializer-and-deserializer/__snapshots__/index.spec.ts.snap
+++ b/examples/python-generate-json-serializer-and-deserializer/__snapshots__/index.spec.ts.snap
@@ -5,23 +5,23 @@ Array [
   "class Root: 
   def __init__(self, input):
     if hasattr(input, 'email'):
-    	self._email = input.email
+      self._email = input.email
     if hasattr(input, 'additionalProperties'):
-    	self._additionalProperties = input.additionalProperties
+      self._additionalProperties = input.additionalProperties
 
-  @property
-  def email(self):
-  	return self._email
-  @email.setter
-  def email(self, email):
-  	self._email = email
+    @property
+    def email(self):
+      return self._email
+    @email.setter
+    def email(self, email):
+    	self._email = email
 
-  @property
-  def additionalProperties(self):
-  	return self._additionalProperties
-  @additionalProperties.setter
-  def additionalProperties(self, additionalProperties):
-  	self._additionalProperties = additionalProperties
+    @property
+    def additionalProperties(self):
+      return self._additionalProperties
+    @additionalProperties.setter
+    def additionalProperties(self, additionalProperties):
+    	self._additionalProperties = additionalProperties
 
   def serializeToJson(self):
     return json.dumps(self.__dict__, default=lambda o: o.__dict__, indent=2)

--- a/src/generators/python/renderers/ClassRenderer.ts
+++ b/src/generators/python/renderers/ClassRenderer.ts
@@ -104,6 +104,7 @@ def ${property.propertyName}(self):
   },
   setter({ renderer, property }) {
     return renderer.indent(`@${property.propertyName}.setter
-def ${property.propertyName}(self, ${property.propertyName}):\n\tself._${property.propertyName} = ${property.propertyName}`);
+def ${property.propertyName}(self, ${property.propertyName}):
+  self._${property.propertyName} = ${property.propertyName}`);
   }
 };

--- a/src/generators/python/renderers/ClassRenderer.ts
+++ b/src/generators/python/renderers/ClassRenderer.ts
@@ -98,13 +98,19 @@ No properties
 ${renderer.indent(body, 2)}`;
   },
   getter({ renderer, property }) {
-    return renderer.indent(`@property
+    return renderer.indent(
+      `@property
 def ${property.propertyName}(self):
-  return self._${property.propertyName}`);
+  return self._${property.propertyName}`,
+      0
+    );
   },
   setter({ renderer, property }) {
-    return renderer.indent(`@${property.propertyName}.setter
+    return renderer.indent(
+      `@${property.propertyName}.setter
 def ${property.propertyName}(self, ${property.propertyName}):
-  self._${property.propertyName} = ${property.propertyName}`);
+  self._${property.propertyName} = ${property.propertyName}`,
+      0
+    );
   }
 };

--- a/src/generators/python/renderers/ClassRenderer.ts
+++ b/src/generators/python/renderers/ClassRenderer.ts
@@ -97,20 +97,14 @@ No properties
     return `def __init__(self, input):
 ${renderer.indent(body, 2)}`;
   },
-  getter({ renderer, property }) {
-    return renderer.indent(
-      `@property
+  getter({ property }) {
+    return `@property
 def ${property.propertyName}(self):
-  return self._${property.propertyName}`,
-      0
-    );
+  return self._${property.propertyName}`;
   },
-  setter({ renderer, property }) {
-    return renderer.indent(
-      `@${property.propertyName}.setter
+  setter({ property }) {
+    return `@${property.propertyName}.setter
 def ${property.propertyName}(self, ${property.propertyName}):
-  self._${property.propertyName} = ${property.propertyName}`,
-      0
-    );
+  self._${property.propertyName} = ${property.propertyName}`;
   }
 };

--- a/src/generators/python/renderers/ClassRenderer.ts
+++ b/src/generators/python/renderers/ClassRenderer.ts
@@ -83,7 +83,8 @@ export const PYTHON_DEFAULT_CLASS_PRESET: ClassPresetType<PythonOptions> = {
     if (Object.keys(properties).length > 0) {
       const assigments = Object.values(properties).map((property) => {
         if (!property.required) {
-          return `if hasattr(input, '${property.propertyName}'):\n\tself._${property.propertyName} = input.${property.propertyName}`;
+          return `if hasattr(input, '${property.propertyName}'):
+  self._${property.propertyName} = input.${property.propertyName}`;
         }
         return `self._${property.propertyName} = input.${property.propertyName}`;
       });
@@ -94,14 +95,15 @@ No properties
 """`;
     }
     return `def __init__(self, input):
-${renderer.indent(body)}`;
+${renderer.indent(body, 2)}`;
   },
-  getter({ property }) {
-    return `@property
-def ${property.propertyName}(self):\n\treturn self._${property.propertyName}`;
+  getter({ renderer, property }) {
+    return renderer.indent(`@property
+def ${property.propertyName}(self):
+  return self._${property.propertyName}`);
   },
-  setter({ property }) {
-    return `@${property.propertyName}.setter
-def ${property.propertyName}(self, ${property.propertyName}):\n\tself._${property.propertyName} = ${property.propertyName}`;
+  setter({ renderer, property }) {
+    return renderer.indent(`@${property.propertyName}.setter
+def ${property.propertyName}(self, ${property.propertyName}):\n\tself._${property.propertyName} = ${property.propertyName}`);
   }
 };

--- a/src/generators/python/renderers/ClassRenderer.ts
+++ b/src/generators/python/renderers/ClassRenderer.ts
@@ -83,8 +83,9 @@ export const PYTHON_DEFAULT_CLASS_PRESET: ClassPresetType<PythonOptions> = {
     if (Object.keys(properties).length > 0) {
       const assigments = Object.values(properties).map((property) => {
         if (!property.required) {
+          const propAssignment = `self._${property.propertyName} = input.${property.propertyName}`;
           return `if hasattr(input, '${property.propertyName}'):
-  self._${property.propertyName} = input.${property.propertyName}`;
+${renderer.indent(propAssignment, 2)}`;
         }
         return `self._${property.propertyName} = input.${property.propertyName}`;
       });
@@ -97,14 +98,16 @@ No properties
     return `def __init__(self, input):
 ${renderer.indent(body, 2)}`;
   },
-  getter({ property }) {
+  getter({ property, renderer }) {
+    const propAssignment = `return self._${property.propertyName}`;
     return `@property
 def ${property.propertyName}(self):
-  return self._${property.propertyName}`;
+${renderer.indent(propAssignment, 2)}`;
   },
-  setter({ property }) {
+  setter({ property, renderer }) {
+    const propAssignment = `self._${property.propertyName} = ${property.propertyName}`;
     return `@${property.propertyName}.setter
 def ${property.propertyName}(self, ${property.propertyName}):
-  self._${property.propertyName} = ${property.propertyName}`;
+${renderer.indent(propAssignment, 2)}`;
   }
 };

--- a/src/generators/python/renderers/EnumRenderer.ts
+++ b/src/generators/python/renderers/EnumRenderer.ts
@@ -19,7 +19,7 @@ export class EnumRenderer extends PythonRenderer<ConstrainedEnumModel> {
     ];
 
     return `class ${this.model.name}(Enum): 
-${this.indent(this.renderBlock(content, 2))}`;
+${this.indent(this.renderBlock(content, 2), 2)}`;
   }
 
   async renderItems(): Promise<string> {

--- a/src/helpers/FormatHelpers.ts
+++ b/src/helpers/FormatHelpers.ts
@@ -171,8 +171,8 @@ export class FormatHelpers {
   /**
    * Ensures indentations are prepended to content.
    * @param {string} content to prepend the indentation.
-   * @param {number} size the number of indendations to use. 1 by default
-   * @param {IndentationTypes} type the type of indendations to use. SPACES by default.
+   * @param {number} size the number of indentations to use. 1 by default
+   * @param {IndentationTypes} type the type of indentations to use. SPACES by default.
    * @returns {string}
    */
   static indent(
@@ -199,10 +199,10 @@ export class FormatHelpers {
   }
 
   /**
-   * Get the indendation string based on how many and which type of indentation are requested.
+   * Get the indentation string based on how many and which type of indentation are requested.
    * @private
-   * @param {number} size the number of indendations to use
-   * @param {IndentationTypes} type the type of indendations to use. SPACES by default.
+   * @param {number} size the number of indentations to use
+   * @param {IndentationTypes} type the type of indentations to use. SPACES by default.
    * @returns {string}
    */
   private static getIndentation(

--- a/test/generators/python/__snapshots__/PythonGenerator.spec.ts.snap
+++ b/test/generators/python/__snapshots__/PythonGenerator.spec.ts.snap
@@ -8,19 +8,19 @@ exports[`PythonGenerator Class should not render reserved keyword 1`] = `
     if hasattr(input, 'reservedDel'):
       self._reservedDel = input.reservedDel
 
-    @property
-    def reservedReservedDel(self):
-      return self._reservedReservedDel
-    @reservedReservedDel.setter
-    def reservedReservedDel(self, reservedReservedDel):
-      self._reservedReservedDel = reservedReservedDel
+  @property
+  def reservedReservedDel(self):
+    return self._reservedReservedDel
+  @reservedReservedDel.setter
+  def reservedReservedDel(self, reservedReservedDel):
+    self._reservedReservedDel = reservedReservedDel
 
-    @property
-    def reservedDel(self):
-      return self._reservedDel
-    @reservedDel.setter
-    def reservedDel(self, reservedDel):
-      self._reservedDel = reservedDel
+  @property
+  def reservedDel(self):
+    return self._reservedDel
+  @reservedDel.setter
+  def reservedDel(self, reservedDel):
+    self._reservedDel = reservedDel
 "
 `;
 
@@ -39,61 +39,61 @@ exports[`PythonGenerator Class should render \`class\` type 1`] = `
     if hasattr(input, 'additionalProperties'):
       self._additionalProperties = input.additionalProperties
 
-    @property
-    def streetName(self):
-      return self._streetName
-    @streetName.setter
-    def streetName(self, streetName):
-      self._streetName = streetName
+  @property
+  def streetName(self):
+    return self._streetName
+  @streetName.setter
+  def streetName(self, streetName):
+    self._streetName = streetName
 
-    @property
-    def city(self):
-      return self._city
-    @city.setter
-    def city(self, city):
-      self._city = city
+  @property
+  def city(self):
+    return self._city
+  @city.setter
+  def city(self, city):
+    self._city = city
 
-    @property
-    def state(self):
-      return self._state
-    @state.setter
-    def state(self, state):
-      self._state = state
+  @property
+  def state(self):
+    return self._state
+  @state.setter
+  def state(self, state):
+    self._state = state
 
-    @property
-    def houseNumber(self):
-      return self._houseNumber
-    @houseNumber.setter
-    def houseNumber(self, houseNumber):
-      self._houseNumber = houseNumber
+  @property
+  def houseNumber(self):
+    return self._houseNumber
+  @houseNumber.setter
+  def houseNumber(self, houseNumber):
+    self._houseNumber = houseNumber
 
-    @property
-    def marriage(self):
-      return self._marriage
-    @marriage.setter
-    def marriage(self, marriage):
-      self._marriage = marriage
+  @property
+  def marriage(self):
+    return self._marriage
+  @marriage.setter
+  def marriage(self, marriage):
+    self._marriage = marriage
 
-    @property
-    def members(self):
-      return self._members
-    @members.setter
-    def members(self, members):
-      self._members = members
+  @property
+  def members(self):
+    return self._members
+  @members.setter
+  def members(self, members):
+    self._members = members
 
-    @property
-    def arrayType(self):
-      return self._arrayType
-    @arrayType.setter
-    def arrayType(self, arrayType):
-      self._arrayType = arrayType
+  @property
+  def arrayType(self):
+    return self._arrayType
+  @arrayType.setter
+  def arrayType(self, arrayType):
+    self._arrayType = arrayType
 
-    @property
-    def additionalProperties(self):
-      return self._additionalProperties
-    @additionalProperties.setter
-    def additionalProperties(self, additionalProperties):
-      self._additionalProperties = additionalProperties
+  @property
+  def additionalProperties(self):
+    return self._additionalProperties
+  @additionalProperties.setter
+  def additionalProperties(self, additionalProperties):
+    self._additionalProperties = additionalProperties
 "
 `;
 
@@ -111,22 +111,22 @@ exports[`PythonGenerator Class should work with custom preset for \`class\` type
       self._additionalProperties = input.additionalProperties
 
   test2
-    @property
-    def property(self):
-      return self._property
+  @property
+  def property(self):
+    return self._property
   test3
-    @property.setter
-    def property(self, property):
-      self._property = property
+  @property.setter
+  def property(self, property):
+    self._property = property
 
   test2
-    @property
-    def additionalProperties(self):
-      return self._additionalProperties
+  @property
+  def additionalProperties(self):
+    return self._additionalProperties
   test3
-    @additionalProperties.setter
-    def additionalProperties(self, additionalProperties):
-      self._additionalProperties = additionalProperties
+  @additionalProperties.setter
+  def additionalProperties(self, additionalProperties):
+    self._additionalProperties = additionalProperties
 "
 `;
 

--- a/test/generators/python/__snapshots__/PythonGenerator.spec.ts.snap
+++ b/test/generators/python/__snapshots__/PythonGenerator.spec.ts.snap
@@ -4,14 +4,14 @@ exports[`PythonGenerator Class should not render reserved keyword 1`] = `
 "class Address: 
   def __init__(self, input):
     if hasattr(input, 'reserved_del'):
-    	self._reserved_del = input.reserved_del
+      self._reserved_del = input.reserved_del
 
   @property
   def reserved_del(self):
-  	return self._reserved_del
+    return self._reserved_del
   @reserved_del.setter
   def reserved_del(self, reserved_del):
-  	self._reserved_del = reserved_del
+    self._reserved_del = reserved_del
 "
 `;
 
@@ -25,22 +25,38 @@ exports[`PythonGenerator Class should render \`class\` type 1`] = `
     if hasattr(input, 'marriage'):
       self._marriage = input.marriage
     if hasattr(input, 'members'):
-    	self._members = input.members
+      self._members = input.members
     self._array_type = input.array_type
     if hasattr(input, 'additional_properties'):
-    	self._additional_properties = input.additional_properties
+      self._additional_properties = input.additional_properties
 
   @property
   def street_name(self):
-  	return self._street_name
+    return self._street_name
   @street_name.setter
   def street_name(self, street_name):
-  	self._street_name = street_name
+    self._street_name = street_name
+
+  @property
+  def city(self):
+    return self._city
+  @city.setter
+  def city(self, city):
+    self._city = city
+
+  @property
+  def state(self):
+    return self._state
+  @state.setter
+  def state(self, state):
+    self._state = state
+
+  @property
   def house_number(self):
-  	return self._house_number
+    return self._house_number
   @house_number.setter
   def house_number(self, house_number):
-  	self._house_number = house_number
+    self._house_number = house_number
 
   @property
   def marriage(self):
@@ -58,17 +74,17 @@ exports[`PythonGenerator Class should render \`class\` type 1`] = `
 
   @property
   def array_type(self):
-  	return self._array_type
+    return self._array_type
   @array_type.setter
   def array_type(self, array_type):
-  	self._array_type = array_type
+    self._array_type = array_type
 
   @property
   def additional_properties(self):
-  	return self._additional_properties
+    return self._additional_properties
   @additional_properties.setter
   def additional_properties(self, additional_properties):
-  	self._additional_properties = additional_properties
+    self._additional_properties = additional_properties
 "
 `;
 
@@ -81,9 +97,9 @@ exports[`PythonGenerator Class should work with custom preset for \`class\` type
 
   def __init__(self, input):
     if hasattr(input, 'property'):
-    	self._property = input.property
+      self._property = input.property
     if hasattr(input, 'additional_properties'):
-    	self._additional_properties = input.additional_properties
+      self._additional_properties = input.additional_properties
 
   test2
   @property
@@ -97,11 +113,11 @@ exports[`PythonGenerator Class should work with custom preset for \`class\` type
   test2
   @property
   def additional_properties(self):
-  	return self._additional_properties
+    return self._additional_properties
   test3
   @additional_properties.setter
   def additional_properties(self, additional_properties):
-  	self._additional_properties = additional_properties
+    self._additional_properties = additional_properties
 "
 `;
 

--- a/test/generators/python/__snapshots__/PythonGenerator.spec.ts.snap
+++ b/test/generators/python/__snapshots__/PythonGenerator.spec.ts.snap
@@ -4,23 +4,23 @@ exports[`PythonGenerator Class should not render reserved keyword 1`] = `
 "class Address: 
   def __init__(self, input):
     if hasattr(input, 'reservedReservedDel'):
-    	self._reservedReservedDel = input.reservedReservedDel
+      self._reservedReservedDel = input.reservedReservedDel
     if hasattr(input, 'reservedDel'):
-    	self._reservedDel = input.reservedDel
+      self._reservedDel = input.reservedDel
 
-  @property
-  def reservedReservedDel(self):
-  	return self._reservedReservedDel
-  @reservedReservedDel.setter
-  def reservedReservedDel(self, reservedReservedDel):
-  	self._reservedReservedDel = reservedReservedDel
+    @property
+    def reservedReservedDel(self):
+      return self._reservedReservedDel
+    @reservedReservedDel.setter
+    def reservedReservedDel(self, reservedReservedDel):
+    	self._reservedReservedDel = reservedReservedDel
 
-  @property
-  def reservedDel(self):
-  	return self._reservedDel
-  @reservedDel.setter
-  def reservedDel(self, reservedDel):
-  	self._reservedDel = reservedDel
+    @property
+    def reservedDel(self):
+      return self._reservedDel
+    @reservedDel.setter
+    def reservedDel(self, reservedDel):
+    	self._reservedDel = reservedDel
 "
 `;
 
@@ -32,68 +32,68 @@ exports[`PythonGenerator Class should render \`class\` type 1`] = `
     self._state = input.state
     self._houseNumber = input.houseNumber
     if hasattr(input, 'marriage'):
-    	self._marriage = input.marriage
+      self._marriage = input.marriage
     if hasattr(input, 'members'):
-    	self._members = input.members
+      self._members = input.members
     self._arrayType = input.arrayType
     if hasattr(input, 'additionalProperties'):
-    	self._additionalProperties = input.additionalProperties
+      self._additionalProperties = input.additionalProperties
 
-  @property
-  def streetName(self):
-  	return self._streetName
-  @streetName.setter
-  def streetName(self, streetName):
-  	self._streetName = streetName
+    @property
+    def streetName(self):
+      return self._streetName
+    @streetName.setter
+    def streetName(self, streetName):
+    	self._streetName = streetName
 
-  @property
-  def city(self):
-  	return self._city
-  @city.setter
-  def city(self, city):
-  	self._city = city
+    @property
+    def city(self):
+      return self._city
+    @city.setter
+    def city(self, city):
+    	self._city = city
 
-  @property
-  def state(self):
-  	return self._state
-  @state.setter
-  def state(self, state):
-  	self._state = state
+    @property
+    def state(self):
+      return self._state
+    @state.setter
+    def state(self, state):
+    	self._state = state
 
-  @property
-  def houseNumber(self):
-  	return self._houseNumber
-  @houseNumber.setter
-  def houseNumber(self, houseNumber):
-  	self._houseNumber = houseNumber
+    @property
+    def houseNumber(self):
+      return self._houseNumber
+    @houseNumber.setter
+    def houseNumber(self, houseNumber):
+    	self._houseNumber = houseNumber
 
-  @property
-  def marriage(self):
-  	return self._marriage
-  @marriage.setter
-  def marriage(self, marriage):
-  	self._marriage = marriage
+    @property
+    def marriage(self):
+      return self._marriage
+    @marriage.setter
+    def marriage(self, marriage):
+    	self._marriage = marriage
 
-  @property
-  def members(self):
-  	return self._members
-  @members.setter
-  def members(self, members):
-  	self._members = members
+    @property
+    def members(self):
+      return self._members
+    @members.setter
+    def members(self, members):
+    	self._members = members
 
-  @property
-  def arrayType(self):
-  	return self._arrayType
-  @arrayType.setter
-  def arrayType(self, arrayType):
-  	self._arrayType = arrayType
+    @property
+    def arrayType(self):
+      return self._arrayType
+    @arrayType.setter
+    def arrayType(self, arrayType):
+    	self._arrayType = arrayType
 
-  @property
-  def additionalProperties(self):
-  	return self._additionalProperties
-  @additionalProperties.setter
-  def additionalProperties(self, additionalProperties):
-  	self._additionalProperties = additionalProperties
+    @property
+    def additionalProperties(self):
+      return self._additionalProperties
+    @additionalProperties.setter
+    def additionalProperties(self, additionalProperties):
+    	self._additionalProperties = additionalProperties
 "
 `;
 
@@ -106,27 +106,27 @@ exports[`PythonGenerator Class should work with custom preset for \`class\` type
 
   def __init__(self, input):
     if hasattr(input, 'property'):
-    	self._property = input.property
+      self._property = input.property
     if hasattr(input, 'additionalProperties'):
-    	self._additionalProperties = input.additionalProperties
+      self._additionalProperties = input.additionalProperties
 
   test2
-  @property
-  def property(self):
-  	return self._property
+    @property
+    def property(self):
+      return self._property
   test3
-  @property.setter
-  def property(self, property):
-  	self._property = property
+    @property.setter
+    def property(self, property):
+    	self._property = property
 
   test2
-  @property
-  def additionalProperties(self):
-  	return self._additionalProperties
+    @property
+    def additionalProperties(self):
+      return self._additionalProperties
   test3
-  @additionalProperties.setter
-  def additionalProperties(self, additionalProperties):
-  	self._additionalProperties = additionalProperties
+    @additionalProperties.setter
+    def additionalProperties(self, additionalProperties):
+    	self._additionalProperties = additionalProperties
 "
 `;
 

--- a/test/generators/python/__snapshots__/PythonGenerator.spec.ts.snap
+++ b/test/generators/python/__snapshots__/PythonGenerator.spec.ts.snap
@@ -13,14 +13,14 @@ exports[`PythonGenerator Class should not render reserved keyword 1`] = `
       return self._reservedReservedDel
     @reservedReservedDel.setter
     def reservedReservedDel(self, reservedReservedDel):
-    	self._reservedReservedDel = reservedReservedDel
+      self._reservedReservedDel = reservedReservedDel
 
     @property
     def reservedDel(self):
       return self._reservedDel
     @reservedDel.setter
     def reservedDel(self, reservedDel):
-    	self._reservedDel = reservedDel
+      self._reservedDel = reservedDel
 "
 `;
 
@@ -44,56 +44,56 @@ exports[`PythonGenerator Class should render \`class\` type 1`] = `
       return self._streetName
     @streetName.setter
     def streetName(self, streetName):
-    	self._streetName = streetName
+      self._streetName = streetName
 
     @property
     def city(self):
       return self._city
     @city.setter
     def city(self, city):
-    	self._city = city
+      self._city = city
 
     @property
     def state(self):
       return self._state
     @state.setter
     def state(self, state):
-    	self._state = state
+      self._state = state
 
     @property
     def houseNumber(self):
       return self._houseNumber
     @houseNumber.setter
     def houseNumber(self, houseNumber):
-    	self._houseNumber = houseNumber
+      self._houseNumber = houseNumber
 
     @property
     def marriage(self):
       return self._marriage
     @marriage.setter
     def marriage(self, marriage):
-    	self._marriage = marriage
+      self._marriage = marriage
 
     @property
     def members(self):
       return self._members
     @members.setter
     def members(self, members):
-    	self._members = members
+      self._members = members
 
     @property
     def arrayType(self):
       return self._arrayType
     @arrayType.setter
     def arrayType(self, arrayType):
-    	self._arrayType = arrayType
+      self._arrayType = arrayType
 
     @property
     def additionalProperties(self):
       return self._additionalProperties
     @additionalProperties.setter
     def additionalProperties(self, additionalProperties):
-    	self._additionalProperties = additionalProperties
+      self._additionalProperties = additionalProperties
 "
 `;
 
@@ -117,7 +117,7 @@ exports[`PythonGenerator Class should work with custom preset for \`class\` type
   test3
     @property.setter
     def property(self, property):
-    	self._property = property
+      self._property = property
 
   test2
     @property
@@ -126,7 +126,7 @@ exports[`PythonGenerator Class should work with custom preset for \`class\` type
   test3
     @additionalProperties.setter
     def additionalProperties(self, additionalProperties):
-    	self._additionalProperties = additionalProperties
+      self._additionalProperties = additionalProperties
 "
 `;
 

--- a/test/generators/python/presets/__snapshots__/JsonSerializer.spec.ts.snap
+++ b/test/generators/python/presets/__snapshots__/JsonSerializer.spec.ts.snap
@@ -4,9 +4,9 @@ exports[`PYTHON_JSON_SERIALIZER_PRESET should render serializer and deserializer
 "class Test: 
   def __init__(self, input):
     if hasattr(input, 'prop'):
-    	self._prop = input.prop
+      self._prop = input.prop
     if hasattr(input, 'additional_properties'):
-    	self._additional_properties = input.additional_properties
+      self._additional_properties = input.additional_properties
 
   @property
   def prop(self):
@@ -17,10 +17,10 @@ exports[`PYTHON_JSON_SERIALIZER_PRESET should render serializer and deserializer
 
   @property
   def additional_properties(self):
-  	return self._additional_properties
+    return self._additional_properties
   @additional_properties.setter
   def additional_properties(self, additional_properties):
-  	self._additional_properties = additional_properties
+    self._additional_properties = additional_properties
 
   def serialize_to_json(self):
     return json.dumps(self.__dict__, default=lambda o: o.__dict__, indent=2)

--- a/test/generators/python/presets/__snapshots__/JsonSerializer.spec.ts.snap
+++ b/test/generators/python/presets/__snapshots__/JsonSerializer.spec.ts.snap
@@ -13,14 +13,14 @@ exports[`PYTHON_JSON_SERIALIZER_PRESET should render serializer and deserializer
       return self._prop
     @prop.setter
     def prop(self, prop):
-    	self._prop = prop
+      self._prop = prop
 
     @property
     def additionalProperties(self):
       return self._additionalProperties
     @additionalProperties.setter
     def additionalProperties(self, additionalProperties):
-    	self._additionalProperties = additionalProperties
+      self._additionalProperties = additionalProperties
 
   def serializeToJson(self):
     return json.dumps(self.__dict__, default=lambda o: o.__dict__, indent=2)

--- a/test/generators/python/presets/__snapshots__/JsonSerializer.spec.ts.snap
+++ b/test/generators/python/presets/__snapshots__/JsonSerializer.spec.ts.snap
@@ -4,23 +4,23 @@ exports[`PYTHON_JSON_SERIALIZER_PRESET should render serializer and deserializer
 "class Test: 
   def __init__(self, input):
     if hasattr(input, 'prop'):
-    	self._prop = input.prop
+      self._prop = input.prop
     if hasattr(input, 'additionalProperties'):
-    	self._additionalProperties = input.additionalProperties
+      self._additionalProperties = input.additionalProperties
 
-  @property
-  def prop(self):
-  	return self._prop
-  @prop.setter
-  def prop(self, prop):
-  	self._prop = prop
+    @property
+    def prop(self):
+      return self._prop
+    @prop.setter
+    def prop(self, prop):
+    	self._prop = prop
 
-  @property
-  def additionalProperties(self):
-  	return self._additionalProperties
-  @additionalProperties.setter
-  def additionalProperties(self, additionalProperties):
-  	self._additionalProperties = additionalProperties
+    @property
+    def additionalProperties(self):
+      return self._additionalProperties
+    @additionalProperties.setter
+    def additionalProperties(self, additionalProperties):
+    	self._additionalProperties = additionalProperties
 
   def serializeToJson(self):
     return json.dumps(self.__dict__, default=lambda o: o.__dict__, indent=2)

--- a/test/generators/python/presets/__snapshots__/JsonSerializer.spec.ts.snap
+++ b/test/generators/python/presets/__snapshots__/JsonSerializer.spec.ts.snap
@@ -8,19 +8,19 @@ exports[`PYTHON_JSON_SERIALIZER_PRESET should render serializer and deserializer
     if hasattr(input, 'additionalProperties'):
       self._additionalProperties = input.additionalProperties
 
-    @property
-    def prop(self):
-      return self._prop
-    @prop.setter
-    def prop(self, prop):
-      self._prop = prop
+  @property
+  def prop(self):
+    return self._prop
+  @prop.setter
+  def prop(self, prop):
+    self._prop = prop
 
-    @property
-    def additionalProperties(self):
-      return self._additionalProperties
-    @additionalProperties.setter
-    def additionalProperties(self, additionalProperties):
-      self._additionalProperties = additionalProperties
+  @property
+  def additionalProperties(self):
+    return self._additionalProperties
+  @additionalProperties.setter
+  def additionalProperties(self, additionalProperties):
+    self._additionalProperties = additionalProperties
 
   def serializeToJson(self):
     return json.dumps(self.__dict__, default=lambda o: o.__dict__, indent=2)


### PR DESCRIPTION
## Description
This PR fixes the inconsistent indentation for the Python models where explicit `\t` characters where used.

## Related Issue
Fixes https://github.com/asyncapi/modelina/issues/1817
