### PR TITLE
fix!: python models not handling circular model dependencies

### DIFF
--- a/docs/languages/Python.md
+++ b/docs/languages/Python.md
@@ -2,6 +2,8 @@
 
 There are special use-cases that each language supports; this document pertains to **Python models**.
 
+The generated Python models require at least v[3.7](https://docs.python.org/release/3.7.0/).
+
 <!-- toc is generated with GitHub Actions do not remove toc markers -->
 
 <!-- toc -->

--- a/docs/migrations/version-3-to-4.md
+++ b/docs/migrations/version-3-to-4.md
@@ -93,6 +93,8 @@ Console.WriteLine(dateTime2);
 
 ## Python
 
+Models are aiming to be >= v3.7 compliant.
+
 ### Pydantic now follows v2 instead of v1
 
 Reference: https://docs.pydantic.dev/2.6/migration/
@@ -104,7 +106,7 @@ class Message(BaseModel):
   identifier: str = Field(description='''The Identifier for the Message''')
 ```
 
-In Modelina 3 this used is rendered as:
+In Modelina v3 this used is rendered as:
 
 ```python
 class Message(BaseModel):
@@ -208,6 +210,10 @@ class Address:
   def street_name(self) -> str:
     return self._street_name
 ```
+
+### Import style deprecation
+
+All models are from this point onwards imported using explicit styles `from . import ${model.name}` to allow for circular model dependencies to work. This means that the option `importsStyle` is deprecated and is no longer in use. It will be removed at some point in the future. 
 
 ## Go
 

--- a/examples/generate-python-complete-models/__snapshots__/index.spec.ts.snap
+++ b/examples/generate-python-complete-models/__snapshots__/index.spec.ts.snap
@@ -2,8 +2,9 @@
 
 exports[`Should be able to render python models and should generate \`implicit\` or \`explicit\` imports for models implementing referenced types: nested-model 1`] = `
 Array [
-  "
+  "from __future__ import annotations
 from typing import Any, Dict
+
 class ObjProperty: 
   def __init__(self, input: Dict):
     if 'number' in input:
@@ -30,8 +31,9 @@ class ObjProperty:
 
 exports[`Should be able to render python models and should generate \`implicit\` or \`explicit\` imports for models implementing referenced types: nested-model 2`] = `
 Array [
-  "
+  "from __future__ import annotations
 from typing import Any, Dict
+
 class ObjProperty: 
   def __init__(self, input: Dict):
     if 'number' in input:
@@ -58,14 +60,15 @@ class ObjProperty:
 
 exports[`Should be able to render python models and should generate \`implicit\` or \`explicit\` imports for models implementing referenced types: root-model-explicit-import 1`] = `
 Array [
-  "from ObjProperty import ObjProperty
+  "from __future__ import annotations
 from typing import Any, Dict
+from . import ObjProperty
 class Root: 
   def __init__(self, input: Dict):
     if 'email' in input:
       self._email: str = input['email']
     if 'obj_property' in input:
-      self._obj_property: ObjProperty = ObjProperty(input['obj_property'])
+      self._obj_property: ObjProperty.ObjProperty = ObjProperty.ObjProperty(input['obj_property'])
 
   @property
   def email(self) -> str:
@@ -75,10 +78,10 @@ class Root:
     self._email = email
 
   @property
-  def obj_property(self) -> ObjProperty:
+  def obj_property(self) -> ObjProperty.ObjProperty:
     return self._obj_property
   @obj_property.setter
-  def obj_property(self, obj_property: ObjProperty):
+  def obj_property(self, obj_property: ObjProperty.ObjProperty):
     self._obj_property = obj_property
 ",
 ]
@@ -86,14 +89,15 @@ class Root:
 
 exports[`Should be able to render python models and should generate \`implicit\` or \`explicit\` imports for models implementing referenced types: root-model-implicit-import 1`] = `
 Array [
-  "from ObjProperty import ObjProperty
+  "from __future__ import annotations
 from typing import Any, Dict
+from . import ObjProperty
 class Root: 
   def __init__(self, input: Dict):
     if 'email' in input:
       self._email: str = input['email']
     if 'obj_property' in input:
-      self._obj_property: ObjProperty = ObjProperty(input['obj_property'])
+      self._obj_property: ObjProperty.ObjProperty = ObjProperty.ObjProperty(input['obj_property'])
 
   @property
   def email(self) -> str:
@@ -103,10 +107,10 @@ class Root:
     self._email = email
 
   @property
-  def obj_property(self) -> ObjProperty:
+  def obj_property(self) -> ObjProperty.ObjProperty:
     return self._obj_property
   @obj_property.setter
-  def obj_property(self, obj_property: ObjProperty):
+  def obj_property(self, obj_property: ObjProperty.ObjProperty):
     self._obj_property = obj_property
 ",
 ]

--- a/examples/generate-python-pydantic-models/__snapshots__/index.spec.ts.snap
+++ b/examples/generate-python-pydantic-models/__snapshots__/index.spec.ts.snap
@@ -6,7 +6,7 @@ Array [
   optional_field: Optional[str] = Field(description='''this field is optional''', default=None, serialization_alias='optionalField')
   required_field: str = Field(description='''this field is required''', serialization_alias='requiredField')
   no_description: Optional[str] = Field(default=None, serialization_alias='noDescription')
-  options: Optional[Options] = Field(default=None, serialization_alias='options')
+  options: Optional[Options.Options] = Field(default=None, serialization_alias='options')
 ",
 ]
 `;

