### PR TITLE
fix: use this. for property setter in c# class renderer

### DIFF
--- a/examples/csharp-change-collection-type/__snapshots__/index.spec.ts.snap
+++ b/examples/csharp-change-collection-type/__snapshots__/index.spec.ts.snap
@@ -9,7 +9,7 @@ Array [
   public IEnumerable<string>? Email 
   {
     get { return email; }
-    set { email = value; }
+    set { this.email = value; }
   }
 }",
 ]

--- a/examples/csharp-generate-equals-and-hashcode/__snapshots__/index.spec.ts.snap
+++ b/examples/csharp-generate-equals-and-hashcode/__snapshots__/index.spec.ts.snap
@@ -9,7 +9,7 @@ Array [
   public string? Email 
   {
     get { return email; }
-    set { email = value; }
+    set { this.email = value; }
   }
 
   public override bool Equals(object obj)

--- a/examples/csharp-generate-json-serializer/__snapshots__/index.spec.ts.snap
+++ b/examples/csharp-generate-json-serializer/__snapshots__/index.spec.ts.snap
@@ -10,7 +10,7 @@ public partial class Root
   public string? Email 
   {
     get { return email; }
-    set { email = value; }
+    set { this.email = value; }
   }
 }
 

--- a/examples/csharp-generate-newtonsoft-serializer/__snapshots__/index.spec.ts.snap
+++ b/examples/csharp-generate-newtonsoft-serializer/__snapshots__/index.spec.ts.snap
@@ -10,7 +10,7 @@ public partial class Root
   public string? Email 
   {
     get { return email; }
-    set { email = value; }
+    set { this.email = value; }
   }
 }
 

--- a/examples/csharp-generate-required-properties/__snapshots__/index.spec.ts.snap
+++ b/examples/csharp-generate-required-properties/__snapshots__/index.spec.ts.snap
@@ -12,25 +12,25 @@ Array [
   public bool RequiredBoolean 
   {
     get { return requiredBoolean; }
-    set { requiredBoolean = value; }
+    set { this.requiredBoolean = value; }
   }
 
   public bool? NotRequiredBoolean 
   {
     get { return notRequiredBoolean; }
-    set { notRequiredBoolean = value; }
+    set { this.notRequiredBoolean = value; }
   }
 
   public string RequiredString 
   {
     get { return requiredString; }
-    set { requiredString = value; }
+    set { this.requiredString = value; }
   }
 
   public string? NotRequiredString 
   {
     get { return notRequiredString; }
-    set { notRequiredString = value; }
+    set { this.notRequiredString = value; }
   }
 }",
 ]

--- a/examples/csharp-use-inheritance/__snapshots__/index.spec.ts.snap
+++ b/examples/csharp-use-inheritance/__snapshots__/index.spec.ts.snap
@@ -9,7 +9,7 @@ Array [
   public string[]? Email 
   {
     get { return email; }
-    set { email = value; }
+    set { this.email = value; }
   }
 }",
 ]

--- a/examples/generate-csharp-models/__snapshots__/index.spec.ts.snap
+++ b/examples/generate-csharp-models/__snapshots__/index.spec.ts.snap
@@ -12,25 +12,25 @@ Array [
   public string? Email 
   {
     get { return email; }
-    set { email = value; }
+    set { this.email = value; }
   }
 
   public System.DateTime? Today 
   {
     get { return today; }
-    set { today = value; }
+    set { this.today = value; }
   }
 
   public System.TimeSpan? Duration 
   {
     get { return duration; }
-    set { duration = value; }
+    set { this.duration = value; }
   }
 
   public System.Guid? UserId 
   {
     get { return userId; }
-    set { userId = value; }
+    set { this.userId = value; }
   }
 }",
 ]

--- a/src/generators/csharp/renderers/ClassRenderer.ts
+++ b/src/generators/csharp/renderers/ClassRenderer.ts
@@ -144,6 +144,6 @@ export const CSHARP_DEFAULT_CLASS_PRESET: CsharpClassPreset<CSharpOptions> = {
     if (options?.autoImplementedProperties) {
       return 'set;';
     }
-    return `set { ${property.propertyName} = value; }`;
+    return `set { this.${property.propertyName} = value; }`;
   }
 };

