### PR TITLE
chore/website: add eslint nextjs automatic fix on package json

### DIFF
--- a/modelina-website/.eslintignore
+++ b/modelina-website/.eslintignore
@@ -1,2 +1,3 @@
 node_modules
 .next
+modelina-website

--- a/modelina-website/package.json
+++ b/modelina-website/package.json
@@ -8,6 +8,7 @@
     "export": "next export",
     "start": "next start",
     "lint": "next lint -c ./.eslintrc",
+    "lint:fix": "next lint -c ./.eslintrc --fix",
     "build:resources": "npm run build:examples && npm run build:docs && npm run copy:docs:img",
     "build:examples": "node scripts/build-examples.js",
     "build:docs": "node scripts/build-docs.js",


### PR DESCRIPTION
## Description
Added `eslint` automatic fix for modelina-website and added modelina-website to eslint ignore in parent project, so no conflicting rule in the future when we start migrating the same rule used in [async website](https://github.com/asyncapi/modelina/pull/2028#pullrequestreview-2106861566) as [mentioned here](https://github.com/asyncapi/modelina/pull/2028#pullrequestreview-2106861566)

## Related Issue
This PR is being made as [mentioned here](https://github.com/asyncapi/modelina/pull/2028#discussion_r1632703345)
