### PR TITLE
feat!: expand format for integer types for C#

### DIFF
--- a/src/generators/csharp/CSharpConstrainer.ts
+++ b/src/generators/csharp/CSharpConstrainer.ts
@@ -51,8 +51,13 @@ export const CSharpDefaultTypeMapping: CSharpTypeMapping = {
   Float({ partOfProperty }): string {
     return getFullTypeDefinition('double', partOfProperty);
   },
-  Integer({ partOfProperty }): string {
-    return getFullTypeDefinition('int', partOfProperty);
+  Integer({ constrainedModel, partOfProperty }): string {
+    switch (constrainedModel.options.format) {
+      case 'int64':
+        return getFullTypeDefinition('long', partOfProperty);
+      default:
+        return getFullTypeDefinition('int', partOfProperty);
+    }
   },
   String({ constrainedModel, partOfProperty }): string {
     switch (constrainedModel.options.format) {

--- a/test/generators/csharp/CSharpConstrainer.spec.ts
+++ b/test/generators/csharp/CSharpConstrainer.spec.ts
@@ -75,13 +75,21 @@ describe('CSharpConstrainer', () => {
     });
   });
   describe('Integer', () => {
-    test('should render type', () => {
+    test('should render int', () => {
       const model = new ConstrainedIntegerModel('test', undefined, {}, '');
       const type = CSharpDefaultTypeMapping.Integer({
         constrainedModel: model,
         ...defaultOptions
       });
       expect(type).toEqual('int');
+    });
+    test('should render long', () => {
+      const model = new ConstrainedIntegerModel('test', undefined, { format: 'int64'}, '');
+      const type = CSharpDefaultTypeMapping.Integer({
+        constrainedModel: model,
+        ...defaultOptions
+      });
+      expect(type).toEqual('long');
     });
   });
   describe('String', () => {

--- a/test/generators/csharp/CSharpConstrainer.spec.ts
+++ b/test/generators/csharp/CSharpConstrainer.spec.ts
@@ -84,7 +84,7 @@ describe('CSharpConstrainer', () => {
       expect(type).toEqual('int');
     });
     test('should render long', () => {
-      const model = new ConstrainedIntegerModel('test', undefined, { format: 'int64'}, '');
+      const model = new ConstrainedIntegerModel('test', undefined, { format: 'int64' }, '');
       const type = CSharpDefaultTypeMapping.Integer({
         constrainedModel: model,
         ...defaultOptions

--- a/test/generators/csharp/CSharpConstrainer.spec.ts
+++ b/test/generators/csharp/CSharpConstrainer.spec.ts
@@ -84,7 +84,12 @@ describe('CSharpConstrainer', () => {
       expect(type).toEqual('int');
     });
     test('should render long', () => {
-      const model = new ConstrainedIntegerModel('test', undefined, { format: 'int64' }, '');
+      const model = new ConstrainedStringModel(
+        'test',
+        undefined,
+        { format: 'int64' },
+        ''
+      );
       const type = CSharpDefaultTypeMapping.Integer({
         constrainedModel: model,
         ...defaultOptions


### PR DESCRIPTION
## Description
Added extra constraints for integer types in the C# generator so int64 format results in long types.

## Related Issue
Fixes https://github.com/asyncapi/modelina/issues/2053

## Checklist
- [ ] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [ ] Tests have been added or updated to cover the changes.
- [ ] Documentation has been updated to reflect the changes.
- [ ] All tests pass successfully locally.(`npm run test`).

## Additional Notes
<!-- Add any additional information or context that might be relevant to reviewers. -->