--- a/test/generators/csharp/__snapshots__/CSharpGenerator.spec.ts.snap
+++ b/test/generators/csharp/__snapshots__/CSharpGenerator.spec.ts.snap
@@ -21,13 +21,13 @@ exports[`CSharpGenerator class renderer should be able to overwrite property pre
   public string? Property 
   {
     get { return property; }
-    set { property = value; }
+    set { this.property = value; }
   }
 
   public Dictionary<string, string>? AdditionalProperties 
   {
     get { return additionalProperties; }
-    set { additionalProperties = value; }
+    set { this.additionalProperties = value; }
   }
 }"
 `;
@@ -48,55 +48,55 @@ exports[`CSharpGenerator should render \`class\` type 1`] = `
   public string StreetName 
   {
     get { return streetName; }
-    set { streetName = value; }
+    set { this.streetName = value; }
   }
 
   public string City 
   {
     get { return city; }
-    set { city = value; }
+    set { this.city = value; }
   }
 
   public string State 
   {
     get { return state; }
-    set { state = value; }
+    set { this.state = value; }
   }
 
   public double HouseNumber 
   {
     get { return houseNumber; }
-    set { houseNumber = value; }
+    set { this.houseNumber = value; }
   }
 
   public bool? Marriage 
   {
     get { return marriage; }
-    set { marriage = value; }
+    set { this.marriage = value; }
   }
 
   public dynamic? Members 
   {
     get { return members; }
-    set { members = value; }
+    set { this.members = value; }
   }
 
   public dynamic[]? TupleType 
   {
     get { return tupleType; }
-    set { tupleType = value; }
+    set { this.tupleType = value; }
   }
 
   public string[] ArrayType 
   {
     get { return arrayType; }
-    set { arrayType = value; }
+    set { this.arrayType = value; }
   }
 
   public Dictionary<string, dynamic>? AdditionalProperties 
   {
     get { return additionalProperties; }
-    set { additionalProperties = value; }
+    set { this.additionalProperties = value; }
   }
 }"
 `;
@@ -218,55 +218,55 @@ exports[`CSharpGenerator should render models and their dependencies 1`] = `
     public string StreetName 
     {
       get { return streetName; }
-      set { streetName = value; }
+      set { this.streetName = value; }
     }
 
     public string City 
     {
       get { return city; }
-      set { city = value; }
+      set { this.city = value; }
     }
 
     public string State 
     {
       get { return state; }
-      set { state = value; }
+      set { this.state = value; }
     }
 
     public double HouseNumber 
     {
       get { return houseNumber; }
-      set { houseNumber = value; }
+      set { this.houseNumber = value; }
     }
 
     public bool? Marriage 
     {
       get { return marriage; }
-      set { marriage = value; }
+      set { this.marriage = value; }
     }
 
     public dynamic? Members 
     {
       get { return members; }
-      set { members = value; }
+      set { this.members = value; }
     }
 
     public dynamic[] ArrayType 
     {
       get { return arrayType; }
-      set { arrayType = value; }
+      set { this.arrayType = value; }
     }
 
     public OtherModel? OtherModel 
     {
       get { return otherModel; }
-      set { otherModel = value; }
+      set { this.otherModel = value; }
     }
 
     public Dictionary<string, dynamic>? AdditionalProperties 
     {
       get { return additionalProperties; }
-      set { additionalProperties = value; }
+      set { this.additionalProperties = value; }
     }
   }
 }"
@@ -285,13 +285,13 @@ exports[`CSharpGenerator should render models and their dependencies 2`] = `
     public string? StreetName 
     {
       get { return streetName; }
-      set { streetName = value; }
+      set { this.streetName = value; }
     }
 
     public Dictionary<string, dynamic>? AdditionalProperties 
     {
       get { return additionalProperties; }
-      set { additionalProperties = value; }
+      set { this.additionalProperties = value; }
     }
   }
 }"
