### PR TITLE
fix!: use recommended Python styles for names

### DIFF
--- a/docs/migrations/version-3-to-4.md
+++ b/docs/migrations/version-3-to-4.md
@@ -112,3 +112,24 @@ Before names of properties and model names did not follow any specific styling s
 In v4, we switched to using the following:
 - Variables and functions: https://peps.python.org/pep-0008/#function-and-variable-names
 - Model names: https://peps.python.org/pep-0008/#class-names
+
+This means that properties and their accessor methods (getter and setters) have been renamed from:
+```diff
+- self._someWeirdValueExclamationQuotationHash_2 = input.someWeirdValueExclamationQuotationHash_2
++ self._some_weird_value_exclamation_quotation_hash_2 = input.some_weird_value_exclamation_quotation_hash_2
+```
+
+And model names have been renamed to:
+```diff
+- class AsyncApi_3Dot_0Dot_0SchemaDot:
++ class AsyncApi3Dot0Dot0SchemaDot:
+```
+
+If you are using the Python preset `PYTHON_JSON_SERIALIZER_PRESET`, the functions have also been renamed:
+```diff
+- serializeToJson
++ serialize_to_json
+
+- deserializeFromJson
++ deserialize_from_json
+```

--- a/docs/migrations/version-3-to-4.md
+++ b/docs/migrations/version-3-to-4.md
@@ -104,3 +104,11 @@ In Modelina 3 this used is rendered as:
 class Message(BaseModel):
   identifier: str = Field(alias='''The Identifier for the Message''')
 ```
+
+### Following standardized styling guide
+
+Before names of properties and model names did not follow any specific styling standard.
+
+In v4, we switched to using the following:
+- Variables and functions: https://peps.python.org/pep-0008/#function-and-variable-names
+- Model names: https://peps.python.org/pep-0008/#class-names

--- a/examples/generate-python-complete-models/__snapshots__/index.spec.ts.snap
+++ b/examples/generate-python-complete-models/__snapshots__/index.spec.ts.snap
@@ -8,8 +8,8 @@ class ObjProperty:
   def __init__(self, input):
     if hasattr(input, 'number'):
     	self._number = input.number
-    if hasattr(input, 'additionalProperties'):
-    	self._additionalProperties = input.additionalProperties
+    if hasattr(input, 'additional_properties'):
+    	self._additional_properties = input.additional_properties
 
   @property
   def number(self):
@@ -19,11 +19,11 @@ class ObjProperty:
   	self._number = number
 
   @property
-  def additionalProperties(self):
-  	return self._additionalProperties
-  @additionalProperties.setter
-  def additionalProperties(self, additionalProperties):
-  	self._additionalProperties = additionalProperties
+  def additional_properties(self):
+  	return self._additional_properties
+  @additional_properties.setter
+  def additional_properties(self, additional_properties):
+  	self._additional_properties = additional_properties
 ",
 ]
 `;
@@ -36,8 +36,8 @@ class ObjProperty:
   def __init__(self, input):
     if hasattr(input, 'number'):
     	self._number = input.number
-    if hasattr(input, 'additionalProperties'):
-    	self._additionalProperties = input.additionalProperties
+    if hasattr(input, 'additional_properties'):
+    	self._additional_properties = input.additional_properties
 
   @property
   def number(self):
@@ -47,11 +47,11 @@ class ObjProperty:
   	self._number = number
 
   @property
