### PR TITLE
fix: circular schema issue with OpenAPI, JSON Schema, and swagger inputs

### DIFF
--- a/src/processors/OpenAPIInputProcessor.ts
+++ b/src/processors/OpenAPIInputProcessor.ts
@@ -271,6 +271,7 @@ export class OpenAPIInputProcessor extends AbstractInputProcessor {
     const namedSchema = JsonSchemaInputProcessor.reflectSchemaNames(
       schema,
       {},
+      new Set(),
       name,
       true
     );

--- a/src/processors/SwaggerInputProcessor.ts
+++ b/src/processors/SwaggerInputProcessor.ts
@@ -172,6 +172,7 @@ export class SwaggerInputProcessor extends AbstractInputProcessor {
     schema = JsonSchemaInputProcessor.reflectSchemaNames(
       schema,
       {},
+      new Set(),
       name,
       true
     );

--- a/test/processors/JsonSchemaInputProcessor.spec.ts
+++ b/test/processors/JsonSchemaInputProcessor.spec.ts
@@ -385,6 +385,7 @@ describe('JsonSchemaInputProcessor', () => {
       const expected = JsonSchemaInputProcessor.reflectSchemaNames(
         schema,
         {},
+        new Set(),
         'root',
         true
       ) as any;

--- a/test/processors/OpenAPIInputProcessor.spec.ts
+++ b/test/processors/OpenAPIInputProcessor.spec.ts
@@ -8,6 +8,12 @@ const basicDoc = JSON.parse(
     'utf8'
   )
 );
+const circularDoc = JSON.parse(
+  fs.readFileSync(
+    path.resolve(__dirname, './OpenAPIInputProcessor/references_circular.json'),
+    'utf8'
+  )
+);
 jest.mock('../../src/utils/LoggingInterface');
 const processorSpy = jest.spyOn(
   OpenAPIInputProcessor,
@@ -133,6 +139,12 @@ describe('OpenAPIInputProcessor', () => {
         { type: 'string' },
         'test_parameters_header_path_parameter'
       ]);
+    });
+    test('should be able to use $ref when circular', async () => {
+      const processor = new OpenAPIInputProcessor();
+      const commonInputModel = await processor.process(circularDoc);
+      expect(commonInputModel).toMatchSnapshot();
+      expect(processorSpy.mock.calls).toMatchSnapshot();
     });
   });
 });

--- a/test/processors/OpenAPIInputProcessor/references_circular.json
+++ b/test/processors/OpenAPIInputProcessor/references_circular.json
@@ -1,0 +1,54 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "circular api"
+  },
+  "paths": {
+    "/test": {
+      "get": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/ApiResponse"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/ApiResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "ApiResponse": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "type": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "loop": {
+          "$ref": "#/components/ApiResponse"
+        }
+      }
+    }
+  }
+}

--- a/test/processors/SwaggerInputProcessor.spec.ts
+++ b/test/processors/SwaggerInputProcessor.spec.ts
@@ -9,6 +9,12 @@ const basicDoc = JSON.parse(
     'utf8'
   )
 );
+const circularDoc = JSON.parse(
+  fs.readFileSync(
+    path.resolve(__dirname, './SwaggerInputProcessor/references_circular.json'),
+    'utf8'
+  )
+);
 jest.mock('../../src/utils/LoggingInterface');
 jest.spyOn(SwaggerInputProcessor, 'convertToInternalSchema');
 const mockedReturnModels = [new CommonModel()];
@@ -27,6 +33,9 @@ jest.mock('../../src/interpreter/Interpreter', () => {
 });
 
 describe('SwaggerInputProcessor', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
   afterAll(() => {
     jest.restoreAllMocks();
   });
@@ -70,6 +79,21 @@ describe('SwaggerInputProcessor', () => {
         });
       const processor = new SwaggerInputProcessor();
       const commonInputModel = await processor.process(basicDoc);
+      expect(commonInputModel).toMatchSnapshot();
+      expect(
+        (
+          SwaggerInputProcessor.convertToInternalSchema as any as jest.SpyInstance
+        ).mock.calls
+      ).toMatchSnapshot();
+    });
+    test('should be able to use $ref when circular', async () => {
+      JsonSchemaInputProcessor.convertSchemaToMetaModel = jest
+        .fn()
+        .mockImplementation(() => {
+          return mockedMetaModel;
+        });
+      const processor = new SwaggerInputProcessor();
+      const commonInputModel = await processor.process(circularDoc);
       expect(commonInputModel).toMatchSnapshot();
       expect(
         (

--- a/test/processors/SwaggerInputProcessor/references_circular.json
+++ b/test/processors/SwaggerInputProcessor/references_circular.json
@@ -1,0 +1,40 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "circular api"
+  },
+  "paths": {
+    "/test": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "$ref": "#/definitions/ApiResponse"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "ApiResponse": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "type": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "loop": {
+          "$ref": "#/definitions/ApiResponse"
+        }
+      }
+    }
+  }
+}

