### PR TITLE
ci: make sure release workflow works in next

### DIFF
--- a/.github/workflows/if-nodejs-release.yml
+++ b/.github/workflows/if-nodejs-release.yml
@@ -15,6 +15,7 @@ on:
       - next-major-spec
       - beta
       - alpha
+      - next
 
 jobs:
 


### PR DESCRIPTION
## Description
As long as https://github.com/asyncapi/.github/pull/294 is not merged, this patch is needed