### PR TITLE
feat!: use snake case for file names in go

### DIFF
--- a/docs/migrations/version-3-to-4.md
+++ b/docs/migrations/version-3-to-4.md
@@ -209,3 +209,8 @@ class Address:
     return self._street_name
 ```
 
+## Go
+
+### File names
+
+In v4, file names for go will be formatted as `snake_case.go`. This is the "standard" in go: https://github.com/golang/go/issues/36060

--- a/src/generators/go/GoFileGenerator.ts
+++ b/src/generators/go/GoFileGenerator.ts
@@ -2,7 +2,7 @@ import { GoGenerator, GoRenderCompleteModelOptions } from './GoGenerator';
 import { InputMetaModel, OutputModel } from '../../models';
 import * as path from 'path';
 import { AbstractFileGenerator } from '../AbstractFileGenerator';
-import { FileHelpers } from '../../helpers';
+import { FileHelpers, FormatHelpers } from '../../helpers';
 
 export class GoFileGenerator
   extends GoGenerator
@@ -28,10 +28,8 @@ export class GoFileGenerator
       return outputModel.modelName !== '';
     });
     for (const outputModel of generatedModels) {
-      const filePath = path.resolve(
-        outputDirectory,
-        `${outputModel.modelName}.go`
-      );
+      const fileName = FormatHelpers.toSnakeCase(outputModel.modelName);
+      const filePath = path.resolve(outputDirectory, `${fileName}.go`);
       await FileHelpers.writerToFileSystem(
         outputModel.result,
         filePath,

--- a/test/generators/FileGenerators.spec.ts
+++ b/test/generators/FileGenerators.spec.ts
@@ -20,64 +20,53 @@ import * as path from 'path';
 const generatorsToTest = [
   {
     generator: new GoFileGenerator(),
-    generatorOptions: { packageName: 'some_package' },
-    fileExtension: 'go'
+    generatorOptions: { packageName: 'some_package' }
   },
   {
     generator: new DartFileGenerator(),
-    generatorOptions: { packageName: 'SomePackage' },
-    fileExtension: 'dart'
+    generatorOptions: { packageName: 'SomePackage' }
   },
   {
     generator: new JavaFileGenerator(),
-    generatorOptions: { packageName: 'SomePackage' },
-    fileExtension: 'java'
+    generatorOptions: { packageName: 'SomePackage' }
   },
   {
     generator: new JavaScriptFileGenerator(),
-    generatorOptions: {},
-    fileExtension: 'js'
+    generatorOptions: {}
   },
   {
     generator: new TypeScriptFileGenerator(),
-    generatorOptions: {},
-    fileExtension: 'ts'
+    generatorOptions: {}
   },
   {
     generator: new CSharpFileGenerator(),
-    generatorOptions: { namespace: 'SomeNamespace' },
-    fileExtension: 'cs'
+    generatorOptions: { namespace: 'SomeNamespace' }
   },
   {
     generator: new RustFileGenerator(),
-    generatorOptions: { namespace: 'SomeNamespace' },
-    fileExtension: 'rs'
+    generatorOptions: { namespace: 'SomeNamespace' }
   },
   {
     generator: new PythonFileGenerator(),
-    generatorOptions: {},
-    fileExtension: 'py'
+    generatorOptions: {}
   },
   {
     generator: new KotlinFileGenerator(),
-    generatorOptions: { packageName: 'SomePackage' },
-    fileExtension: 'kt'
+    generatorOptions: { packageName: 'SomePackage' }
   },
   {
     generator: new PhpFileGenerator(),
-    generatorOptions: { packageName: 'SomePackage' },
-    fileExtension: 'php'
+    generatorOptions: { packageName: 'SomePackage' }
   },
   {
     generator: new CplusplusFileGenerator(),
-    generatorOptions: { namespace: 'SomeNamespace' },
-    fileExtension: 'hpp'
+    generatorOptions: { namespace: 'SomeNamespace' }
   }
 ];
 
 describe.each(generatorsToTest)(
   'generateToFiles',
-  ({ generator, generatorOptions, fileExtension }) => {
+  ({ generator, generatorOptions }) => {
     afterEach(() => {
       jest.restoreAllMocks();
     });
@@ -106,7 +95,7 @@ describe.each(generatorsToTest)(
         .mockResolvedValue([
           new OutputModel(
             'content',
-            new ConstrainedAnyModel('', undefined, ''),
+            new ConstrainedAnyModel('', undefined, {}, ''),
             'test',
             new InputMetaModel(),
             []
@@ -119,17 +108,9 @@ describe.each(generatorsToTest)(
       expect(generator.generateCompleteModels).toHaveBeenCalledTimes(1);
       expect(FileHelpers.writerToFileSystem).toHaveBeenCalledTimes(1);
     });
-    test('should try and generate models to files', async () => {
+    test.only('should try and generate models to files', async () => {
       const outputDir = './test';
       const expectedOutputDirPath = path.resolve(outputDir);
-      const expectedOutputFilePath = path.resolve(
-        `${outputDir}/test.${fileExtension}`
-      );
-      const expectedWriteToFileParameters = [
-        'content',
-        expectedOutputFilePath,
-        false
-      ];
       jest
         .spyOn(FileHelpers, 'writerToFileSystem')
         .mockResolvedValue(undefined);
@@ -138,8 +119,8 @@ describe.each(generatorsToTest)(
         .mockResolvedValue([
           new OutputModel(
             'content',
-            new ConstrainedAnyModel('', undefined, ''),
-            'test',
+            new ConstrainedAnyModel('', undefined, {}, ''),
+            'TestModel',
             new InputMetaModel(),
             []
           )
@@ -153,8 +134,18 @@ describe.each(generatorsToTest)(
       expect(generator.generateCompleteModels).toHaveBeenCalledTimes(1);
       expect(FileHelpers.writerToFileSystem).toHaveBeenCalledTimes(1);
       expect(
-        (FileHelpers.writerToFileSystem as jest.Mock).mock.calls[0]
-      ).toEqual(expectedWriteToFileParameters);
+        (FileHelpers.writerToFileSystem as jest.Mock).mock.calls.at(0).at(0)
+      ).toEqual('content');
+      const filePath: string = (
+        FileHelpers.writerToFileSystem as jest.Mock
+      ).mock.calls
+        .at(0)
+        .at(1);
+      expect(filePath).toMatch(expectedOutputDirPath);
+      expect(filePath.replace(expectedOutputDirPath, '')).toMatchSnapshot();
+      expect(
+        (FileHelpers.writerToFileSystem as jest.Mock).mock.calls.at(0).at(2)
+      ).toEqual(false);
     });
     test('should ignore models that have not been rendered', async () => {
       const outputDir = './test';
@@ -167,7 +158,7 @@ describe.each(generatorsToTest)(
         .mockResolvedValue([
           new OutputModel(
             '',
-            new ConstrainedAnyModel('', undefined, ''),
+            new ConstrainedAnyModel('', undefined, {}, ''),
             '',
             new InputMetaModel(),
             []

--- a/test/generators/FileGenerators.spec.ts
+++ b/test/generators/FileGenerators.spec.ts
@@ -108,7 +108,7 @@ describe.each(generatorsToTest)(
       expect(generator.generateCompleteModels).toHaveBeenCalledTimes(1);
       expect(FileHelpers.writerToFileSystem).toHaveBeenCalledTimes(1);
     });
-    test.only('should try and generate models to files', async () => {
+    test('should try and generate models to files', async () => {
       const outputDir = './test';
       const expectedOutputDirPath = path.resolve(outputDir);
       jest

--- a/test/generators/__snapshots__/FileGenerators.spec.ts.snap
+++ b/test/generators/__snapshots__/FileGenerators.spec.ts.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`generateToFiles should try and generate models to files 1`] = `"/test_model.go"`;
+
+exports[`generateToFiles should try and generate models to files 2`] = `"/TestModel.dart"`;
+
+exports[`generateToFiles should try and generate models to files 3`] = `"/TestModel.java"`;
+
+exports[`generateToFiles should try and generate models to files 4`] = `"/TestModel.js"`;
+
+exports[`generateToFiles should try and generate models to files 5`] = `"/TestModel.ts"`;
+
+exports[`generateToFiles should try and generate models to files 6`] = `"/TestModel.cs"`;
+
+exports[`generateToFiles should try and generate models to files 7`] = `"/test_model.rs"`;
+
+exports[`generateToFiles should try and generate models to files 8`] = `"/TestModel.py"`;
+
+exports[`generateToFiles should try and generate models to files 9`] = `"/TestModel.kt"`;
+
+exports[`generateToFiles should try and generate models to files 10`] = `"/TestModel.php"`;
+
+exports[`generateToFiles should try and generate models to files 11`] = `"/TestModel.hpp"`;


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes introduced by this pull request. -->

This MR enforces go file names to be in snake_case format. This is considered best practice in golang: https://github.com/golang/go/issues/36060

## Related Issue
<!-- If this pull request is related to any existing issue, mention it here. -->

## Checklist
- [x] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [x] Tests have been added or updated to cover the changes.
- [x] Documentation has been updated to reflect the changes.
- [x] All tests pass successfully locally.(`npm run test`).

## Additional Notes
<!-- Add any additional information or context that might be relevant to reviewers. -->
