### PR TITLE
fix(website): fix broken open graph images

### DIFF
--- a/modelina-website/src/components/layouts/Head.tsx
+++ b/modelina-website/src/components/layouts/Head.tsx
@@ -18,9 +18,9 @@ export interface HeadProps {
 export default function HeadComponent({
   title,
   description = 'Open source tools to easily build and maintain your event-driven architecture. All powered by the AsyncAPI specification, the industry standard for defining asynchronous APIs.',
-  image = '/img/social/website-card.jpg'
+  image = '/img/card/website-card.jpg'
 }: HeadProps) {
-  const url = process.env.DEPLOY_PRIME_URL || process.env.DEPLOY_URL;
+  const url = 'https://modelina.org';
   const { path } = useContext(AppContext);
   const permalink = `${url}${path}`;
   let type = 'website';

--- a/modelina-website/src/components/layouts/Head.tsx
+++ b/modelina-website/src/components/layouts/Head.tsx
@@ -20,7 +20,7 @@ export default function HeadComponent({
   description = 'Open source tools to easily build and maintain your event-driven architecture. All powered by the AsyncAPI specification, the industry standard for defining asynchronous APIs.',
   image = '/img/card/website-card.jpg'
 }: HeadProps) {
-  const url = 'https://modelina.org';
+  const url = process.env.NEXT_PUBLIC_DEPLOY_PRIME_URL || process.env.NEXT_PUBLIC_DEPLOY_URL;
   const { path } = useContext(AppContext);
   const permalink = `${url}${path}`;
   let type = 'website';


### PR DESCRIPTION
## Description
Images in HeadComponents is not the actual folder where the images have been put in

## Related Issue
Fixes #1165 