--- a/src/generators/python/PythonConstrainer.ts
+++ b/src/generators/python/PythonConstrainer.ts
@@ -14,7 +14,7 @@ export const PythonDefaultTypeMapping: PythonTypeMapping = {
     return constrainedModel.name;
   },
   Reference({ constrainedModel }): string {
-    return constrainedModel.name;
+    return `${constrainedModel.name}.${constrainedModel.name}`;
   },
   Any({ dependencyManager }): string {
     dependencyManager.addDependency('from typing import Any');

--- a/src/generators/python/PythonDependencyManager.ts
+++ b/src/generators/python/PythonDependencyManager.ts
@@ -15,9 +15,8 @@ export class PythonDependencyManager extends AbstractDependencyManager {
    */
   renderDependency(model: ConstrainedMetaModel): string {
     const useExplicitImports = this.options.importsStyle === 'explicit';
-    return `from ${useExplicitImports ? '.' : ''}${model.name} import ${
-      model.name
-    }`;
+    //return `import ${model.name} as ${model.name}`;
+    return `from . import ${model.name}`;
   }
 
   /**

--- a/src/generators/python/PythonDependencyManager.ts
+++ b/src/generators/python/PythonDependencyManager.ts
@@ -14,8 +14,6 @@ export class PythonDependencyManager extends AbstractDependencyManager {
    * Simple helper function to render a dependency based on the module system that the user defines.
    */
   renderDependency(model: ConstrainedMetaModel): string {
-    const useExplicitImports = this.options.importsStyle === 'explicit';
-    //return `import ${model.name} as ${model.name}`;
     return `from . import ${model.name}`;
   }
 
@@ -25,14 +23,24 @@ export class PythonDependencyManager extends AbstractDependencyManager {
    * For example `from typing import Dict` and `from typing import Any` would form a single import `from typing import Dict, Any`
    */
   renderDependencies(): string[] {
+    let dependenciesToRender = this.dependencies;
+    dependenciesToRender =
+      this.mergeIndividualDependencies(dependenciesToRender);
+    dependenciesToRender = this.moveFutureDependency(dependenciesToRender);
+    return dependenciesToRender;
+  }
+
+  /**
+   * Split up each dependency that matches `from x import y` and keep everything else as is.
+   *
+   * Merge all `y` together and make sure they are unique and render the dependency as `from x import y1, y2, y3`
+   */
+  private mergeIndividualDependencies(
+    individualDependencies: string[]
+  ): string[] {
     const importMap: Record<string, string[]> = {};
     const dependenciesToRender = [];
-    /**
-     * Split up each dependency that matches `from x import y` and keep everything else as is.
-     *
-     * Merge all `y` together and make sure they are unique and render the dependency as `from x import y1, y2, y3`
-     */
-    for (const dependency of this.dependencies) {
+    for (const dependency of individualDependencies) {
       const regex = /from ([A-Za-z0-9]+) import ([A-Za-z0-9,\s]+)/g;
       const matches = regex.exec(dependency);
 
@@ -56,5 +64,20 @@ export class PythonDependencyManager extends AbstractDependencyManager {
       );
     }
     return dependenciesToRender;
+  }
+
+  /**
+   * If you import `from __future__ import x` it always has to be rendered first
+   */
+  private moveFutureDependency(individualDependencies: string[]): string[] {
+    const futureDependencyIndex = individualDependencies.findIndex((element) =>
+      element.includes('__future__')
+    );
+    if (futureDependencyIndex !== -1) {
+      individualDependencies.unshift(
+        individualDependencies.splice(futureDependencyIndex, 1)[0]
+      );
+    }
+    return individualDependencies;
   }
 }

--- a/src/generators/python/PythonGenerator.ts
+++ b/src/generators/python/PythonGenerator.ts
@@ -40,6 +40,10 @@ export interface PythonOptions
   typeMapping: TypeMapping<PythonOptions, PythonDependencyManager>;
   constraints: Constraints<PythonOptions>;
   importsStyle: 'explicit' | 'implicit';
+  /**
+   * In order to handle circular model dependencies, we have to use a specific import style
+   */
+  pathToModels: string;
 }
 export type PythonConstantConstraint = ConstantConstraint<PythonOptions>;
 export type PythonEnumKeyConstraint = EnumKeyConstraint<PythonOptions>;
@@ -63,6 +67,7 @@ export class PythonGenerator extends AbstractGenerator<
     typeMapping: PythonDefaultTypeMapping,
     constraints: PythonDefaultConstraints,
     importsStyle: 'implicit',
+    pathToModels: '.',
     // Temporarily set
     dependencyManager: () => {
       return {} as PythonDependencyManager;

--- a/src/generators/python/PythonGenerator.ts
+++ b/src/generators/python/PythonGenerator.ts
@@ -43,10 +43,6 @@ export interface PythonOptions
    * @deprecated no longer in use - we had to switch to using explicit import style, always to support circular model dependencies.
    */
   importsStyle: 'explicit' | 'implicit';
-  /**
-   * In order to handle circular model dependencies, we have to use a specific import style
-   */
-  pathToModels: string;
 }
 export type PythonConstantConstraint = ConstantConstraint<PythonOptions>;
 export type PythonEnumKeyConstraint = EnumKeyConstraint<PythonOptions>;
@@ -70,7 +66,6 @@ export class PythonGenerator extends AbstractGenerator<
     typeMapping: PythonDefaultTypeMapping,
     constraints: PythonDefaultConstraints,
     importsStyle: 'explicit',
-    pathToModels: '.',
     // Temporarily set
     dependencyManager: () => {
       return {} as PythonDependencyManager;

--- a/src/generators/python/PythonGenerator.ts
+++ b/src/generators/python/PythonGenerator.ts
@@ -39,6 +39,9 @@ export interface PythonOptions
   extends CommonGeneratorOptions<PythonPreset, PythonDependencyManager> {
   typeMapping: TypeMapping<PythonOptions, PythonDependencyManager>;
   constraints: Constraints<PythonOptions>;
+  /**
+   * @deprecated no longer in use - we had to switch to using explicit import style, always to support circular model dependencies.
+   */
   importsStyle: 'explicit' | 'implicit';
   /**
    * In order to handle circular model dependencies, we have to use a specific import style
@@ -66,7 +69,7 @@ export class PythonGenerator extends AbstractGenerator<
     defaultPreset: PYTHON_DEFAULT_PRESET,
     typeMapping: PythonDefaultTypeMapping,
     constraints: PythonDefaultConstraints,
-    importsStyle: 'implicit',
+    importsStyle: 'explicit',
     pathToModels: '.',
     // Temporarily set
     dependencyManager: () => {

--- a/src/generators/python/PythonGenerator.ts
+++ b/src/generators/python/PythonGenerator.ts
@@ -211,8 +211,8 @@ export class PythonGenerator extends AbstractGenerator<
       .map((model) => {
         return dependencyManagerToUse.renderDependency(model);
       });
-    const outputContent = `${modelDependencies.join('\n')}
-${outputModel.dependencies.join('\n')}
+    const outputContent = `${outputModel.dependencies.join('\n')}
+${modelDependencies.join('\n')}
 ${outputModel.result}`;
     return RenderOutput.toRenderOutput({
       result: outputContent,

--- a/src/generators/python/presets/Pydantic.ts
+++ b/src/generators/python/presets/Pydantic.ts
@@ -21,30 +21,34 @@ const PYTHON_PYDANTIC_CLASS_PRESET: ClassPresetType<PythonOptions> = {
       `class ${model.name}(BaseModel):`
     );
   },
-  property(params) {
-    let type = params.property.property.type;
-    const propertyName = params.property.propertyName;
+  property({ property, model, renderer }) {
+    let type = property.property.type;
+    const propertyName = property.propertyName;
 
-    if (params.property.property instanceof ConstrainedUnionModel) {
-      const unionTypes = params.property.property.union.map(
+    if (property.property instanceof ConstrainedUnionModel) {
+      const unionTypes = property.property.union.map(
         (unionModel) => unionModel.type
       );
       type = `Union[${unionTypes.join(', ')}]`;
     }
 
-    if (!params.property.required) {
+    if (!property.required) {
       type = `Optional[${type}]`;
     }
+    type = renderer.renderPropertyType({
+      modelType: model.type,
+      propertyType: type
+    });
 
-    const description = params.property.property.originalInput['description']
-      ? `description='''${params.property.property.originalInput['description']}'''`
+    const description = property.property.originalInput['description']
+      ? `description='''${property.property.originalInput['description']}'''`
       : undefined;
-    const defaultValue = params.property.required ? undefined : 'default=None';
-    const jsonAlias = `serialization_alias='${params.property.unconstrainedPropertyName}'`;
+    const defaultValue = property.required ? undefined : 'default=None';
+    const jsonAlias = `serialization_alias='${property.unconstrainedPropertyName}'`;
     let exclude = undefined;
     if (
-      params.property.property instanceof ConstrainedDictionaryModel &&
-      params.property.property.serializationType === 'unwrap'
+      property.property instanceof ConstrainedDictionaryModel &&
+      property.property.serializationType === 'unwrap'
     ) {
       exclude = 'exclude=True';
     }

--- a/src/generators/python/renderers/ClassRenderer.ts
+++ b/src/generators/python/renderers/ClassRenderer.ts
@@ -103,7 +103,10 @@ ${this.indent(this.renderBlock(content, 2))}
       property instanceof ConstrainedReferenceModel && property.ref === model;
     if (isSelfReference) {
       // Use forward references for getters and setters
-      return propertyType.replace(property.ref.type, `'${property.ref.type}'`);
+      return propertyType.replace(
+        `${property.ref.type}`,
+        `'${property.ref.type}'`
+      );
     } else if (property instanceof ConstrainedArrayModel) {
       return this.returnPropertyType({
         model,
@@ -154,12 +157,18 @@ export const PYTHON_DEFAULT_CLASS_PRESET: ClassPresetType<PythonOptions> = {
     let body = '';
     if (Object.keys(properties).length > 0) {
       const assignments = Object.values(properties).map((property) => {
-        const propertyType = property.property.type;
+        let propertyType = property.property.type;
+        const isSelfReference =
+          property.property instanceof ConstrainedReferenceModel &&
+          property.property.ref === model;
         if (property.property.options.const) {
           return `self._${property.propertyName}: ${propertyType} = ${property.property.options.const.value}`;
         }
         let assignment: string;
         if (property.property instanceof ConstrainedReferenceModel) {
+          if (!isSelfReference) {
+            propertyType = `${propertyType}.${propertyType}`;
+          }
           assignment = `self._${property.propertyName}: ${propertyType} = ${propertyType}(input['${property.propertyName}'])`;
         } else {
           assignment = `self._${property.propertyName}: ${propertyType} = input['${property.propertyName}']`;

--- a/src/helpers/CommonModelToMetaModel.ts
+++ b/src/helpers/CommonModelToMetaModel.ts
@@ -516,11 +516,7 @@ export function convertToDictionaryModel(
   }
   const originalInput =
     getOriginalInputFromAdditionalAndPatterns(jsonSchemaModel);
-  const keyModel = new StringModel(
-    name,
-    originalInput,
-    getMetaModelOptions(jsonSchemaModel, options)
-  );
+  const keyModel = new StringModel(name, originalInput, {});
   const valueModel = convertAdditionalAndPatterns(context);
   return new DictionaryModel(
     name,

--- a/test/generators/python/PythonConstrainer.spec.ts
+++ b/test/generators/python/PythonConstrainer.spec.ts
@@ -34,7 +34,7 @@ describe('PythonConstrainer', () => {
     });
   });
   describe('Reference', () => {
-    test('should render the constrained name as type', () => {
+    test('should render the constrained name as type with import', () => {
       const refModel = new ConstrainedAnyModel('test', undefined, {}, '');
       const model = new ConstrainedReferenceModel(
         'test',
@@ -47,7 +47,7 @@ describe('PythonConstrainer', () => {
         constrainedModel: model,
         ...defaultOptions
       });
-      expect(type).toEqual(model.name);
+      expect(type).toEqual(`${model.name}.${model.name}`);
     });
   });
   describe('Any', () => {

--- a/test/generators/python/PythonDependencyManager.spec.ts
+++ b/test/generators/python/PythonDependencyManager.spec.ts
@@ -15,7 +15,17 @@ describe('PythonDependencyManager', () => {
         ['from x import y', 'from x import y2']
       );
       expect(dependencyManager.renderDependencies()).toEqual([
-        `from x import y, y2`
+        'from x import y, y2'
+      ]);
+    });
+    test('should render __future__ dependency first', () => {
+      const dependencyManager = new PythonDependencyManager(
+        PythonGenerator.defaultOptions,
+        ['from x import y', 'from __future__ import y']
+      );
+      expect(dependencyManager.renderDependencies()).toEqual([
+        'from __future__ import y',
+        'from x import y'
       ]);
     });
   });

--- a/test/generators/python/PythonGenerator.spec.ts
+++ b/test/generators/python/PythonGenerator.spec.ts
@@ -90,7 +90,7 @@ describe('PythonGenerator', () => {
           array_model: { type: 'array', items: { $ref: '#' } },
           tuple_model: {
             type: 'array',
-            items: [{ $ref: '#' }],
+            items: [{ $ref: '#' }, { type: 'string' }],
             additionalItems: false
           },
           map_model: {
@@ -100,7 +100,7 @@ describe('PythonGenerator', () => {
             }
           },
           union_model: {
-            oneOf: [{ $ref: '#' }]
+            oneOf: [{ $ref: '#' }, { type: 'string' }]
           }
         },
         additionalProperties: false

--- a/test/generators/python/__snapshots__/PythonGenerator.spec.ts.snap
+++ b/test/generators/python/__snapshots__/PythonGenerator.spec.ts.snap
@@ -4,49 +4,49 @@ exports[`PythonGenerator Class should handle self reference models 1`] = `
 "class Address: 
   def __init__(self, input: Dict):
     if 'self_model' in input:
-      self._self_model: Address = Address(input['self_model'])
+      self._self_model: Address.Address = Address.Address(input['self_model'])
     if 'array_model' in input:
-      self._array_model: List[Address] = input['array_model']
+      self._array_model: List[Address.Address] = input['array_model']
     if 'tuple_model' in input:
-      self._tuple_model: tuple[Address] = input['tuple_model']
+      self._tuple_model: tuple[Address.Address, str] = input['tuple_model']
     if 'map_model' in input:
-      self._map_model: dict[str, Address] = input['map_model']
+      self._map_model: dict[str, Address.Address] = input['map_model']
     if 'union_model' in input:
-      self._union_model: Address = input['union_model']
+      self._union_model: Address.Address | str = input['union_model']
 
   @property
-  def self_model(self) -> 'Address':
+  def self_model(self) -> Address.Address:
     return self._self_model
   @self_model.setter
-  def self_model(self, self_model: 'Address'):
+  def self_model(self, self_model: Address.Address):
     self._self_model = self_model
 
   @property
-  def array_model(self) -> List['Address']:
+  def array_model(self) -> List[Address.Address]:
     return self._array_model
   @array_model.setter
-  def array_model(self, array_model: List['Address']):
+  def array_model(self, array_model: List[Address.Address]):
     self._array_model = array_model
 
   @property
-  def tuple_model(self) -> tuple['Address']:
+  def tuple_model(self) -> tuple[Address.Address, str]:
     return self._tuple_model
   @tuple_model.setter
-  def tuple_model(self, tuple_model: tuple['Address']):
+  def tuple_model(self, tuple_model: tuple[Address.Address, str]):
     self._tuple_model = tuple_model
 
   @property
-  def map_model(self) -> dict[str, 'Address']:
+  def map_model(self) -> dict[str, Address.Address]:
     return self._map_model
   @map_model.setter
-  def map_model(self, map_model: dict[str, 'Address']):
+  def map_model(self, map_model: dict[str, Address.Address]):
     self._map_model = map_model
 
   @property
-  def union_model(self) -> 'Address':
+  def union_model(self) -> Address.Address | str:
     return self._union_model
   @union_model.setter
-  def union_model(self, union_model: 'Address'):
+  def union_model(self, union_model: Address.Address | str):
     self._union_model = union_model
 "
 `;

--- a/test/generators/python/__snapshots__/PythonGenerator.spec.ts.snap
+++ b/test/generators/python/__snapshots__/PythonGenerator.spec.ts.snap
@@ -4,49 +4,49 @@ exports[`PythonGenerator Class should handle self reference models 1`] = `
 "class Address: 
   def __init__(self, input: Dict):
     if 'self_model' in input:
-      self._self_model: Address.Address = Address.Address(input['self_model'])
+      self._self_model: Address = Address(input['self_model'])
     if 'array_model' in input:
-      self._array_model: List[Address.Address] = input['array_model']
+      self._array_model: List[Address] = input['array_model']
     if 'tuple_model' in input:
-      self._tuple_model: tuple[Address.Address, str] = input['tuple_model']
+      self._tuple_model: tuple[Address, str] = input['tuple_model']
     if 'map_model' in input:
-      self._map_model: dict[str, Address.Address] = input['map_model']
+      self._map_model: dict[str, Address] = input['map_model']
     if 'union_model' in input:
-      self._union_model: Address.Address | str = input['union_model']
+      self._union_model: Address | str = input['union_model']
 
   @property
-  def self_model(self) -> Address.Address:
+  def self_model(self) -> Address:
     return self._self_model
   @self_model.setter
-  def self_model(self, self_model: Address.Address):
+  def self_model(self, self_model: Address):
     self._self_model = self_model
 
   @property
-  def array_model(self) -> List[Address.Address]:
+  def array_model(self) -> List[Address]:
     return self._array_model
   @array_model.setter
-  def array_model(self, array_model: List[Address.Address]):
+  def array_model(self, array_model: List[Address]):
     self._array_model = array_model
 
   @property
-  def tuple_model(self) -> tuple[Address.Address, str]:
+  def tuple_model(self) -> tuple[Address, str]:
     return self._tuple_model
   @tuple_model.setter
-  def tuple_model(self, tuple_model: tuple[Address.Address, str]):
+  def tuple_model(self, tuple_model: tuple[Address, str]):
     self._tuple_model = tuple_model
 
   @property
-  def map_model(self) -> dict[str, Address.Address]:
+  def map_model(self) -> dict[str, Address]:
     return self._map_model
   @map_model.setter
-  def map_model(self, map_model: dict[str, Address.Address]):
+  def map_model(self, map_model: dict[str, Address]):
     self._map_model = map_model
 
   @property
-  def union_model(self) -> Address.Address | str:
+  def union_model(self) -> Address | str:
     return self._union_model
   @union_model.setter
-  def union_model(self, union_model: Address.Address | str):
+  def union_model(self, union_model: Address | str):
     self._union_model = union_model
 "
 `;

--- a/test/generators/python/presets/__snapshots__/Pydantic.spec.ts.snap
+++ b/test/generators/python/presets/__snapshots__/Pydantic.spec.ts.snap
@@ -13,7 +13,7 @@ exports[`PYTHON_PYDANTIC_PRESET should render pydantic for class 1`] = `
 exports[`PYTHON_PYDANTIC_PRESET should render union to support Python < 3.10 1`] = `
 Array [
   "class UnionTest(BaseModel): 
-  union_test: Optional[Union[Union1, Union2]] = Field(default=None, serialization_alias='unionTest')
+  union_test: Optional[Union[Union1.Union1, Union2.Union2]] = Field(default=None, serialization_alias='unionTest')
   additional_properties: Optional[dict[str, Any]] = Field(default=None, serialization_alias='additionalProperties', exclude=True)
 ",
   "class Union1(BaseModel): 


### PR DESCRIPTION
## Description

This PR fixes two major problems with the Python generator; self-referencing models give errors and circular model dependencies do not work.

## Self-referencing models
If a model depends on itself the current dependency setup will not work in Python. This fixes it by changing the import style to using forward references (`forward references: when a type hint contains names that have not been defined yet, that definition needs to be expressed as a string literal;`) through the new [Postponed Evaluation of Annotations](https://peps.python.org/pep-0563/).

I tried to experiment with all kinds of different solutions, such as those highlighted here: https://stackoverflow.com/a/55344418/6803886

However, this one was the most straightforward solution. It does mean that we add the requirement of using at least Python 3.7, which is why this is breaking.

## Circular model dependencies
If we have two models, that each other reference each other in a circular manner Python will complain about it because of the current import style. Going forward we only support explicit import style to allow for this use-case.

## Related Issues
Fixes https://github.com/asyncapi/modelina/issues/1940
Fixes https://github.com/asyncapi/modelina/issues/1814