### PR TITLE
feat!: export and import interfaces as types when using named imports and ESM Module Syntax

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -135,6 +135,7 @@ These are all specific examples only relevant to the TypeScript generator:
 - [typescript-generate-example](./typescript-generate-example) - A basic example of how to use Modelina and output a TypeScript class with an example function.
 - [typescript-generate-marshalling](./typescript-generate-marshalling) - A basic example of how to use the un/marshalling functionality of the typescript class.
 - [typescript-generate-comments](./typescript-generate-comments) - A basic example of how to generate TypeScript interfaces with comments from description and example fields.
+- [typescript-interfaces-as-types](./typescript-interfaces-as-types) - A basic example that generate the models as interfaces and uses ESM module system syntax to import and export them as types.
 - [typescript-use-esm](./typescript-use-esm) - A basic example that generate the models to use ESM module system.
 - [typescript-use-cjs](./typescript-use-cjs) - A basic example that generate the models to use CJS module system.
 - [typescript-generate-jsonbinpack](./typescript-generate-jsonbinpack) - A basic example showing how to generate models that include [jsonbinpack](https://github.com/sourcemeta/jsonbinpack) functionality.

--- a/examples/typescript-interfaces-as-types/README.md
+++ b/examples/typescript-interfaces-as-types/README.md
@@ -1,0 +1,17 @@
+# TypeScript interface as types
+
+A basic example of how to use Modelina and output TypeScript interfaces that are exported as types using ESM Module Syntax.
+
+## How to run this example
+
+Run this example using:
+
+```sh
+npm i && npm run start
+```
+
+If you are on Windows, use the `start:windows` script instead:
+
+```sh
+npm i && npm run start:windows
+```

--- a/examples/typescript-interfaces-as-types/__snapshots__/index.spec.ts.snap
+++ b/examples/typescript-interfaces-as-types/__snapshots__/index.spec.ts.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Should be able to render typescript interfaces as types and should log expected output to console 1`] = `
+Array [
+  "import type {OtherModel} from './OtherModel';
+interface Root {
+  email?: string;
+  otherModel?: OtherModel;
+}
+export type { Root };",
+]
+`;
+
+exports[`Should be able to render typescript interfaces as types and should log expected output to console 2`] = `
+Array [
+  "
+interface OtherModel {
+  streetName?: string;
+  additionalProperties?: Map<string, any>;
+}
+export type { OtherModel };",
+]
+`;

--- a/examples/typescript-interfaces-as-types/index.spec.ts
+++ b/examples/typescript-interfaces-as-types/index.spec.ts
@@ -1,0 +1,16 @@
+const spy = jest.spyOn(global.console, 'log').mockImplementation(() => {
+  return;
+});
+import { generate } from './index';
+
+describe('Should be able to render typescript interfaces as types', () => {
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+  test('and should log expected output to console', async () => {
+    await generate();
+    expect(spy.mock.calls.length).toEqual(2);
+    expect(spy.mock.calls[0]).toMatchSnapshot();
+    expect(spy.mock.calls[1]).toMatchSnapshot();
+  });
+});

--- a/examples/typescript-interfaces-as-types/index.ts
+++ b/examples/typescript-interfaces-as-types/index.ts
@@ -1,0 +1,34 @@
+import { TypeScriptGenerator } from '../../src';
+
+const generator = new TypeScriptGenerator({
+  modelType: 'interface',
+  moduleSystem: 'ESM'
+});
+const jsonSchemaDraft7 = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    email: {
+      type: 'string',
+      format: 'email'
+    },
+    other_model: {
+      type: 'object',
+      $id: 'OtherModel',
+      properties: { street_name: { type: 'string' } }
+    }
+  }
+};
+
+export async function generate(): Promise<void> {
+  const models = await generator.generateCompleteModels(jsonSchemaDraft7, {
+    exportType: 'named'
+  });
+  for (const model of models) {
+    console.log(model.result);
+  }
+}
+if (require.main === module) {
+  generate();
+}

--- a/examples/typescript-interfaces-as-types/package-lock.json
+++ b/examples/typescript-interfaces-as-types/package-lock.json
@@ -1,0 +1,10 @@
+{
+  "name": "typescript-interfaces-as-types",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "hasInstallScript": true
+    }
+  }
+}

--- a/examples/typescript-interfaces-as-types/package.json
+++ b/examples/typescript-interfaces-as-types/package.json
@@ -1,0 +1,10 @@
+{
+  "config" : { "example_name" : "typescript-interfaces-as-types" },
+  "scripts": {
+    "install": "cd ../.. && npm i",
+    "start": "../../node_modules/.bin/ts-node --cwd ../../ ./examples/$npm_package_config_example_name/index.ts",
+    "start:windows": "..\\..\\node_modules\\.bin\\ts-node --cwd ..\\..\\ .\\examples\\%npm_package_config_example_name%\\index.ts",
+    "test": "../../node_modules/.bin/jest --config=../../jest.config.js ./examples/$npm_package_config_example_name/index.spec.ts",
+    "test:windows": "..\\..\\node_modules\\.bin\\jest --config=..\\..\\jest.config.js examples/%npm_package_config_example_name%/index.spec.ts"
+  }
+}

--- a/src/generators/typescript/TypeScriptDependencyManager.ts
+++ b/src/generators/typescript/TypeScriptDependencyManager.ts
@@ -1,6 +1,10 @@
 import { AbstractDependencyManager } from '../AbstractDependencyManager';
 import { renderJavaScriptDependency } from '../../helpers';
-import { ConstrainedMetaModel } from '../../models';
+import {
+  ConstrainedMetaModel,
+  ConstrainedObjectModel,
+  ConstrainedReferenceModel
+} from '../../models';
 import {
   TypeScriptExportType,
   TypeScriptModelType,
@@ -55,12 +59,16 @@ export class TypeScriptDependencyManager extends AbstractDependencyManager {
     exportType: TypeScriptExportType,
     modelType: TypeScriptModelType
   ): string {
+    const isInterface =
+      model instanceof ConstrainedObjectModel ||
+      (model instanceof ConstrainedReferenceModel &&
+        model.ref instanceof ConstrainedObjectModel);
     const dependencyObject =
       exportType === 'named' ? `{${model.name}}` : model.name;
     return this.renderDependency(
       dependencyObject,
       `./${model.name}`,
-      modelType
+      isInterface ? modelType : 'class'
     );
   }
 
@@ -85,7 +93,9 @@ export class TypeScriptDependencyManager extends AbstractDependencyManager {
         ? `export default ${model.name};\n`
         : `export type { ${model.name} };`;
     const esmExport =
-      modelType === 'interface' ? esmExportType : esmExportValue;
+      modelType === 'interface' && model instanceof ConstrainedObjectModel
+        ? esmExportType
+        : esmExportValue;
     return this.options.moduleSystem === 'CJS' ? cjsExport : esmExport;
   }
 }

--- a/src/generators/typescript/TypeScriptGenerator.ts
+++ b/src/generators/typescript/TypeScriptGenerator.ts
@@ -39,13 +39,14 @@ import { TypeScriptDependencyManager } from './TypeScriptDependencyManager';
 
 export type TypeScriptModuleSystemType = 'ESM' | 'CJS';
 export type TypeScriptExportType = 'named' | 'default';
+export type TypeScriptModelType = 'class' | 'interface';
 export interface TypeScriptOptions
   extends CommonGeneratorOptions<
     TypeScriptPreset,
     TypeScriptDependencyManager
   > {
   renderTypes: boolean;
-  modelType: 'class' | 'interface';
+  modelType: TypeScriptModelType;
   enumType: 'enum' | 'union';
   mapType: 'indexedObject' | 'map' | 'record';
   typeMapping: TypeMapping<TypeScriptOptions, TypeScriptDependencyManager>;
@@ -210,12 +211,14 @@ export class TypeScriptGenerator extends AbstractGenerator<
     const modelDependencyImports = modelDependencies.map((model) => {
       return dependencyManagerToUse.renderCompleteModelDependencies(
         model,
-        completeModelOptionsToUse.exportType
+        completeModelOptionsToUse.exportType,
+        optionsToUse.modelType
       );
     });
     const modelExport = dependencyManagerToUse.renderExport(
       args.constrainedModel,
-      completeModelOptionsToUse.exportType
+      completeModelOptionsToUse.exportType,
+      optionsToUse.modelType
     );
 
     const modelCode = `${outputModel.result}\n${modelExport}`;

--- a/src/helpers/DependencyHelpers.ts
+++ b/src/helpers/DependencyHelpers.ts
@@ -10,11 +10,18 @@ import { ConstrainedMetaModel } from '../models';
 export function renderJavaScriptDependency(
   toImport: string,
   fromModule: string,
-  moduleSystem: 'CJS' | 'ESM'
+  moduleSystem: 'CJS' | 'ESM',
+  importType: 'type' | 'value' = 'value'
 ): string {
-  return moduleSystem === 'CJS'
-    ? `const ${toImport} = require('${fromModule}');`
-    : `import ${toImport} from '${fromModule}';`;
+  const importValueStatement =
+    moduleSystem === 'CJS'
+      ? `const ${toImport} = require('${fromModule}');`
+      : `import ${toImport} from '${fromModule}';`;
+  const importTypeStatement =
+    moduleSystem === 'CJS'
+      ? `const ${toImport} = require('${fromModule}');`
+      : `import type ${toImport} from '${fromModule}';`;
+  return importType === 'type' ? importTypeStatement : importValueStatement;
 }
 
 /**

--- a/test/generators/typescript/TypeScriptGenerator.spec.ts
+++ b/test/generators/typescript/TypeScriptGenerator.spec.ts
@@ -381,6 +381,19 @@ ${content}`;
     expect(models[1].result).toMatchSnapshot();
   });
 
