### PR TITLE
chore(website-costum-404): add custom 404 from nextjs app

### DIFF
--- a/modelina-website/netlify.toml
+++ b/modelina-website/netlify.toml
@@ -9,3 +9,9 @@
 
 [functions]
   directory = ".next/server/pages/api"
+
+# Show a custom 404 for this path
+[[redirects]]
+from = "/"
+to = "/404"
+status = 404


### PR DESCRIPTION
## Description
Add redirect from netlify 404 not found to custom 404 not found from nextjs app

## Related Issue
<!-- If this pull request is related to any existing issue, mention it here. -->
Fixes #1360 