@@ -315,67 +315,67 @@ exports[`CSharpGenerator should render null-forgiving operator if handleNullable
   public string StreetName 
   {
     get { return streetName; }
-    set { streetName = value; }
+    set { this.streetName = value; }
   }
 
   public string City 
   {
     get { return city; }
-    set { city = value; }
+    set { this.city = value; }
   }
 
   public string State 
   {
     get { return state; }
-    set { state = value; }
+    set { this.state = value; }
   }
 
   public double HouseNumber 
   {
     get { return houseNumber; }
-    set { houseNumber = value; }
+    set { this.houseNumber = value; }
   }
 
   public bool? Marriage 
   {
     get { return marriage; }
-    set { marriage = value; }
+    set { this.marriage = value; }
   }
 
   public HouseType HouseType 
   {
     get { return houseType; }
-    set { houseType = value; }
+    set { this.houseType = value; }
   }
 
   public TerraceType? TerraceType 
   {
     get { return terraceType; }
-    set { terraceType = value; }
+    set { this.terraceType = value; }
   }
 
   public dynamic? Members 
   {
     get { return members; }
-    set { members = value; }
+    set { this.members = value; }
   }
 
   public dynamic[]? TupleType 
   {
     get { return tupleType; }
-    set { tupleType = value; }
+    set { this.tupleType = value; }
   }
 
   public string[] ArrayType 
   {
     get { return arrayType; }
-    set { arrayType = value; }
+    set { this.arrayType = value; }
   }
 
   public Dictionary<string, dynamic>? AdditionalProperties 
   {
     get { return additionalProperties; }
-    set { additionalProperties = value; }
+    set { this.additionalProperties = value; }
   }
 }"
 `;

--- a/test/generators/csharp/presets/__snapshots__/CommonPreset.spec.ts.snap
+++ b/test/generators/csharp/presets/__snapshots__/CommonPreset.spec.ts.snap
@@ -11,25 +11,25 @@ exports[`CSHARP_COMMON_PRESET should render Equals support function 1`] = `
   public string StringProp 
   {
     get { return stringProp; }
-    set { stringProp = value; }
+    set { this.stringProp = value; }
   }
 
   public double? NumberProp 
   {
     get { return numberProp; }
-    set { numberProp = value; }
+    set { this.numberProp = value; }
   }
 
   public NestedTest? ObjectProp 
   {
     get { return objectProp; }
-    set { objectProp = value; }
+    set { this.objectProp = value; }
   }
 
   public Dictionary<string, dynamic>? AdditionalProperties 
   {
     get { return additionalProperties; }
-    set { additionalProperties = value; }
+    set { this.additionalProperties = value; }
   }
 
   public override bool Equals(object obj)
@@ -67,13 +67,13 @@ exports[`CSHARP_COMMON_PRESET should render Equals support function 2`] = `
   public string? StringProp 
   {
     get { return stringProp; }
-    set { stringProp = value; }
+    set { this.stringProp = value; }
   }
 
   public Dictionary<string, dynamic>? AdditionalProperties 
   {
     get { return additionalProperties; }
-    set { additionalProperties = value; }
+    set { this.additionalProperties = value; }
   }
 
   public override bool Equals(object obj)
@@ -109,25 +109,25 @@ exports[`CSHARP_COMMON_PRESET should render GetHashCode support function 1`] = `
   public string StringProp 
   {
     get { return stringProp; }
-    set { stringProp = value; }
+    set { this.stringProp = value; }
   }
 
   public double? NumberProp 
   {
     get { return numberProp; }
-    set { numberProp = value; }
+    set { this.numberProp = value; }
   }
 
   public NestedTest? ObjectProp 
   {
     get { return objectProp; }
-    set { objectProp = value; }
+    set { this.objectProp = value; }
   }
 
   public Dictionary<string, dynamic>? AdditionalProperties 
   {
     get { return additionalProperties; }
-    set { additionalProperties = value; }
+    set { this.additionalProperties = value; }
   }
 
   public override int GetHashCode()
@@ -151,13 +151,13 @@ exports[`CSHARP_COMMON_PRESET should render GetHashCode support function 2`] = `
   public string? StringProp 
   {
     get { return stringProp; }
-    set { stringProp = value; }
+    set { this.stringProp = value; }
   }
 
   public Dictionary<string, dynamic>? AdditionalProperties 
   {
     get { return additionalProperties; }
-    set { additionalProperties = value; }
+    set { this.additionalProperties = value; }
   }
 
   public override int GetHashCode()

--- a/test/generators/csharp/presets/__snapshots__/JsonSerializerPreset.spec.ts.snap
+++ b/test/generators/csharp/presets/__snapshots__/JsonSerializerPreset.spec.ts.snap
@@ -13,31 +13,31 @@ public partial class Test
   public string StringProp 
   {
     get { return stringProp; }
-    set { stringProp = value; }
+    set { this.stringProp = value; }
   }
 
   public double? NumberProp 
   {
     get { return numberProp; }
-    set { numberProp = value; }
+    set { this.numberProp = value; }
   }
 
   public EnumTest? EnumProp 
   {
     get { return enumProp; }
-    set { enumProp = value; }
+    set { this.enumProp = value; }
   }
 
   public NestedTest? ObjectProp 
   {
     get { return objectProp; }
-    set { objectProp = value; }
+    set { this.objectProp = value; }
   }
 
   public Dictionary<string, dynamic>? AdditionalProperties 
   {
     get { return additionalProperties; }
-    set { additionalProperties = value; }
+    set { this.additionalProperties = value; }
   }
 }
 
