### PR TITLE
chore: make the npm script portable in Maven example

### DIFF
--- a/examples/integrate-with-maven/maven-project/pom.xml
+++ b/examples/integrate-with-maven/maven-project/pom.xml
@@ -97,6 +97,16 @@
             </configuration>
           </execution>
           <execution>
+            <id>Dependencies</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>npm</goal>
+            </goals>
+            <configuration>
+              <arguments>install</arguments>
+            </configuration>
+          </execution>
+          <execution>
             <id>Generate sources</id>
             <phase>generate-sources</phase>
             <goals>

--- a/examples/integrate-with-maven/maven-project/scripts/modelina/generate.ts
+++ b/examples/integrate-with-maven/maven-project/scripts/modelina/generate.ts
@@ -2,8 +2,8 @@ import { JAVA_JACKSON_PRESET, JavaFileGenerator } from '@asyncapi/modelina';
 import path from 'path';
 
 // Where should the models be placed relative to root maven project?
-const PACKAGE_NAME = 'java/com/mycompany/app';
-const MODEL_DIR = `src/main/${PACKAGE_NAME}`;
+const PACKAGE_NAME = 'com/mycompany/app';
+const MODEL_DIR = `src/main/java/${PACKAGE_NAME}`;
 
 const FINAL_OUTPUT_PATH = path.resolve(__dirname, '../../', MODEL_DIR);
 // Setup the generator and all it's configurations

--- a/examples/integrate-with-maven/maven-project/scripts/modelina/package.json
+++ b/examples/integrate-with-maven/maven-project/scripts/modelina/package.json
@@ -4,7 +4,6 @@
     "ts-node": "^10.3.0"
   },
   "scripts": {
-    "generate": "./node_modules/.bin/ts-node ./generate.ts",
-    "generate:windows": "..\\node_modules\\.bin\\ts-node .%\\generate.ts"
+    "generate": "ts-node ./generate.ts"
   }
 }


### PR DESCRIPTION
## Description

* Make the npm script portable in Maven example. npm guideline is to not prefix with relative path, as executables are added to the $PATH. Tested on Windows and macOS.
* Add missing "npm install" excution to Maven frontend plugin.

## Checklist

I don't think it's applicable, as the examples are not run in the CI ?
