### PR TITLE
fix: support dash in property names (Pydantic generator)

### DIFF
--- a/examples/generate-python-pydantic-models/__snapshots__/index.spec.ts.snap
+++ b/examples/generate-python-pydantic-models/__snapshots__/index.spec.ts.snap
@@ -3,10 +3,11 @@
 exports[`Should be able to render python models and should log expected output to console: class-model 1`] = `
 Array [
   "class Root(BaseModel): 
-  optionalField: Optional[str] = Field(alias='''this field is optional''', default=None)
-  requiredField: str = Field(alias='''this field is required''')
+  optionalField: Optional[str] = Field(description='''this field is optional''', default=None)
+  requiredField: str = Field(description='''this field is required''')
   noDescription: Optional[str] = Field(default=None)
   options: Optional[Options] = Field(default=None)
+  contentType: Optional[str] = Field(default=None, alias='''content-type''')
 ",
 ]
 `;

--- a/examples/generate-python-pydantic-models/index.ts
+++ b/examples/generate-python-pydantic-models/index.ts
@@ -26,7 +26,8 @@ const jsonSchemaDraft7 = {
       $id: 'options',
       type: ['integer', 'boolean', 'string'],
       enum: [123, 213, true, 'Run']
-    }
+    },
+    'content-type': { type: 'string' }
   }
 };
 

--- a/src/generators/python/constrainer/PropertyKeyConstrainer.ts
+++ b/src/generators/python/constrainer/PropertyKeyConstrainer.ts
@@ -25,10 +25,10 @@ export type PropertyKeyConstraintOptions = {
 
 export const DefaultPropertyKeyConstraints: PropertyKeyConstraintOptions = {
   NO_SPECIAL_CHAR: (value: string) => {
-    //Exclude ` ` because it gets formatted by NAMING_FORMATTER
+    //Exclude ` ` and `-` because they gets formatted by NAMING_FORMATTER
     //Exclude '_' because they are allowed
     return FormatHelpers.replaceSpecialCharacters(value, {
-      exclude: [' ', '_'],
+      exclude: [' ', '-', '_'],
       separator: '_'
     });
   },

--- a/src/generators/python/presets/Pydantic.ts
+++ b/src/generators/python/presets/Pydantic.ts
@@ -33,17 +33,25 @@ const PYTHON_PYDANTIC_CLASS_PRESET: ClassPresetType<PythonOptions> = {
       type = `Optional[${type}]`;
     }
 
-    const alias = params.property.property.originalInput['description']
-      ? `alias='''${params.property.property.originalInput['description']}'''`
-      : '';
-    const defaultValue = params.property.required ? '' : 'default=None';
+    const decoratorArgs: string[] = [];
 
-    if (alias && defaultValue) {
-      return `${propertyName}: ${type} = Field(${alias}, ${defaultValue})`;
-    } else if (alias) {
-      return `${propertyName}: ${type} = Field(${alias})`;
+    if (params.property.property.originalInput['description']) {
+      decoratorArgs.push(
+        `description='''${params.property.property.originalInput['description']}'''`
+      );
     }
-    return `${propertyName}: ${type} = Field(${defaultValue})`;
+    if (!params.property.required) {
+      decoratorArgs.push('default=None');
+    }
+    if (
+      params.property.propertyName !== params.property.unconstrainedPropertyName
+    ) {
+      decoratorArgs.push(
+        `alias='''${params.property.unconstrainedPropertyName}'''`
+      );
+    }
+
+    return `${propertyName}: ${type} = Field(${decoratorArgs.join(', ')})`;
   },
   ctor: () => '',
   getter: () => '',

--- a/test/generators/python/presets/__snapshots__/Pydantic.spec.ts.snap
+++ b/test/generators/python/presets/__snapshots__/Pydantic.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`PYTHON_PYDANTIC_PRESET should render pydantic for class 1`] = `
 "class Test(BaseModel): 
-  prop: Optional[str] = Field(alias='''test
+  prop: Optional[str] = Field(description='''test
     multi
     line
     description''', default=None)


### PR DESCRIPTION
## Description
This enables the generated models for Pydantic to work for properties with dashes in the name.

The generated code now puts descriptions in the "description" argument of the Pydantic Field decorator, and puts the original, unconstrained, property name in the "alias" field. This is correct usage as per the [Pydantic documentation](https://docs.pydantic.dev/latest/concepts/fields/#field-aliases)

Also, dashes are allowed through in property key constrainer, so that a property name like "content-type" is converted into "contentType" instead of "contentMinusType".

## Related Issue
I believe this fixes https://github.com/asyncapi/modelina/issues/1058 but apparently that has been closed with a fix to an mostly unrelated problem.

## Checklist
- [x] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [x] Tests have been added or updated to cover the changes.
- [x] Documentation has been updated to reflect the changes.
- [x] All tests pass successfully locally.(`npm run test`).

## Additional Notes
With these changes the generated Pydantic model class can correctly deserialise and serialise the JSON object described by the schema in the updated [generate-python-pydantic-models](https://github.com/asyncapi/modelina/blob/9610ee2e66b9de045543590bc627585b5f7955ef/examples/generate-python-pydantic-models/index.ts) test:

```json
{
   "requiredField": "test@example.com",
   "noDescription": "test",
   "options": 123,
   "content-type": "application/json"
}
```

Without this change Pydantic would ignore the `"content-type"` field since it would not know to map that to the models `contentType` property.

Note that this is technically a breaking change, since before users could use the "description" field in the JSON schema to set the "alias" field on the Pydantic model. This would be a misuse of the description field, though, since it is to decorate a user interface with information about the data produced by this user interface.