### PR TITLE
fix: python using the wrong key type for dictionaries

### DIFF
--- a/src/generators/python/PythonConstrainer.ts
+++ b/src/generators/python/PythonConstrainer.ts
@@ -51,7 +51,7 @@ export const PythonDefaultTypeMapping: PythonTypeMapping = {
     return unionTypes.join(' | ');
   },
   Dictionary({ constrainedModel }): string {
-    return `dict[${constrainedModel.value.type}, ${constrainedModel.value.type}]`;
+    return `dict[${constrainedModel.key.type}, ${constrainedModel.value.type}]`;
   }
 };
 

--- a/test/generators/python/PythonConstrainer.spec.ts
+++ b/test/generators/python/PythonConstrainer.spec.ts
@@ -223,7 +223,7 @@ describe('PythonConstrainer', () => {
         'test',
         undefined,
         {},
-        'str'
+        'str2'
       );
       const model = new ConstrainedDictionaryModel(
         'test',
@@ -237,7 +237,7 @@ describe('PythonConstrainer', () => {
         constrainedModel: model,
         ...defaultOptions
       });
-      expect(type).toEqual('dict[str, str]');
+      expect(type).toEqual('dict[str, str2]');
     });
   });
 });

--- a/test/generators/python/presets/__snapshots__/Pydantic.spec.ts.snap
+++ b/test/generators/python/presets/__snapshots__/Pydantic.spec.ts.snap
@@ -6,7 +6,7 @@ exports[`PYTHON_PYDANTIC_PRESET should render pydantic for class 1`] = `
     multi
     line
     description''', default=None)
-  additionalProperties: Optional[dict[Any, Any]] = Field(default=None)
+  additionalProperties: Optional[dict[str, Any]] = Field(default=None)
 "
 `;
 
@@ -14,15 +14,15 @@ exports[`PYTHON_PYDANTIC_PRESET should render union to support Python < 3.10 1`]
 Array [
   "class UnionTest(BaseModel): 
   unionTest: Optional[Union[Union1, Union2]] = Field(default=None)
-  additionalProperties: Optional[dict[Any, Any]] = Field(default=None)
+  additionalProperties: Optional[dict[str, Any]] = Field(default=None)
 ",
   "class Union1(BaseModel): 
   testProp1: Optional[str] = Field(default=None)
-  additionalProperties: Optional[dict[Any, Any]] = Field(default=None)
+  additionalProperties: Optional[dict[str, Any]] = Field(default=None)
 ",
   "class Union2(BaseModel): 
   testProp2: Optional[str] = Field(default=None)
-  additionalProperties: Optional[dict[Any, Any]] = Field(default=None)
+  additionalProperties: Optional[dict[str, Any]] = Field(default=None)
 ",
 ]
 `;


### PR DESCRIPTION
## Description
This PR fixes that the Python constrainer is using an incorrect value for the key for dictionaries.