### PR TITLE
fix: add serialization alias for Pydantic 

### DIFF
--- a/examples/generate-python-pydantic-models/__snapshots__/index.spec.ts.snap
+++ b/examples/generate-python-pydantic-models/__snapshots__/index.spec.ts.snap
@@ -3,10 +3,10 @@
 exports[`Should be able to render python models and should log expected output to console: class-model 1`] = `
 Array [
   "class Root(BaseModel): 
-  optionalField: Optional[str] = Field(description='''this field is optional''', default=None)
-  requiredField: str = Field(description='''this field is required''')
-  noDescription: Optional[str] = Field(default=None)
-  options: Optional[Options] = Field(default=None)
+  optionalField: Optional[str] = Field(description='''this field is optional''', default=None, serialization_alias='optionalField')
+  requiredField: str = Field(description='''this field is required''', serialization_alias='requiredField')
+  noDescription: Optional[str] = Field(default=None, serialization_alias='noDescription')
+  options: Optional[Options] = Field(default=None, serialization_alias='options')
 ",
 ]
 `;

--- a/src/generators/python/presets/Pydantic.ts
+++ b/src/generators/python/presets/Pydantic.ts
@@ -35,15 +35,13 @@ const PYTHON_PYDANTIC_CLASS_PRESET: ClassPresetType<PythonOptions> = {
 
     const description = params.property.property.originalInput['description']
       ? `description='''${params.property.property.originalInput['description']}'''`
-      : '';
-    const defaultValue = params.property.required ? '' : 'default=None';
-
-    if (description && defaultValue) {
-      return `${propertyName}: ${type} = Field(${description}, ${defaultValue})`;
-    } else if (description) {
-      return `${propertyName}: ${type} = Field(${description})`;
-    }
-    return `${propertyName}: ${type} = Field(${defaultValue})`;
+      : undefined;
+    const defaultValue = params.property.required ? undefined : 'default=None';
+    const jsonAlias = `serialization_alias='${params.property.unconstrainedPropertyName}'`;
+    const fieldTags = [description, defaultValue, jsonAlias].filter(
+      (value) => value
+    );
+    return `${propertyName}: ${type} = Field(${fieldTags.join(', ')})`;
   },
   ctor: () => '',
   getter: () => '',

--- a/test/generators/python/presets/__snapshots__/Pydantic.spec.ts.snap
+++ b/test/generators/python/presets/__snapshots__/Pydantic.spec.ts.snap
@@ -5,24 +5,24 @@ exports[`PYTHON_PYDANTIC_PRESET should render pydantic for class 1`] = `
   prop: Optional[str] = Field(description='''test
     multi
     line
-    description''', default=None)
-  additionalProperties: Optional[dict[Any, Any]] = Field(default=None)
+    description''', default=None, serialization_alias='prop')
+  additionalProperties: Optional[dict[Any, Any]] = Field(default=None, serialization_alias='additionalProperties')
 "
 `;
 
 exports[`PYTHON_PYDANTIC_PRESET should render union to support Python < 3.10 1`] = `
 Array [
   "class UnionTest(BaseModel): 
-  unionTest: Optional[Union[Union1, Union2]] = Field(default=None)
-  additionalProperties: Optional[dict[Any, Any]] = Field(default=None)
+  unionTest: Optional[Union[Union1, Union2]] = Field(default=None, serialization_alias='unionTest')
+  additionalProperties: Optional[dict[Any, Any]] = Field(default=None, serialization_alias='additionalProperties')
 ",
   "class Union1(BaseModel): 
-  testProp1: Optional[str] = Field(default=None)
-  additionalProperties: Optional[dict[Any, Any]] = Field(default=None)
+  testProp1: Optional[str] = Field(default=None, serialization_alias='testProp1')
+  additionalProperties: Optional[dict[Any, Any]] = Field(default=None, serialization_alias='additionalProperties')
 ",
   "class Union2(BaseModel): 
-  testProp2: Optional[str] = Field(default=None)
-  additionalProperties: Optional[dict[Any, Any]] = Field(default=None)
+  testProp2: Optional[str] = Field(default=None, serialization_alias='testProp2')
+  additionalProperties: Optional[dict[Any, Any]] = Field(default=None, serialization_alias='additionalProperties')
 ",
 ]
 `;


### PR DESCRIPTION
## Description
This PR adds serialization alias field tags for the Pydantic preset, so properties are accurately serialized and deserialized 