+  test('should render models and their dependencies for ESM module system with named exports as interfaces', async () => {
+    generator = new TypeScriptGenerator({
+      moduleSystem: 'ESM',
+      modelType: 'interface'
+    });
+    const models = await generator.generateCompleteModels(doc, {
+      exportType: 'named'
+    });
+    expect(models).toHaveLength(2);
+    expect(models[0].result).toMatchSnapshot();
+    expect(models[1].result).toMatchSnapshot();
+  });
+
   describe('AsyncAPI with polymorphism', () => {
     const asyncapiDoc = {
       asyncapi: '2.4.0',

--- a/test/generators/typescript/TypeScriptGenerator.spec.ts
+++ b/test/generators/typescript/TypeScriptGenerator.spec.ts
@@ -382,6 +382,44 @@ ${content}`;
   });
 
   test('should render models and their dependencies for ESM module system with named exports as interfaces', async () => {
+    const doc = {
+      $id: 'Address',
+      type: 'object',
+      properties: {
+        street_name: { type: 'string' },
+        city: { type: 'string', description: 'City description' },
+        state: { type: 'string' },
+        house_number: { type: 'number' },
+        house_type: {
+          type: 'string',
+          title: 'HouseType',
+          enum: ['apartment', 'house', 'condo']
+        },
+        marriage: {
+          type: 'boolean',
+          description: 'Status if marriage live in given house'
+        },
+        members: {
+          oneOf: [{ type: 'string' }, { type: 'number' }, { type: 'boolean' }]
+        },
+        array_type: {
+          type: 'array',
+          items: [{ type: 'string' }, { type: 'number' }]
+        },
+        other_model: {
+          type: 'object',
+          $id: 'OtherModel',
+          properties: { street_name: { type: 'string' } }
+        }
+      },
+      patternProperties: {
+        '^S(.?*)test&': {
+          type: 'string'
+        }
+      },
+      required: ['street_name', 'city', 'state', 'house_number', 'array_type']
+    };
+
     generator = new TypeScriptGenerator({
       moduleSystem: 'ESM',
       modelType: 'interface'
@@ -389,9 +427,10 @@ ${content}`;
     const models = await generator.generateCompleteModels(doc, {
       exportType: 'named'
     });
-    expect(models).toHaveLength(2);
+    expect(models).toHaveLength(3);
     expect(models[0].result).toMatchSnapshot();
     expect(models[1].result).toMatchSnapshot();
+    expect(models[2].result).toMatchSnapshot();
   });
 
   describe('AsyncAPI with polymorphism', () => {

--- a/test/generators/typescript/__snapshots__/TypeScriptGenerator.spec.ts.snap
+++ b/test/generators/typescript/__snapshots__/TypeScriptGenerator.spec.ts.snap
@@ -949,12 +949,14 @@ export { OtherModel };"
 `;
 
 exports[`TypeScriptGenerator should render models and their dependencies for ESM module system with named exports as interfaces 1`] = `
-"import type {OtherModel} from './OtherModel';
+"import {HouseType} from './HouseType';
+import type {OtherModel} from './OtherModel';
 interface Address {
   streetName: string;
   city: string;
   state: string;
   houseNumber: number;
+  houseType?: HouseType;
   marriage?: boolean;
   members?: string | number | boolean;
   arrayType: (string | number | any)[];
@@ -965,6 +967,16 @@ export type { Address };"
 `;
 
 exports[`TypeScriptGenerator should render models and their dependencies for ESM module system with named exports as interfaces 2`] = `
+"
+enum HouseType {
+  APARTMENT = \\"apartment\\",
+  HOUSE = \\"house\\",
+  CONDO = \\"condo\\",
+}
+export { HouseType };"
+`;
+
+exports[`TypeScriptGenerator should render models and their dependencies for ESM module system with named exports as interfaces 3`] = `
 "
 interface OtherModel {
   streetName?: string;

--- a/test/generators/typescript/__snapshots__/TypeScriptGenerator.spec.ts.snap
+++ b/test/generators/typescript/__snapshots__/TypeScriptGenerator.spec.ts.snap
@@ -948,6 +948,31 @@ class OtherModel {
 export { OtherModel };"
 `;
 
+exports[`TypeScriptGenerator should render models and their dependencies for ESM module system with named exports as interfaces 1`] = `
+"import type {OtherModel} from './OtherModel';
+interface Address {
+  streetName: string;
+  city: string;
+  state: string;
+  houseNumber: number;
+  marriage?: boolean;
+  members?: string | number | boolean;
+  arrayType: (string | number | any)[];
+  otherModel?: OtherModel;
+  additionalProperties?: Map<string, any | string>;
+}
+export type { Address };"
+`;
+
+exports[`TypeScriptGenerator should render models and their dependencies for ESM module system with named exports as interfaces 2`] = `
+"
+interface OtherModel {
+  streetName?: string;
+  additionalProperties?: Map<string, any>;
+}
+export type { OtherModel };"
+`;
+
 exports[`TypeScriptGenerator should render union \`enum\` values 1`] = `
 "enum States {
   NUMBER_2 = 2,


### PR DESCRIPTION
## Description
When using modelType 'interface', exportType 'named' and moduleSystem 'ESM' export and import interfaces as types to support verbatimModuleSyntax.
This should not be a breaking change, interfaces are types even when not using verbatimModuleSyntax, explicitly marking them as types is optional in that case though.

## Related Issue
fixes #1793 

## Checklist
- [x] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [x] Tests have been added or updated to cover the changes.
- [ ] Documentation has been updated to reflect the changes.
- [x] All tests pass successfully locally.(`npm run test`).

## Additional Notes
This PR also includes a change that makes sure only interfaces are imported/exported as types, as the previous version of this PR also exported enums as types.