### PR TITLE
feat: json tag support for go union

### DIFF
--- a/examples/go-union-type/__snapshots__/index.spec.ts.snap
+++ b/examples/go-union-type/__snapshots__/index.spec.ts.snap
@@ -8,8 +8,7 @@ type AdditionalProperty struct {
   AdditionalPropertyOneOf_1
   string
   float64
-  ModelinaArrType []string
-  ModelinaArrType []Union
+  ModelinaArrType
   AdditionalPropertyOneOf_6
 }",
 ]
@@ -21,7 +20,7 @@ Array [
 type Union struct {
   string
   float64
-  ModelinaAnyType interface{}
+  ModelinaAnyType
 }",
 ]
 `;

--- a/src/generators/go/presets/CommonPreset.ts
+++ b/src/generators/go/presets/CommonPreset.ts
@@ -66,5 +66,10 @@ export const GO_COMMON_PRESET: GoPreset<GoCommonPresetOptions> = {
 
       return `${content}\n ${blocks.join('\n')}`;
     }
+  },
+  union: {
+    field: ({content}) => {
+      return `${content} \`json:"-,omitempty\``
+    },
   }
 };

--- a/src/generators/go/presets/CommonPreset.ts
+++ b/src/generators/go/presets/CommonPreset.ts
@@ -68,8 +68,8 @@ export const GO_COMMON_PRESET: GoPreset<GoCommonPresetOptions> = {
     }
   },
   union: {
-    field: ({content}) => {
-      return `${content} \`json:"-,omitempty\``
-    },
+    field: ({ content }) => {
+      return `${content} \`json:"-,omitempty\``;
+    }
   }
 };

--- a/src/generators/go/renderers/UnionRenderer.ts
+++ b/src/generators/go/renderers/UnionRenderer.ts
@@ -82,13 +82,13 @@ export const GO_DEFAULT_UNION_PRESET: UnionPresetType<GoOptions> = {
     const fieldType = field.type;
 
     if (fieldType === 'interface{}') {
-      return `${options.unionAnyModelName} ${fieldType}`;
+      return `${options.unionAnyModelName}`;
     }
     if (fieldType.includes('map')) {
-      return `${options.unionDictModelName} ${fieldType}`;
+      return `${options.unionDictModelName}`;
     }
     if (fieldType.includes('[]')) {
-      return `${options.unionArrModelName} ${fieldType}`;
+      return `${options.unionArrModelName}`;
     }
     return `${fieldType}`;
   },

--- a/test/generators/go/__snapshots__/GoGenerator.spec.ts.snap
+++ b/test/generators/go/__snapshots__/GoGenerator.spec.ts.snap
@@ -20,7 +20,7 @@ package some_package
 type Union struct {
   string
   float64
-  ModelinaAnyType interface{}
+  ModelinaAnyType
 }"
 `;
 
@@ -30,7 +30,7 @@ package some_package
 
 // AdditionalProperties represents a AdditionalProperties model.
 type AdditionalProperties struct {
-  ModelinaAnyType interface{}
+  ModelinaAnyType
   string
 }"
 `;
@@ -88,7 +88,7 @@ package some_package
 type Union struct {
   string
   float64
-  ModelinaAnyType interface{}
+  ModelinaAnyType
 }"
 `;
 
@@ -98,7 +98,7 @@ package some_package
 
 // AdditionalProperties represents a AdditionalProperties model.
 type AdditionalProperties struct {
-  ModelinaAnyType interface{}
+  ModelinaAnyType
   string
 }"
 `;
@@ -296,7 +296,7 @@ exports[`GoGenerator should render \`struct\` type 2`] = `
 type Union struct {
   string
   float64
-  ModelinaAnyType interface{}
+  ModelinaAnyType
 }"
 `;
 
@@ -333,7 +333,7 @@ type Members struct {
 type Union struct {
   string
   float64
-  ModelinaAnyType interface{}
+  ModelinaAnyType
 }
 // LocationAdditionalProperty represents a LocationAdditionalProperty model.
 type LocationAdditionalProperty struct {


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes introduced by this pull request. -->
Adding `json` tags on go union types, to omit if empty. 

## Related Issue
<!-- If this pull request is related to any existing issue, mention it here. -->
Fixes #2034 

## Checklist
- [x] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [x] Tests have been added or updated to cover the changes.
- [x] Documentation has been updated to reflect the changes.
- [x] All tests pass successfully locally.(`npm run test`).

