### PR TITLE
feat: add typescript raw option to the CLI 

### DIFF
--- a/modelina-cli/src/helpers/typescript.ts
+++ b/modelina-cli/src/helpers/typescript.ts
@@ -51,6 +51,11 @@ export const TypeScriptOclifFlags = {
     required: false,
     default: false,
   }),
+  tsRawPropertyNames: Flags.boolean({
+    description: 'Typescript specific, generate the models using raw property names.',
+    required: false,
+    default: false,
+  }),
 }
 
 /**
@@ -60,7 +65,7 @@ export const TypeScriptOclifFlags = {
  * @returns 
  */
 export function buildTypeScriptGenerator(flags: any): BuilderReturnType {
-  const { tsModelType, tsEnumType, tsIncludeComments, tsModuleSystem, tsExportType, tsJsonBinPack, tsMarshalling, tsExampleInstance } = flags;
+  const { tsModelType, tsEnumType, tsIncludeComments, tsModuleSystem, tsExportType, tsJsonBinPack, tsMarshalling, tsExampleInstance, tsRawPropertyNames } = flags;
   const presets = [];
   const options = {
     marshalling: tsMarshalling,
@@ -82,6 +87,7 @@ export function buildTypeScriptGenerator(flags: any): BuilderReturnType {
   const fileGenerator = new TypeScriptFileGenerator({
     modelType: tsModelType as 'class' | 'interface',
     enumType: tsEnumType as 'enum' | 'union',
+    rawPropertyNames: tsRawPropertyNames,
     presets
   });
   const fileOptions = {

--- a/modelina-cli/test/integration/generate.test.ts
+++ b/modelina-cli/test/integration/generate.test.ts
@@ -104,7 +104,7 @@ describe('models', () => {
     test
       .stderr()
       .stdout()
-      .command([...generalOptions,'typescript', './test/fixtures/specification.yml', '--tsRawPropertyNames'])
+      .command([...generalOptions, 'typescript', ASYNCAPI_V2_DOCUMENT, '--tsRawPropertyNames'])
       .it('works when tsRawPropertyNames is set', (ctx, done) => {
         expect(ctx.stdout).to.contain(
           'Successfully generated the following models: '

--- a/modelina-cli/test/integration/generate.test.ts
+++ b/modelina-cli/test/integration/generate.test.ts
@@ -94,8 +94,18 @@ describe('models', () => {
     test
       .stderr()
       .stdout()
-      .command([...generalOptions,'typescript', ASYNCAPI_V2_DOCUMENT, '--tsIncludeComments'])
+      .command([...generalOptions, 'typescript', ASYNCAPI_V2_DOCUMENT, '--tsIncludeComments'])
       .it('works when tsExampleInstance is set', (ctx, done) => {
+        expect(ctx.stdout).to.contain(
+          'Successfully generated the following models: '
+        );
+        done();
+      });
+    test
+      .stderr()
+      .stdout()
+      .command([...generalOptions,'typescript', './test/fixtures/specification.yml', '--tsRawPropertyNames'])
+      .it('works when tsRawPropertyNames is set', (ctx, done) => {
         expect(ctx.stdout).to.contain(
           'Successfully generated the following models: '
         );


### PR DESCRIPTION
## Description
This PR adds support for using the `--tsRawPropertyNames` that was introduced in https://github.com/asyncapi/cli/pull/1362