### PR TITLE
docs: update go language docs

### DIFF
--- a/docs/languages/Go.md
+++ b/docs/languages/Go.md
@@ -11,20 +11,22 @@ There are special use-cases that each language supports; this document pertains 
 
 <!-- tocstop -->
 
-## Generate JSON struct-tags and marshaler functions for enums
-
-To generate go models that works correctly with JSON marshal functions we need to generate appropriate JSON `struct-tags`, use the preset `GO_COMMON_PRESET` and provide the option `addJsonTag: true`.
-
-check out this [example for a live demonstration](../../examples/go-json-tags/)
-
 ## Generate serializer and deserializer functionality
 
-The most widely used usecase for Modelina is to generate models that include serialization and deserialization functionality to convert the models into payload data. This payload data can of course be many different kinds, JSON, XML, raw binary, you name it.
+The most widely used use-case for Modelina is to generate models that include serialization and deserialization functionality to convert the models into payload data. This payload data can of course be many different kinds, JSON, XML, raw binary, you name it.
 
 As you normally only need one library to do this, we developers can never get enough with creating new stuff, therefore there might be one specific library you need or want to integrate with. Therefore there is not one specific preset that offers everything. Below is a list of all the supported serialization presets. 
 
 ### To and from JSON
-Currently not supported, [let everyone know you need it](https://github.com/asyncapi/modelina/issues/new?assignees=&labels=enhancement&template=enhancement.md)!
+Here are all the supported presets and the libraries they use for converting to and from JSON:
+
+- [JSON Tags](#json-tags)
+
+#### JSON Tags
+
+To generate go models that work correctly with JSON marshal functions we need to generate appropriate JSON `struct-tags`, use the preset `GO_COMMON_PRESET` and provide the option `addJsonTag: true`.
+
+check out this [example for a live demonstration](../../examples/go-json-tags/)
 
 ### To and from XML
 Currently not supported, [let everyone know you need it](https://github.com/asyncapi/modelina/issues/new?assignees=&labels=enhancement&template=enhancement.md)!


### PR DESCRIPTION
## Description
This PR updates the go language docs to better explain that JSON tags are supported.