-  def additionalProperties(self):
-  	return self._additionalProperties
-  @additionalProperties.setter
-  def additionalProperties(self, additionalProperties):
-  	self._additionalProperties = additionalProperties
+  def additional_properties(self):
+  	return self._additional_properties
+  @additional_properties.setter
+  def additional_properties(self, additional_properties):
+  	self._additional_properties = additional_properties
 ",
 ]
 `;
@@ -64,8 +64,8 @@ class Root:
   def __init__(self, input):
     if hasattr(input, 'email'):
     	self._email = input.email
-    if hasattr(input, 'objProperty'):
-    	self._objProperty = input.objProperty
+    if hasattr(input, 'obj_property'):
+    	self._obj_property = input.obj_property
 
   @property
   def email(self):
@@ -75,11 +75,11 @@ class Root:
   	self._email = email
 
   @property
-  def objProperty(self):
-  	return self._objProperty
-  @objProperty.setter
-  def objProperty(self, objProperty):
-  	self._objProperty = objProperty
+  def obj_property(self):
+  	return self._obj_property
+  @obj_property.setter
+  def obj_property(self, obj_property):
+  	self._obj_property = obj_property
 ",
 ]
 `;
@@ -92,8 +92,8 @@ class Root:
   def __init__(self, input):
     if hasattr(input, 'email'):
     	self._email = input.email
-    if hasattr(input, 'objProperty'):
-    	self._objProperty = input.objProperty
+    if hasattr(input, 'obj_property'):
+    	self._obj_property = input.obj_property
 
   @property
   def email(self):
@@ -103,11 +103,11 @@ class Root:
   	self._email = email
 
   @property
-  def objProperty(self):
-  	return self._objProperty
-  @objProperty.setter
-  def objProperty(self, objProperty):
-  	self._objProperty = objProperty
+  def obj_property(self):
+  	return self._obj_property
+  @obj_property.setter
+  def obj_property(self, obj_property):
+  	self._obj_property = obj_property
 ",
 ]
 `;

--- a/examples/generate-python-pydantic-models/__snapshots__/index.spec.ts.snap
+++ b/examples/generate-python-pydantic-models/__snapshots__/index.spec.ts.snap
@@ -3,9 +3,9 @@
 exports[`Should be able to render python models and should log expected output to console: class-model 1`] = `
 Array [
   "class Root(BaseModel): 
-  optionalField: Optional[str] = Field(description='''this field is optional''', default=None, serialization_alias='optionalField')
-  requiredField: str = Field(description='''this field is required''', serialization_alias='requiredField')
-  noDescription: Optional[str] = Field(default=None, serialization_alias='noDescription')
+  optional_field: Optional[str] = Field(description='''this field is optional''', default=None, serialization_alias='optionalField')
+  required_field: str = Field(description='''this field is required''', serialization_alias='requiredField')
+  no_description: Optional[str] = Field(default=None, serialization_alias='noDescription')
   options: Optional[Options] = Field(default=None, serialization_alias='options')
 ",
 ]

