### PR TITLE
feat: add --pyDantic to cli for Python and Pydantic preset

### DIFF
--- a/modelina-cli/src/helpers/python.ts
+++ b/modelina-cli/src/helpers/python.ts
@@ -1,7 +1,15 @@
-import { PythonFileGenerator } from "@asyncapi/modelina";
+import { Flags } from "@oclif/core";
+import { PYTHON_PYDANTIC_PRESET, PythonFileGenerator } from "@asyncapi/modelina";
 import { BuilderReturnType } from "./generate";
 
-export const PythonOclifFlags = { }
+export const PythonOclifFlags = {
+  pyDantic: Flags.boolean({
+    description: 'Python specific, generate the Pydantic models.',
+    required: false,
+    default: false,
+  }),
+
+ }
 
 /**
  * This function builds all the relevant information for the main generate command
@@ -10,7 +18,13 @@ export const PythonOclifFlags = { }
  * @returns 
  */
 export function buildPythonGenerator(flags: any): BuilderReturnType {
-  const fileGenerator = new PythonFileGenerator();
+  const {pyDantic} = flags;
+  const presets = [];
+  if (pyDantic) {
+    presets.push(PYTHON_PYDANTIC_PRESET);
+  }
+
+  const fileGenerator = new PythonFileGenerator({presets});
   const fileOptions = undefined;
   return {
     fileOptions,

--- a/modelina-cli/test/integration/generate.test.ts
+++ b/modelina-cli/test/integration/generate.test.ts
@@ -127,6 +127,16 @@ describe('models', () => {
         );
         done();
       });
+    test
+      .stderr()
+      .stdout()
+      .command([...generalOptions, 'python', ASYNCAPI_V2_DOCUMENT, '--pyDantic'])
+      .it('works when --pyDantic is set', (ctx, done) => {
+        expect(ctx.stdout).to.contain(
+          'Successfully generated the following models: '
+        );
+        done();
+      });
   });
 
   describe('for Rust', () => {


### PR DESCRIPTION
## Description

Add an option to the modelina CLI to enable the PYDANTIC preset for Python output.

## Related Issue
<!-- If this pull request is related to any existing issue, mention it here. -->

## Checklist
- [X] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [x] Tests have been added or updated to cover the changes.
- [ ] Documentation has been updated to reflect the changes.
- [X] All tests pass successfully locally.(`npm run test`).

## Additional Notes
<!-- Add any additional information or context that might be relevant to reviewers. -->
