### PR TITLE
feat: trigger upload resources on next

### DIFF
--- a/.github/workflows/upload-release-assets.yml
+++ b/.github/workflows/upload-release-assets.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - master
+      - next
 
 jobs:
   upload-assets:


### PR DESCRIPTION
## Description
Currently the CLI binaries are not uploaded on `next`, this fixes that
