### PR TITLE
feat: adding support to change the collection type for arrays in Java models

### DIFF
--- a/modelina-cli/README.md
+++ b/modelina-cli/README.md
@@ -406,7 +406,7 @@ USAGE
     [--tsModelType class|interface] [--tsEnumType enum|union] [--tsModuleSystem ESM|CJS] [--tsIncludeComments]
     [--tsExportType default|named] [--tsJsonBinPack] [--tsMarshalling] [--tsExampleInstance] [--tsRawPropertyNames]
     [--csharpAutoImplement] [--csharpNewtonsoft] [--csharpArrayType Array|List] [--csharpHashcode] [--csharpEqual]
-    [--csharpSystemJson] [--javaIncludeComments] [--javaJackson] [--javaConstraints]
+    [--csharpSystemJson] [--javaIncludeComments] [--javaJackson] [--javaConstraints] [--javaArrayType Array|List]
 
 ARGUMENTS
   LANGUAGE  (typescript|csharp|golang|java|javascript|dart|python|rust|kotlin|php|cplusplus|scala) The language you want
@@ -424,6 +424,8 @@ FLAGS
       --csharpHashcode            C# specific, generate the models with the GetHashCode method overwritten
       --csharpNewtonsoft          C# specific, generate the models with newtonsoft serialization support
       --csharpSystemJson          C# specific, generate the models with System.Text.Json serialization support
+      --javaArrayType             [default: Array] Java specific, define which type of array needs to be generated.
+                                  <options: Array|List>
       --javaConstraints           Java specific, generate the models with constraints
       --javaIncludeComments       Java specific, if enabled add comments while generating models.
       --javaJackson               Java specific, generate the models with Jackson serialization support

--- a/modelina-cli/src/helpers/java.ts
+++ b/modelina-cli/src/helpers/java.ts
@@ -18,6 +18,13 @@ export const JavaOclifFlags = {
     required: false,
     default: false
   }),
+  javaArrayType: Flags.string({
+    type: 'option',
+    description: 'Java specific, define which type of array needs to be generated.',
+    options: ['Array', 'List'],
+    required: false,
+    default: 'Array'
+  })
 }
 
 /**
@@ -27,7 +34,7 @@ export const JavaOclifFlags = {
  * @returns 
  */
 export function buildJavaGenerator(flags: any): BuilderReturnType {
-  const { packageName, javaIncludeComments, javaJackson, javaConstraints } = flags;
+  const { packageName, javaIncludeComments, javaJackson, javaConstraints, javaArrayType } = flags;
   const presets = []
   
   if (packageName === undefined) {
@@ -40,7 +47,10 @@ export function buildJavaGenerator(flags: any): BuilderReturnType {
   if (javaIncludeComments) {presets.push(JAVA_DESCRIPTION_PRESET);}
   if (javaJackson) {presets.push(JAVA_JACKSON_PRESET);}
   if (javaConstraints) {presets.push(JAVA_CONSTRAINTS_PRESET);}
-  const fileGenerator = new JavaFileGenerator({ presets });
+  const fileGenerator = new JavaFileGenerator({
+    presets,
+    collectionType: javaArrayType as 'Array' | 'List'
+  });
   const fileOptions = {
     packageName
   };

--- a/modelina-cli/test/integration/generate.test.ts
+++ b/modelina-cli/test/integration/generate.test.ts
@@ -266,6 +266,16 @@ describe('models', () => {
         expect(ctx.stderr).to.contain('Error: In order to generate models to Java, we need to know which package they are under. Add `--packageName=PACKAGENAME` to set the desired package name.\n');
         done();
       });
+    test
+      .stderr()
+      .stdout()
+      .command([...generalOptions, 'java', ASYNCAPI_V2_DOCUMENT, `-o=${ path.resolve(outputDir, './java')}`, '--packageName', 'test.pkg', '--javaArrayType=List'])
+      .it('works when array type is provided', (ctx, done) => {
+        expect(ctx.stdout).to.contain(
+          'Successfully generated the following models: '
+        );
+        done();
+      });
   });
 
   describe('for Go', () => {


### PR DESCRIPTION
## Description
This PR adds support to change the collection type in Java models by introducing a new parameter "javaArrayType" to the generate models command.

## Checklist
- [x] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [x] Tests have been added or updated to cover the changes.
- [x] Documentation has been updated to reflect the changes.
- [x] All tests pass successfully locally.(`npm run test`).

