### PR TITLE
ci: switch to fail slow for Cli release

### DIFF
--- a/.github/workflows/upload-release-assets.yml
+++ b/.github/workflows/upload-release-assets.yml
@@ -14,6 +14,7 @@ jobs:
     if: startsWith(github.event.commits[0].message, 'chore(release):')
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest


### PR DESCRIPTION
## Description
This PR disables fail fast so even if one packaging fails, the rest continues to work fine.