### PR TITLE
fix: exclude unwrappable dictionaries for pydantic preset

### DIFF
--- a/docs/languages/Python.md
+++ b/docs/languages/Python.md
@@ -17,6 +17,9 @@ There are special use-cases that each language supports; this document pertains 
 In some cases you might want to use [pydantic](https://pypi.org/project/pydantic/) data validation and settings management using Python type hints for the models.
 Modelina follows Pydantic v2.
 
+There are some limitations to the current implementation:
+1. The preset doesn't unwrap properties of type `ConstrainedDictionaryModel` with `serialilzationType = unwrap`, they are simply excluded from the serialization
+
 You can find an example of its use [here](../../examples/generate-python-pydantic-models/index.ts)
 
 ## Generate models with JSON Serializer and Deserializer methods

--- a/examples/generate-python-pydantic-models/__snapshots__/index.spec.ts.snap
+++ b/examples/generate-python-pydantic-models/__snapshots__/index.spec.ts.snap
@@ -3,10 +3,10 @@
 exports[`Should be able to render python models and should log expected output to console: class-model 1`] = `
 Array [
   "class Root(BaseModel): 
-  optionalField: Optional[str] = Field(description='''this field is optional''', default=None)
-  requiredField: str = Field(description='''this field is required''')
-  noDescription: Optional[str] = Field(default=None)
-  options: Optional[Options] = Field(default=None)
+  optionalField: Optional[str] = Field(description='''this field is optional''', default=None, serialization_alias='optionalField')
+  requiredField: str = Field(description='''this field is required''', serialization_alias='requiredField')
+  noDescription: Optional[str] = Field(default=None, serialization_alias='noDescription')
+  options: Optional[Options] = Field(default=None, serialization_alias='options')
 ",
 ]
 `;

--- a/src/generators/python/presets/Pydantic.ts
+++ b/src/generators/python/presets/Pydantic.ts
@@ -1,4 +1,7 @@
-import { ConstrainedDictionaryModel, ConstrainedUnionModel } from '../../../models';
+import {
+  ConstrainedDictionaryModel,
+  ConstrainedUnionModel
+} from '../../../models';
 import { PythonOptions } from '../PythonGenerator';
 import { ClassPresetType, PythonPreset } from '../PythonPreset';
 

--- a/src/generators/python/presets/Pydantic.ts
+++ b/src/generators/python/presets/Pydantic.ts
@@ -35,15 +35,13 @@ const PYTHON_PYDANTIC_CLASS_PRESET: ClassPresetType<PythonOptions> = {
 
     const description = params.property.property.originalInput['description']
       ? `description='''${params.property.property.originalInput['description']}'''`
-      : '';
-    const defaultValue = params.property.required ? '' : 'default=None';
-
-    if (description && defaultValue) {
-      return `${propertyName}: ${type} = Field(${description}, ${defaultValue})`;
-    } else if (description) {
-      return `${propertyName}: ${type} = Field(${description})`;
-    }
-    return `${propertyName}: ${type} = Field(${defaultValue})`;
+      : undefined;
+    const defaultValue = params.property.required ? undefined : 'default=None';
+    const jsonAlias = `serialization_alias='${params.property.unconstrainedPropertyName}'`;
+    const fieldTags = [description, defaultValue, jsonAlias].filter(
+      (value) => value
+    );
+    return `${propertyName}: ${type} = Field(${fieldTags.join(', ')})`;
   },
   ctor: () => '',
   getter: () => '',

--- a/src/generators/python/presets/Pydantic.ts
+++ b/src/generators/python/presets/Pydantic.ts
@@ -1,4 +1,4 @@
-import { ConstrainedUnionModel } from '../../../models';
+import { ConstrainedDictionaryModel, ConstrainedUnionModel } from '../../../models';
 import { PythonOptions } from '../PythonGenerator';
 import { ClassPresetType, PythonPreset } from '../PythonPreset';
 
@@ -38,7 +38,14 @@ const PYTHON_PYDANTIC_CLASS_PRESET: ClassPresetType<PythonOptions> = {
       : undefined;
     const defaultValue = params.property.required ? undefined : 'default=None';
     const jsonAlias = `serialization_alias='${params.property.unconstrainedPropertyName}'`;
-    const fieldTags = [description, defaultValue, jsonAlias].filter(
+    let exclude = undefined;
+    if (
+      params.property.property instanceof ConstrainedDictionaryModel &&
+      params.property.property.serializationType === 'unwrap'
+    ) {
+      exclude = 'exclude=True';
+    }
+    const fieldTags = [description, defaultValue, jsonAlias, exclude].filter(
       (value) => value
     );
     return `${propertyName}: ${type} = Field(${fieldTags.join(', ')})`;

--- a/test/generators/python/presets/__snapshots__/Pydantic.spec.ts.snap
+++ b/test/generators/python/presets/__snapshots__/Pydantic.spec.ts.snap
@@ -5,24 +5,24 @@ exports[`PYTHON_PYDANTIC_PRESET should render pydantic for class 1`] = `
   prop: Optional[str] = Field(description='''test
     multi
     line
-    description''', default=None)
-  additionalProperties: Optional[dict[Any, Any]] = Field(default=None)
+    description''', default=None, serialization_alias='prop')
+  additionalProperties: Optional[dict[Any, Any]] = Field(default=None, serialization_alias='additionalProperties')
 "
 `;
 
 exports[`PYTHON_PYDANTIC_PRESET should render union to support Python < 3.10 1`] = `
 Array [
   "class UnionTest(BaseModel): 
-  unionTest: Optional[Union[Union1, Union2]] = Field(default=None)
-  additionalProperties: Optional[dict[Any, Any]] = Field(default=None)
+  unionTest: Optional[Union[Union1, Union2]] = Field(default=None, serialization_alias='unionTest')
+  additionalProperties: Optional[dict[Any, Any]] = Field(default=None, serialization_alias='additionalProperties')
 ",
   "class Union1(BaseModel): 
-  testProp1: Optional[str] = Field(default=None)
-  additionalProperties: Optional[dict[Any, Any]] = Field(default=None)
+  testProp1: Optional[str] = Field(default=None, serialization_alias='testProp1')
+  additionalProperties: Optional[dict[Any, Any]] = Field(default=None, serialization_alias='additionalProperties')
 ",
   "class Union2(BaseModel): 
-  testProp2: Optional[str] = Field(default=None)
-  additionalProperties: Optional[dict[Any, Any]] = Field(default=None)
+  testProp2: Optional[str] = Field(default=None, serialization_alias='testProp2')
+  additionalProperties: Optional[dict[Any, Any]] = Field(default=None, serialization_alias='additionalProperties')
 ",
 ]
 `;

--- a/test/generators/python/presets/__snapshots__/Pydantic.spec.ts.snap
+++ b/test/generators/python/presets/__snapshots__/Pydantic.spec.ts.snap
@@ -6,7 +6,7 @@ exports[`PYTHON_PYDANTIC_PRESET should render pydantic for class 1`] = `
     multi
     line
     description''', default=None, serialization_alias='prop')
-  additionalProperties: Optional[dict[Any, Any]] = Field(default=None, serialization_alias='additionalProperties')
+  additionalProperties: Optional[dict[Any, Any]] = Field(default=None, serialization_alias='additionalProperties', exclude=True)
 "
 `;
 
@@ -14,15 +14,15 @@ exports[`PYTHON_PYDANTIC_PRESET should render union to support Python < 3.10 1`]
 Array [
   "class UnionTest(BaseModel): 
   unionTest: Optional[Union[Union1, Union2]] = Field(default=None, serialization_alias='unionTest')
-  additionalProperties: Optional[dict[Any, Any]] = Field(default=None, serialization_alias='additionalProperties')
+  additionalProperties: Optional[dict[Any, Any]] = Field(default=None, serialization_alias='additionalProperties', exclude=True)
 ",
   "class Union1(BaseModel): 
   testProp1: Optional[str] = Field(default=None, serialization_alias='testProp1')
-  additionalProperties: Optional[dict[Any, Any]] = Field(default=None, serialization_alias='additionalProperties')
+  additionalProperties: Optional[dict[Any, Any]] = Field(default=None, serialization_alias='additionalProperties', exclude=True)
 ",
   "class Union2(BaseModel): 
   testProp2: Optional[str] = Field(default=None, serialization_alias='testProp2')
-  additionalProperties: Optional[dict[Any, Any]] = Field(default=None, serialization_alias='additionalProperties')
+  additionalProperties: Optional[dict[Any, Any]] = Field(default=None, serialization_alias='additionalProperties', exclude=True)
 ",
 ]
 `;


### PR DESCRIPTION
## Description
This PR adds the exclusion tag for properties with type `ConstrainedDictionaryModel` with `serialilzationType = unwrap` to make sure they don't clutter up the serialized JSON.

## Related Issue
Blocked by #1859 (this extends it)
