### PR TITLE
fix: treat nullable property as optional

### DIFF
--- a/src/generators/python/presets/Pydantic.ts
+++ b/src/generators/python/presets/Pydantic.ts
@@ -29,7 +29,10 @@ const PYTHON_PYDANTIC_CLASS_PRESET: ClassPresetType<PythonOptions> = {
       type = `Union[${unionTypes.join(', ')}]`;
     }
 
-    if (!params.property.required) {
+    const isOptional =
+      !params.property.required ||
+      params.property.property.options.isNullable === true;
+    if (isOptional) {
       type = `Optional[${type}]`;
     }
 
@@ -40,7 +43,7 @@ const PYTHON_PYDANTIC_CLASS_PRESET: ClassPresetType<PythonOptions> = {
         `description='''${params.property.property.originalInput['description']}'''`
       );
     }
-    if (!params.property.required) {
+    if (isOptional) {
       decoratorArgs.push('default=None');
     }
     if (

--- a/test/generators/python/presets/Pydantic.spec.ts
+++ b/test/generators/python/presets/Pydantic.spec.ts
@@ -65,4 +65,33 @@ describe('PYTHON_PYDANTIC_PRESET', () => {
     const models = await generator.generate(doc);
     expect(models.map((model) => model.result)).toMatchSnapshot();
   });
+
+  test('should render nullable union', async () => {
+    const doc = {
+      title: 'NullableUnionTest',
+      type: 'object',
+      required: ['nullableUnionTest'],
+      properties: {
+        nullableUnionTest: {
+          anyOf: [
+            {
+              title: 'Union1',
+              type: 'object',
+              properties: {
+                testProp1: {
+                  type: 'string'
+                }
+              }
+            },
+            {
+              type: 'null'
+            }
+          ]
+        }
+      }
+    };
+
+    const models = await generator.generate(doc);
+    expect(models.map((model) => model.result)).toMatchSnapshot();
+  });
 });

--- a/test/generators/python/presets/__snapshots__/Pydantic.spec.ts.snap
+++ b/test/generators/python/presets/__snapshots__/Pydantic.spec.ts.snap
@@ -1,5 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`PYTHON_PYDANTIC_PRESET should render nullable union 1`] = `
+Array [
+  "class NullableUnionTest(BaseModel): 
+  nullableUnionTest: Optional[Union[Union1]] = Field(default=None)
+  additionalProperties: Optional[dict[Any, Any]] = Field(default=None)
+",
+  "class Union1(BaseModel): 
+  testProp1: Optional[str] = Field(default=None)
+  additionalProperties: Optional[dict[Any, Any]] = Field(default=None)
+",
+]
+`;
+
 exports[`PYTHON_PYDANTIC_PRESET should render pydantic for class 1`] = `
 "class Test(BaseModel): 
   prop: Optional[str] = Field(description='''test


### PR DESCRIPTION
## Description
Add a test for a required, but nullable, union type and update the Pydantic preset to treat nullable properties as optional.

## Related Issue
Fixes https://github.com/asyncapi/modelina/issues/2000

## Checklist
- [x] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [x] Tests have been added or updated to cover the changes.
- [ ] Documentation has been updated to reflect the changes.
- [x] All tests pass successfully locally.(`npm run test`).
