### PR TITLE
fix: include modelina dependency as release for cli

### DIFF
--- a/modelina-cli/package.json
+++ b/modelina-cli/package.json
@@ -45,7 +45,8 @@
     "/assets",
     "/npm-shrinkwrap.json",
     "/oclif.manifest.json",
-    "/README.md"
+    "/README.md",
+    "./scripts/modelina-package/asyncapi-modelina.tgz"
   ],
   "homepage": "https://github.com/asyncapi/modelina",
   "keywords": [


### PR DESCRIPTION
## Description
This PR adds the Modelina tar ball as part of the release, otherwise it's not accessible for others when they install the library.