@@ -204,13 +204,13 @@ public partial class NestedTest
   public string? StringProp 
   {
     get { return stringProp; }
-    set { stringProp = value; }
+    set { this.stringProp = value; }
   }
 
   public Dictionary<string, dynamic>? AdditionalProperties 
   {
     get { return additionalProperties; }
-    set { additionalProperties = value; }
+    set { this.additionalProperties = value; }
   }
 }
 

--- a/test/generators/csharp/presets/__snapshots__/NewtonsoftSerializerPreset.spec.ts.snap
+++ b/test/generators/csharp/presets/__snapshots__/NewtonsoftSerializerPreset.spec.ts.snap
@@ -13,31 +13,31 @@ public partial class Test
   public string StringProp 
   {
     get { return stringProp; }
-    set { stringProp = value; }
+    set { this.stringProp = value; }
   }
 
   public double? NumberProp 
   {
     get { return numberProp; }
-    set { numberProp = value; }
+    set { this.numberProp = value; }
   }
 
   public EnumTest? EnumProp 
   {
     get { return enumProp; }
-    set { enumProp = value; }
+    set { this.enumProp = value; }
   }
 
   public NestedTest? ObjectProp 
   {
     get { return objectProp; }
-    set { objectProp = value; }
+    set { this.objectProp = value; }
   }
 
   public Dictionary<string, dynamic>? AdditionalProperties 
   {
     get { return additionalProperties; }
-    set { additionalProperties = value; }
+    set { this.additionalProperties = value; }
   }
 }
 
@@ -160,13 +160,13 @@ public partial class NestedTest
   public string? StringProp 
   {
     get { return stringProp; }
-    set { stringProp = value; }
+    set { this.stringProp = value; }
   }
 
   public Dictionary<string, dynamic>? AdditionalProperties 
   {
     get { return additionalProperties; }
-    set { additionalProperties = value; }
+    set { this.additionalProperties = value; }
   }
 }
 


### PR DESCRIPTION
## Description
The setter for c# class properties should use this.{propertyName} to assign values to avoid an edge case where there is a property named 'value'

## Related Issue
Fixes #1862 

## Checklist
- [x] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [x] Tests have been added or updated to cover the changes.
- [ ] Documentation has been updated to reflect the changes.
- [x] All tests pass successfully locally.(`npm run test`).

## Additional Notes
<!-- Add any additional information or context that might be relevant to reviewers. -->