--- a/examples/python-generate-json-serializer-and-deserializer/__snapshots__/index.spec.ts.snap
+++ b/examples/python-generate-json-serializer-and-deserializer/__snapshots__/index.spec.ts.snap
@@ -6,8 +6,8 @@ Array [
   def __init__(self, input):
     if hasattr(input, 'email'):
     	self._email = input.email
-    if hasattr(input, 'additionalProperties'):
-    	self._additionalProperties = input.additionalProperties
+    if hasattr(input, 'additional_properties'):
+    	self._additional_properties = input.additional_properties
 
   @property
   def email(self):
@@ -17,17 +17,17 @@ Array [
   	self._email = email
 
   @property
-  def additionalProperties(self):
-  	return self._additionalProperties
-  @additionalProperties.setter
-  def additionalProperties(self, additionalProperties):
-  	self._additionalProperties = additionalProperties
+  def additional_properties(self):
+  	return self._additional_properties
+  @additional_properties.setter
+  def additional_properties(self, additional_properties):
+  	self._additional_properties = additional_properties
 
-  def serializeToJson(self):
+  def serialize_to_json(self):
     return json.dumps(self.__dict__, default=lambda o: o.__dict__, indent=2)
 
   @staticmethod
-  def deserializeFromJson(json_string):
+  def deserialize_from_json(json_string):
     return Root(**json.loads(json_string))
 ",
 ]

--- a/src/generators/python/constrainer/ModelNameConstrainer.ts
+++ b/src/generators/python/constrainer/ModelNameConstrainer.ts
@@ -27,7 +27,7 @@ export const DefaultModelNameConstraints: ModelNameConstraints = {
   NO_NUMBER_START_CHAR,
   NO_EMPTY_VALUE,
   NAMING_FORMATTER: (value: string) => {
-    return FormatHelpers.toPascalCase(value);
+    return FormatHelpers.toPascalCaseMergingNumbers(value);
   },
   NO_RESERVED_KEYWORDS: (value: string) => {
     return NO_RESERVED_KEYWORDS(value, isReservedPythonKeyword);

--- a/src/generators/python/constrainer/PropertyKeyConstrainer.ts
+++ b/src/generators/python/constrainer/PropertyKeyConstrainer.ts
@@ -35,7 +35,7 @@ export const DefaultPropertyKeyConstraints: PropertyKeyConstraintOptions = {
   NO_NUMBER_START_CHAR,
   NO_DUPLICATE_PROPERTIES,
   NO_EMPTY_VALUE,
-  NAMING_FORMATTER: FormatHelpers.toCamelCase,
+  NAMING_FORMATTER: FormatHelpers.toSnakeCase,
   NO_RESERVED_KEYWORDS: (value: string) => {
     return NO_RESERVED_KEYWORDS(value, isReservedPythonKeyword);
   }

--- a/src/generators/python/presets/JsonSerializer.ts
+++ b/src/generators/python/presets/JsonSerializer.ts
@@ -11,11 +11,11 @@ export const PYTHON_JSON_SERIALIZER_PRESET: PythonPreset = {
     additionalContent({ renderer, model, content }) {
       renderer.dependencyManager.addDependency('import json');
 
-      const serializeContent = `def serializeToJson(self):
+      const serializeContent = `def serialize_to_json(self):
   return json.dumps(self.__dict__, default=lambda o: o.__dict__, indent=2)`.trim();
 
       const deserializeContent = `@staticmethod
-def deserializeFromJson(json_string):
+def deserialize_from_json(json_string):
   return ${model.name}(**json.loads(json_string))`.trim();
 
       return renderer.renderBlock(

--- a/test/generators/python/__snapshots__/PythonGenerator.spec.ts.snap
+++ b/test/generators/python/__snapshots__/PythonGenerator.spec.ts.snap
@@ -3,48 +3,39 @@
 exports[`PythonGenerator Class should not render reserved keyword 1`] = `
 "class Address: 
   def __init__(self, input):
-    if hasattr(input, 'reservedReservedDel'):
-    	self._reservedReservedDel = input.reservedReservedDel
-    if hasattr(input, 'reservedDel'):
-    	self._reservedDel = input.reservedDel
+    if hasattr(input, 'reserved_del'):
+    	self._reserved_del = input.reserved_del
 
   @property
-  def reservedReservedDel(self):
-  	return self._reservedReservedDel
-  @reservedReservedDel.setter
-  def reservedReservedDel(self, reservedReservedDel):
-  	self._reservedReservedDel = reservedReservedDel
-
-  @property
-  def reservedDel(self):
-  	return self._reservedDel
-  @reservedDel.setter
-  def reservedDel(self, reservedDel):
-  	self._reservedDel = reservedDel
+  def reserved_del(self):
+  	return self._reserved_del
+  @reserved_del.setter
+  def reserved_del(self, reserved_del):
+  	self._reserved_del = reserved_del
 "
 `;
 
 exports[`PythonGenerator Class should render \`class\` type 1`] = `
 "class Address: 
   def __init__(self, input):
-    self._streetName = input.streetName
+    self._street_name = input.street_name
     self._city = input.city
     self._state = input.state
-    self._houseNumber = input.houseNumber
+    self._house_number = input.house_number
     if hasattr(input, 'marriage'):
     	self._marriage = input.marriage
     if hasattr(input, 'members'):
     	self._members = input.members
-    self._arrayType = input.arrayType
-    if hasattr(input, 'additionalProperties'):
-    	self._additionalProperties = input.additionalProperties
+    self._array_type = input.array_type
+    if hasattr(input, 'additional_properties'):
+    	self._additional_properties = input.additional_properties
 
   @property
-  def streetName(self):
-  	return self._streetName
-  @streetName.setter
-  def streetName(self, streetName):
-  	self._streetName = streetName
+  def street_name(self):
+  	return self._street_name
+  @street_name.setter
+  def street_name(self, street_name):
+  	self._street_name = street_name
 
   @property
   def city(self):
@@ -61,11 +52,11 @@ exports[`PythonGenerator Class should render \`class\` type 1`] = `
   	self._state = state
 
   @property
-  def houseNumber(self):
-  	return self._houseNumber
-  @houseNumber.setter
-  def houseNumber(self, houseNumber):
-  	self._houseNumber = houseNumber
+  def house_number(self):
+  	return self._house_number
+  @house_number.setter
+  def house_number(self, house_number):
+  	self._house_number = house_number
 
   @property
   def marriage(self):
@@ -82,18 +73,18 @@ exports[`PythonGenerator Class should render \`class\` type 1`] = `
   	self._members = members
 
   @property
-  def arrayType(self):
-  	return self._arrayType
-  @arrayType.setter
-  def arrayType(self, arrayType):
-  	self._arrayType = arrayType
+  def array_type(self):
+  	return self._array_type
+  @array_type.setter
+  def array_type(self, array_type):
+  	self._array_type = array_type
 
   @property
-  def additionalProperties(self):
-  	return self._additionalProperties
-  @additionalProperties.setter
-  def additionalProperties(self, additionalProperties):
-  	self._additionalProperties = additionalProperties
+  def additional_properties(self):
+  	return self._additional_properties
+  @additional_properties.setter
+  def additional_properties(self, additional_properties):
+  	self._additional_properties = additional_properties
 "
 `;
 
@@ -107,8 +98,8 @@ exports[`PythonGenerator Class should work with custom preset for \`class\` type
   def __init__(self, input):
     if hasattr(input, 'property'):
     	self._property = input.property
-    if hasattr(input, 'additionalProperties'):
-    	self._additionalProperties = input.additionalProperties
+    if hasattr(input, 'additional_properties'):
+    	self._additional_properties = input.additional_properties
 
   test2
   @property
@@ -121,12 +112,12 @@ exports[`PythonGenerator Class should work with custom preset for \`class\` type
 
   test2
   @property
-  def additionalProperties(self):
-  	return self._additionalProperties
+  def additional_properties(self):
+  	return self._additional_properties
   test3
-  @additionalProperties.setter
-  def additionalProperties(self, additionalProperties):
-  	self._additionalProperties = additionalProperties
+  @additional_properties.setter
+  def additional_properties(self, additional_properties):
+  	self._additional_properties = additional_properties
 "
 `;
 

--- a/test/generators/python/constrainer/EnumConstrainer.spec.ts
+++ b/test/generators/python/constrainer/EnumConstrainer.spec.ts
@@ -2,7 +2,8 @@ import { PythonDefaultConstraints } from '../../../../src/generators/python/Pyth
 import { EnumModel } from '../../../../src/models/MetaModel';
 import {
   ConstrainedEnumModel,
-  ConstrainedEnumValueModel
+  ConstrainedEnumValueModel,
+  PythonGenerator
 } from '../../../../src';
 
 describe('EnumConstrainer', () => {
@@ -20,7 +21,8 @@ describe('EnumConstrainer', () => {
       const constrainedKey = PythonDefaultConstraints.enumKey({
         enumModel,
         constrainedEnumModel,
-        enumKey: '%'
+        enumKey: '%',
+        options: PythonGenerator.defaultOptions
       });
       expect(constrainedKey).toEqual('PERCENT');
     });
@@ -29,7 +31,8 @@ describe('EnumConstrainer', () => {
       const constrainedKey = PythonDefaultConstraints.enumKey({
         enumModel,
         constrainedEnumModel,
-        enumKey: '1'
+        enumKey: '1',
+        options: PythonGenerator.defaultOptions
       });
       expect(constrainedKey).toEqual('NUMBER_1');
     });
@@ -50,7 +53,8 @@ describe('EnumConstrainer', () => {
       const constrainedKey = PythonDefaultConstraints.enumKey({
         enumModel,
         constrainedEnumModel,
-        enumKey: ''
+        enumKey: '',
+        options: PythonGenerator.defaultOptions
       });
       expect(constrainedKey).toEqual('RESERVED_EMPTY');
     });
@@ -59,7 +63,8 @@ describe('EnumConstrainer', () => {
       const constrainedKey = PythonDefaultConstraints.enumKey({
         enumModel,
         constrainedEnumModel,
-        enumKey: ''
+        enumKey: '',
+        options: PythonGenerator.defaultOptions
       });
       expect(constrainedKey).toEqual('EMPTY');
     });
@@ -68,7 +73,8 @@ describe('EnumConstrainer', () => {
       const constrainedKey = PythonDefaultConstraints.enumKey({
         enumModel,
         constrainedEnumModel,
-        enumKey: 'some weird_value!"#2'
+        enumKey: 'some weird_value!"#2',
+        options: PythonGenerator.defaultOptions
       });
       expect(constrainedKey).toEqual(
         'SOME_WEIRD_VALUE_EXCLAMATION_QUOTATION_HASH_2'
@@ -79,7 +85,8 @@ describe('EnumConstrainer', () => {
       const constrainedKey = PythonDefaultConstraints.enumKey({
         enumModel,
         constrainedEnumModel,
-        enumKey: 'return'
+        enumKey: 'return',
+        options: PythonGenerator.defaultOptions
       });
       expect(constrainedKey).toEqual('RESERVED_RETURN');
     });
@@ -90,7 +97,8 @@ describe('EnumConstrainer', () => {
       const constrainedValue = PythonDefaultConstraints.enumValue({
         enumModel,
         constrainedEnumModel,
-        enumValue: 'string value'
+        enumValue: 'string value',
+        options: PythonGenerator.defaultOptions
       });
       expect(constrainedValue).toEqual('"string value"');
     });
@@ -99,7 +107,8 @@ describe('EnumConstrainer', () => {
       const constrainedValue = PythonDefaultConstraints.enumValue({
         enumModel,
         constrainedEnumModel,
-        enumValue: true
+        enumValue: true,
+        options: PythonGenerator.defaultOptions
       });
       expect(constrainedValue).toEqual('"true"');
     });
@@ -108,7 +117,8 @@ describe('EnumConstrainer', () => {
       const constrainedValue = PythonDefaultConstraints.enumValue({
         enumModel,
         constrainedEnumModel,
-        enumValue: 123
+        enumValue: 123,
+        options: PythonGenerator.defaultOptions
       });
       expect(constrainedValue).toEqual(123);
     });
@@ -117,7 +127,8 @@ describe('EnumConstrainer', () => {
       const constrainedValue = PythonDefaultConstraints.enumValue({
         enumModel,
         constrainedEnumModel,
-        enumValue: { test: 'test' }
+        enumValue: { test: 'test' },
+        options: PythonGenerator.defaultOptions
       });
       expect(constrainedValue).toEqual('"{\\"test\\":\\"test\\"}"');
     });
@@ -126,7 +137,8 @@ describe('EnumConstrainer', () => {
       const constrainedValue = PythonDefaultConstraints.enumValue({
         enumModel,
         constrainedEnumModel,
-        enumValue: undefined
+        enumValue: undefined,
+        options: PythonGenerator.defaultOptions
       });
       expect(constrainedValue).toEqual(`"undefined"`);
     });

--- a/test/generators/python/constrainer/ModelNameConstrainer.spec.ts
+++ b/test/generators/python/constrainer/ModelNameConstrainer.spec.ts
@@ -1,3 +1,4 @@
+import { PythonGenerator } from '../../../../src';
 import { PythonDefaultConstraints } from '../../../../src/generators/python/PythonConstrainer';
 import {
   DefaultModelNameConstraints,
@@ -8,31 +9,36 @@ import {
 describe('ModelNameConstrainer', () => {
   test('should never render special chars', () => {
     const constrainedKey = PythonDefaultConstraints.modelName({
-      modelName: '%'
+      modelName: '%',
+      options: PythonGenerator.defaultOptions
     });
     expect(constrainedKey).toEqual('Percent');
   });
   test('should never render number as start char', () => {
     const constrainedKey = PythonDefaultConstraints.modelName({
-      modelName: '1'
+      modelName: '1',
+      options: PythonGenerator.defaultOptions
     });
-    expect(constrainedKey).toEqual('Number_1');
+    expect(constrainedKey).toEqual('Number1');
   });
   test('should never contain empty name', () => {
     const constrainedKey = PythonDefaultConstraints.modelName({
-      modelName: ''
+      modelName: '',
+      options: PythonGenerator.defaultOptions
     });
     expect(constrainedKey).toEqual('Empty');
   });
   test('should use pascal naming format', () => {
     const constrainedKey = PythonDefaultConstraints.modelName({
-      modelName: 'some weird_value!"#2'
+      modelName: 'some weird_value!"#2',
+      options: PythonGenerator.defaultOptions
     });
-    expect(constrainedKey).toEqual('SomeWeirdValueExclamationQuotationHash_2');
+    expect(constrainedKey).toEqual('SomeWeirdValueExclamationQuotationHash2');
   });
   test('should never render reserved keywords', () => {
     const constrainedKey = PythonDefaultConstraints.modelName({
-      modelName: 'return'
+      modelName: 'return',
+      options: PythonGenerator.defaultOptions
     });
     expect(constrainedKey).toEqual('ReservedReturn');
   });
@@ -48,7 +54,10 @@ describe('ModelNameConstrainer', () => {
       const constrainFunction = defaultModelNameConstraints(
         mockedConstraintCallbacks
       );
-      constrainFunction({ modelName: '' });
+      constrainFunction({
+        modelName: '',
+        options: PythonGenerator.defaultOptions
+      });
       //Expect all callbacks to be called
       for (const jestMockCallback of Object.values(mockedConstraintCallbacks)) {
         expect(jestMockCallback).toHaveBeenCalled();
@@ -66,7 +75,10 @@ describe('ModelNameConstrainer', () => {
       const constrainFunction = defaultModelNameConstraints({
         NAMING_FORMATTER: jestCallback
       });
-      const constrainedValue = constrainFunction({ modelName: '' });
+      const constrainedValue = constrainFunction({
+        modelName: '',
+        options: PythonGenerator.defaultOptions
+      });
       expect(constrainedValue).toEqual('');
       for (const jestMockCallback of spies) {
         expect(jestMockCallback).toHaveBeenCalled();

--- a/test/generators/python/constrainer/PropertyKeyConstrainer.spec.ts
+++ b/test/generators/python/constrainer/PropertyKeyConstrainer.spec.ts
@@ -71,12 +71,12 @@ describe('PropertyKeyConstrainer', () => {
       {}
     );
     const objectPropertyModel = new ObjectPropertyModel(
-      'reservedReturn',
+      'reserved_return',
       false,
       objectModel
     );
     const constrainedObjectPropertyModel = new ConstrainedObjectPropertyModel(
-      'reservedReturn',
+      'reserved_return',
       '',
       objectPropertyModel.required,
       constrainedObjectModel
@@ -92,7 +92,7 @@ describe('PropertyKeyConstrainer', () => {
       objectPropertyModel.required,
       constrainedObjectModel
     );
-    constrainedObjectModel.properties['reservedReturn'] =
+    constrainedObjectModel.properties['reserved_return'] =
       constrainedObjectPropertyModel;
     constrainedObjectModel.properties['return'] =
       constrainedObjectPropertyModel2;
@@ -103,11 +103,11 @@ describe('PropertyKeyConstrainer', () => {
       constrainedObjectPropertyModel: constrainedObjectPropertyModel2,
       options: PythonGenerator.defaultOptions
     });
-    expect(constrainedKey).toEqual('reservedReservedReturn');
+    expect(constrainedKey).toEqual('reserved_reserved_return');
   });
   test('should never render reserved keywords', () => {
     const constrainedKey = constrainPropertyName('return');
-    expect(constrainedKey).toEqual('reservedReturn');
+    expect(constrainedKey).toEqual('reserved_return');
   });
   describe('custom constraints', () => {
     test('should be able to overwrite all hooks', () => {

--- a/test/generators/python/constrainer/PropertyKeyConstrainer.spec.ts
+++ b/test/generators/python/constrainer/PropertyKeyConstrainer.spec.ts
@@ -3,7 +3,8 @@ import {
   ConstrainedObjectModel,
   ConstrainedObjectPropertyModel,
   ObjectModel,
-  ObjectPropertyModel
+  ObjectPropertyModel,
+  PythonGenerator
 } from '../../../../src';
 import {
   DefaultPropertyKeyConstraints,
@@ -37,7 +38,8 @@ describe('PropertyKeyConstrainer', () => {
       constrainedObjectModel,
       objectModel,
       objectPropertyModel,
-      constrainedObjectPropertyModel
+      constrainedObjectPropertyModel,
+      options: PythonGenerator.defaultOptions
     });
   };
 
@@ -55,7 +57,9 @@ describe('PropertyKeyConstrainer', () => {
   });
   test('should use camel naming format', () => {
     const constrainedKey = constrainPropertyName('some weird_value!"#2');
-    expect(constrainedKey).toEqual('someWeirdValueExclamationQuotationHash_2');
+    expect(constrainedKey).toEqual(
+      'some_weird_value_exclamation_quotation_hash_2'
+    );
   });
   test('should not contain duplicate properties', () => {
     const objectModel = new ObjectModel('test', undefined, {}, {});
@@ -96,7 +100,8 @@ describe('PropertyKeyConstrainer', () => {
       constrainedObjectModel,
       objectModel,
       objectPropertyModel: objectPropertyModel2,
-      constrainedObjectPropertyModel: constrainedObjectPropertyModel2
+      constrainedObjectPropertyModel: constrainedObjectPropertyModel2,
+      options: PythonGenerator.defaultOptions
     });
     expect(constrainedKey).toEqual('reservedReservedReturn');
   });
@@ -131,7 +136,8 @@ describe('PropertyKeyConstrainer', () => {
         constrainedObjectModel,
         objectModel,
         objectPropertyModel,
-        constrainedObjectPropertyModel
+        constrainedObjectPropertyModel,
+        options: PythonGenerator.defaultOptions
       });
       //Expect all callbacks to be called
       for (const jestMockCallback of Object.values(mockedConstraintCallbacks)) {
@@ -170,7 +176,8 @@ describe('PropertyKeyConstrainer', () => {
         constrainedObjectModel,
         objectModel,
         objectPropertyModel,
-        constrainedObjectPropertyModel
+        constrainedObjectPropertyModel,
+        options: PythonGenerator.defaultOptions
       });
       expect(constrainedValue).toEqual('');
       expect(jestCallback).toHaveBeenCalled();

--- a/test/generators/python/presets/__snapshots__/JsonSerializer.spec.ts.snap
+++ b/test/generators/python/presets/__snapshots__/JsonSerializer.spec.ts.snap
@@ -22,11 +22,11 @@ exports[`PYTHON_JSON_SERIALIZER_PRESET should render serializer and deserializer
   def additional_properties(self, additional_properties):
   	self._additional_properties = additional_properties
 
-  def serializeToJson(self):
+  def serialize_to_json(self):
     return json.dumps(self.__dict__, default=lambda o: o.__dict__, indent=2)
 
   @staticmethod
-  def deserializeFromJson(json_string):
+  def deserialize_from_json(json_string):
     return Test(**json.loads(json_string))
 "
 `;

--- a/test/generators/python/presets/__snapshots__/JsonSerializer.spec.ts.snap
+++ b/test/generators/python/presets/__snapshots__/JsonSerializer.spec.ts.snap
@@ -5,8 +5,8 @@ exports[`PYTHON_JSON_SERIALIZER_PRESET should render serializer and deserializer
   def __init__(self, input):
     if hasattr(input, 'prop'):
     	self._prop = input.prop
-    if hasattr(input, 'additionalProperties'):
-    	self._additionalProperties = input.additionalProperties
+    if hasattr(input, 'additional_properties'):
+    	self._additional_properties = input.additional_properties
 
   @property
   def prop(self):
@@ -16,11 +16,11 @@ exports[`PYTHON_JSON_SERIALIZER_PRESET should render serializer and deserializer
   	self._prop = prop
 
   @property
-  def additionalProperties(self):
-  	return self._additionalProperties
-  @additionalProperties.setter
-  def additionalProperties(self, additionalProperties):
-  	self._additionalProperties = additionalProperties
+  def additional_properties(self):
+  	return self._additional_properties
+  @additional_properties.setter
+  def additional_properties(self, additional_properties):
+  	self._additional_properties = additional_properties
 
   def serializeToJson(self):
     return json.dumps(self.__dict__, default=lambda o: o.__dict__, indent=2)

--- a/test/generators/python/presets/__snapshots__/Pydantic.spec.ts.snap
+++ b/test/generators/python/presets/__snapshots__/Pydantic.spec.ts.snap
@@ -6,23 +6,23 @@ exports[`PYTHON_PYDANTIC_PRESET should render pydantic for class 1`] = `
     multi
     line
     description''', default=None)
-  additionalProperties: Optional[dict[Any, Any]] = Field(default=None)
+  additional_properties: Optional[dict[Any, Any]] = Field(default=None)
 "
 `;
 
 exports[`PYTHON_PYDANTIC_PRESET should render union to support Python < 3.10 1`] = `
 Array [
   "class UnionTest(BaseModel): 
-  unionTest: Optional[Union[Union1, Union2]] = Field(default=None)
-  additionalProperties: Optional[dict[Any, Any]] = Field(default=None)
+  union_test: Optional[Union[Union1, Union2]] = Field(default=None)
+  additional_properties: Optional[dict[Any, Any]] = Field(default=None)
 ",
   "class Union1(BaseModel): 
-  testProp1: Optional[str] = Field(default=None)
-  additionalProperties: Optional[dict[Any, Any]] = Field(default=None)
+  test_prop1: Optional[str] = Field(default=None)
+  additional_properties: Optional[dict[Any, Any]] = Field(default=None)
 ",
   "class Union2(BaseModel): 
-  testProp2: Optional[str] = Field(default=None)
-  additionalProperties: Optional[dict[Any, Any]] = Field(default=None)
+  test_prop2: Optional[str] = Field(default=None)
+  additional_properties: Optional[dict[Any, Any]] = Field(default=None)
 ",
 ]
 `;


### PR DESCRIPTION
## Description
This PR uses the standard style guide for properties and model names:
- Variables and functions: https://peps.python.org/pep-0008/#function-and-variable-names
- Model names: https://peps.python.org/pep-0008/#class-names

## Related Issue
Fixes https://github.com/asyncapi/modelina/issues/1818