### PR TITLE
fix: lonely additionalProperties not interpreted as dictionary

### DIFF
--- a/src/interpreter/InterpretAdditionalProperties.ts
+++ b/src/interpreter/InterpretAdditionalProperties.ts
@@ -20,7 +20,10 @@ export default function interpretAdditionalProperties(
   interpreter: Interpreter,
   interpreterOptions: InterpreterOptions = Interpreter.defaultInterpreterOptions
 ): void {
-  if (typeof schema === 'boolean' || isModelObject(model) === false) {
+  if (
+    typeof schema === 'boolean' ||
+    (model.type !== undefined && isModelObject(model) === false)
+  ) {
     return;
   }
   let defaultAdditionalProperties = true;

--- a/test/interpreter/unit/InterpretAdditionalProperties.spec.ts
+++ b/test/interpreter/unit/InterpretAdditionalProperties.spec.ts
@@ -32,6 +32,26 @@ describe('Interpretation of additionalProperties', () => {
       schema
     );
   });
+  test('should try and interpret additionalProperties schema if no type', () => {
+    const schema: any = { additionalProperties: { type: 'string' } };
+    const model = new CommonModel();
+    const interpreter = new Interpreter();
+    const mockedReturnModel = new CommonModel();
+    (interpreter.interpret as jest.Mock).mockReturnValue(mockedReturnModel);
+
+    interpretAdditionalProperties(schema, model, interpreter);
+
+    expect(interpreter.interpret).toHaveBeenNthCalledWith(
+      1,
+      { type: 'string' },
+      Interpreter.defaultInterpreterOptions
+    );
+    expect(model.addAdditionalProperty).toHaveBeenNthCalledWith(
+      1,
+      mockedReturnModel,
+      schema
+    );
+  });
   test('should ignore model if interpreter cannot interpret additionalProperty schema', () => {
     const schema: any = {};
     const model = new CommonModel();


### PR DESCRIPTION
## Description
This PR fixes that lonely additionalProperties not interpreted as dictionary.

## Related Issue
Fixes https://github.com/asyncapi/modelina/issues/1977