--- a/test/processors/__snapshots__/OpenAPIInputProcessor.spec.ts.snap
+++ b/test/processors/__snapshots__/OpenAPIInputProcessor.spec.ts.snap
@@ -1,5 +1,138 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`OpenAPIInputProcessor process() should be able to use $ref when circular 1`] = `
+InputMetaModel {
+  "models": Object {
+    "": AnyModel {
+      "name": "",
+      "options": undefined,
+      "originalInput": undefined,
+    },
+  },
+  "originalInput": Object {
+    "components": Object {
+      "ApiResponse": Object {
+        "properties": Object {
+          "code": Object {
+            "format": "int32",
+            "type": "integer",
+          },
+          "loop": [Circular],
+          "message": Object {
+            "type": "string",
+          },
+          "type": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+    },
+    "info": Object {
+      "title": "circular api",
+    },
+    "openapi": "3.0.3",
+    "paths": Object {
+      "/test": Object {
+        "get": Object {
+          "requestBody": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "properties": Object {
+                    "code": Object {
+                      "format": "int32",
+                      "type": "integer",
+                    },
+                    "loop": [Circular],
+                    "message": Object {
+                      "type": "string",
+                    },
+                    "type": Object {
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "required": true,
+          },
+          "responses": Object {
+            "200": Object {
+              "content": Object {
+                "application/json": Object {
+                  "schema": Object {
+                    "properties": Object {
+                      "code": Object {
+                        "format": "int32",
+                        "type": "integer",
+                      },
+                      "loop": [Circular],
+                      "message": Object {
+                        "type": "string",
+                      },
+                      "type": Object {
+                        "type": "string",
+                      },
+                    },
+                    "type": "object",
+                  },
+                },
+              },
+              "description": "Successful operation",
+            },
+          },
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`OpenAPIInputProcessor process() should be able to use $ref when circular 2`] = `
+Array [
+  Array [
+    Object {
+      "properties": Object {
+        "code": Object {
+          "format": "int32",
+          "type": "integer",
+        },
+        "loop": [Circular],
+        "message": Object {
+          "type": "string",
+        },
+        "type": Object {
+          "type": "string",
+        },
+      },
+      "type": "object",
+    },
+    "test_get_200_application_json",
+  ],
+  Array [
+    Object {
+      "properties": Object {
+        "code": Object {
+          "format": "int32",
+          "type": "integer",
+        },
+        "loop": [Circular],
+        "message": Object {
+          "type": "string",
+        },
+        "type": Object {
+          "type": "string",
+        },
+      },
+      "type": "object",
+    },
+    "test_get_application_json",
+  ],
+]
+`;
+
 exports[`OpenAPIInputProcessor process() should process the OpenAPI document accurately 1`] = `
 InputMetaModel {
   "models": Object {

--- a/test/processors/__snapshots__/SwaggerInputProcessor.spec.ts.snap
+++ b/test/processors/__snapshots__/SwaggerInputProcessor.spec.ts.snap
@@ -1,5 +1,92 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`SwaggerInputProcessor process() should be able to use $ref when circular 1`] = `
+InputMetaModel {
+  "models": Object {
+    "": AnyModel {
+      "name": "",
+      "options": Object {},
+      "originalInput": undefined,
+    },
+  },
+  "originalInput": Object {
+    "definitions": Object {
+      "ApiResponse": Object {
+        "properties": Object {
+          "code": Object {
+            "format": "int32",
+            "type": "integer",
+          },
+          "loop": [Circular],
+          "message": Object {
+            "type": "string",
+          },
+          "type": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+    },
+    "info": Object {
+      "title": "circular api",
+    },
+    "paths": Object {
+      "/test": Object {
+        "get": Object {
+          "responses": Object {
+            "200": Object {
+              "description": "successful operation",
+              "schema": Object {
+                "properties": Object {
+                  "code": Object {
+                    "format": "int32",
+                    "type": "integer",
+                  },
+                  "loop": [Circular],
+                  "message": Object {
+                    "type": "string",
+                  },
+                  "type": Object {
+                    "type": "string",
+                  },
+                },
+                "type": "object",
+              },
+            },
+          },
+        },
+      },
+    },
+    "swagger": "2.0",
+  },
+}
+`;
+
+exports[`SwaggerInputProcessor process() should be able to use $ref when circular 2`] = `
+Array [
+  Array [
+    Object {
+      "properties": Object {
+        "code": Object {
+          "format": "int32",
+          "type": "integer",
+        },
+        "loop": [Circular],
+        "message": Object {
+          "type": "string",
+        },
+        "type": Object {
+          "type": "string",
+        },
+      },
+      "type": "object",
+    },
+    "test_get_200",
+  ],
+]
+`;
+
 exports[`SwaggerInputProcessor process() should process the swagger document accurately 1`] = `
 InputMetaModel {
   "models": Object {


### PR DESCRIPTION
## Description

Generating models for OpenAPI 3 and Swagger documents fail due to infinite recursion in `JsonSchemaInpoutProcessor:reflectSchmaNames(...)` if the schema uses `$ref` that result in cycles in the schema.

Example failure message:

```text
Generating models from: /openapi.yaml
.../node_modules/@asyncapi/modelina/lib/cjs/processors/JsonSchemaInputProcessor.js:197
    static reflectSchemaNames(schema, namesStack, name, isRoot) {

RangeError: Maximum call stack size exceeded
    at JsonSchemaInputProcessor.reflectSchemaNames (.../node_modules/@asyncapi/modelina/lib/cjs/processors/JsonSchemaInputProcessor.js:197:30)
    at JsonSchemaInputProcessor.reflectSchemaNames (.../node_modules/@asyncapi/modelina/lib/cjs/processors/JsonSchemaInputProcessor.js:245:37)
    at JsonSchemaInputProcessor.reflectSchemaNames (.../node_modules/@asyncapi/modelina/lib/cjs/processors/JsonSchemaInputProcessor.js:251:57)
    at JsonSchemaInputProcessor.reflectSchemaNames (.../node_modules/@asyncapi/modelina/lib/cjs/processors/JsonSchemaInputProcessor.js:251:57)
    at JsonSchemaInputProcessor.reflectSchemaNames (.../node_modules/@asyncapi/modelina/lib/cjs/processors/JsonSchemaInputProcessor.js:245:37)
    at JsonSchemaInputProcessor.reflectSchemaNames (.../node_modules/@asyncapi/modelina/lib/cjs/processors/JsonSchemaInputProcessor.js:251:57)
    at JsonSchemaInputProcessor.reflectSchemaNames (.../node_modules/@asyncapi/modelina/lib/cjs/processors/JsonSchemaInputProcessor.js:251:57)
    at JsonSchemaInputProcessor.reflectSchemaNames (.../node_modules/@asyncapi/modelina/lib/cjs/processors/JsonSchemaInputProcessor.js:245:37)
    at JsonSchemaInputProcessor.reflectSchemaNames (.../node_modules/@asyncapi/modelina/lib/cjs/processors/JsonSchemaInputProcessor.js:251:57)
    at JsonSchemaInputProcessor.reflectSchemaNames (.../node_modules/@asyncapi/modelina/lib/cjs/processors/JsonSchemaInputProcessor.js:251:57)

```

Example failing schema:
* test/processors/OpenAPIInputProcessor/references_circular.json
* test/processors/SwaggerInputProcessor/references_circular.json

## Related Issue
none

## Checklist
- [x] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [x] Tests have been added or updated to cover the changes.
- [x] Documentation has been updated to reflect the changes.
- [x] All tests pass successfully locally.(`npm run test`).

## Additional Notes
Non-breaking fix as the working functionally was masked by the crash 
