### PR TITLE
chore: use @asyncapi/multi-parser instead of @smoya/multi-parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^11.1.0",
         "@apidevtools/swagger-parser": "^10.1.0",
+        "@asyncapi/multi-parser": "^2.1.1",
         "@asyncapi/parser": "^3.1.0",
-        "@smoya/multi-parser": "^5.0.1",
         "@swc/core": "^1.3.5",
         "@swc/jest": "^0.2.23",
         "@types/node": "^20.3.3",
@@ -136,140 +136,40 @@
       }
     },
     "node_modules/@asyncapi/avro-schema-parser": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@asyncapi/avro-schema-parser/-/avro-schema-parser-3.0.4.tgz",
-      "integrity": "sha512-2EwTS+0deHsqIJG41dJGE2/O9pD1RJZpUCahz24tgZzcK/GQM1HBuoVvqBkPcloS9EeOXo/ZcfCMAvflj5UB/g==",
+      "version": "3.0.24",
+      "resolved": "https://registry.npmjs.org/@asyncapi/avro-schema-parser/-/avro-schema-parser-3.0.24.tgz",
+      "integrity": "sha512-YMyr2S2heMrWHRyECknjHeejlZl5exUSv9nD1gTejAT13fSf0PqIRydZ9ZuoglCLBg55AeehypR2zLIBu/9kHQ==",
       "dependencies": {
-        "@asyncapi/parser": "^2.1.1",
+        "@asyncapi/parser": "^3.1.0",
         "@types/json-schema": "^7.0.11",
         "avsc": "^5.7.6"
       }
     },
-    "node_modules/@asyncapi/avro-schema-parser/node_modules/@asyncapi/parser": {
+    "node_modules/@asyncapi/multi-parser": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-2.1.1.tgz",
-      "integrity": "sha512-FnJ5Du9iMu9MEb5mF90gF7z1ZkdnazisBsm3GHVFr7VaiF8luAoB+bklGYFwoMb+9QWKWr1099orY5VyXULAcQ==",
+      "resolved": "https://registry.npmjs.org/@asyncapi/multi-parser/-/multi-parser-2.1.1.tgz",
+      "integrity": "sha512-nGf9ete+KHKQ/VdaLQ/AoqIAm6/L5oehyx5Cam/hUpybPNRyBkOCqiikDreoc2PiduaAcYkLbZdQceoKpEbSdg==",
       "dependencies": {
-        "@asyncapi/specs": "^5.1.0",
-        "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
-        "@stoplight/json": "^3.20.2",
-        "@stoplight/json-ref-readers": "^1.2.2",
-        "@stoplight/json-ref-resolver": "^3.1.5",
-        "@stoplight/spectral-core": "^1.16.1",
-        "@stoplight/spectral-functions": "^1.7.2",
-        "@stoplight/spectral-parsers": "^1.0.2",
-        "@stoplight/spectral-ref-resolver": "^1.0.3",
-        "@stoplight/types": "^13.12.0",
-        "@types/json-schema": "^7.0.11",
-        "@types/urijs": "^1.19.19",
-        "ajv": "^8.11.0",
-        "ajv-errors": "^3.0.0",
-        "ajv-formats": "^2.1.1",
-        "avsc": "^5.7.5",
-        "js-yaml": "^4.1.0",
-        "jsonpath-plus": "^7.2.0",
-        "node-fetch": "2.6.7",
-        "ramldt2jsonschema": "^1.2.3",
-        "webapi-parser": "^0.5.0"
+        "@asyncapi/avro-schema-parser": "^3.0.3",
+        "@asyncapi/openapi-schema-parser": "^3.0.4",
+        "@asyncapi/parser": "*",
+        "@asyncapi/protobuf-schema-parser": "^3.0.0",
+        "@asyncapi/raml-dt-schema-parser": "^4.0.4",
+        "parserapiv1": "npm:@asyncapi/parser@^2.1.0",
+        "parserapiv2": "npm:@asyncapi/parser@3.0.0-next-major-spec.8"
       }
-    },
-    "node_modules/@asyncapi/avro-schema-parser/node_modules/@asyncapi/specs": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-5.1.0.tgz",
-      "integrity": "sha512-yffhETqehkim43luMnPKOwzY0D0YtU4bKpORIXIaid6p5Y5kDLrMGJaEPkNieQp03HMjhjFrnUPtT8kvqe0+aQ==",
-      "dependencies": {
-        "@types/json-schema": "^7.0.11"
-      }
-    },
-    "node_modules/@asyncapi/avro-schema-parser/node_modules/@stoplight/json": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/@stoplight/json/-/json-3.21.0.tgz",
-      "integrity": "sha512-5O0apqJ/t4sIevXCO3SBN9AHCEKKR/Zb4gaj7wYe5863jme9g02Q0n/GhM7ZCALkL+vGPTe4ZzTETP8TFtsw3g==",
-      "dependencies": {
-        "@stoplight/ordered-object-literal": "^1.0.3",
-        "@stoplight/path": "^1.3.2",
-        "@stoplight/types": "^13.6.0",
-        "jsonc-parser": "~2.2.1",
-        "lodash": "^4.17.21",
-        "safe-stable-stringify": "^1.1"
-      },
-      "engines": {
-        "node": ">=8.3.0"
-      }
-    },
-    "node_modules/@asyncapi/avro-schema-parser/node_modules/safe-stable-stringify": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-1.1.1.tgz",
-      "integrity": "sha512-ERq4hUjKDbJfE4+XtZLFPCDi8Vb1JqaxAPTxWFLBx8XcAlf9Bda/ZJdVezs/NAfsMQScyIlUMx+Yeu7P7rx5jw=="
     },
     "node_modules/@asyncapi/openapi-schema-parser": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@asyncapi/openapi-schema-parser/-/openapi-schema-parser-3.0.5.tgz",
-      "integrity": "sha512-2CPP0arkI/ibXTdae6DqeQyor3xuSf0GOyh0+yFPqVkbiYPBkC8K2UNbQ610vt8KpcEFeijX+7YuV+FTuQ5CHg==",
+      "version": "3.0.24",
+      "resolved": "https://registry.npmjs.org/@asyncapi/openapi-schema-parser/-/openapi-schema-parser-3.0.24.tgz",
+      "integrity": "sha512-7wz2yVDedJMS+TzOuqCvRWJMc6pNHICKZcOhnW6ZvyVLAh7hYIqQE1WA4OoXT4cKVbwSU3V2Q4bZagSsAIQd6Q==",
       "dependencies": {
-        "@asyncapi/parser": "^2.1.1",
+        "@asyncapi/parser": "^3.1.0",
         "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",
         "ajv-formats": "^2.1.1"
       }
-    },
-    "node_modules/@asyncapi/openapi-schema-parser/node_modules/@asyncapi/parser": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-2.1.1.tgz",
-      "integrity": "sha512-FnJ5Du9iMu9MEb5mF90gF7z1ZkdnazisBsm3GHVFr7VaiF8luAoB+bklGYFwoMb+9QWKWr1099orY5VyXULAcQ==",
-      "dependencies": {
-        "@asyncapi/specs": "^5.1.0",
-        "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
-        "@stoplight/json": "^3.20.2",
-        "@stoplight/json-ref-readers": "^1.2.2",
-        "@stoplight/json-ref-resolver": "^3.1.5",
-        "@stoplight/spectral-core": "^1.16.1",
-        "@stoplight/spectral-functions": "^1.7.2",
-        "@stoplight/spectral-parsers": "^1.0.2",
-        "@stoplight/spectral-ref-resolver": "^1.0.3",
-        "@stoplight/types": "^13.12.0",
-        "@types/json-schema": "^7.0.11",
-        "@types/urijs": "^1.19.19",
-        "ajv": "^8.11.0",
-        "ajv-errors": "^3.0.0",
-        "ajv-formats": "^2.1.1",
-        "avsc": "^5.7.5",
-        "js-yaml": "^4.1.0",
-        "jsonpath-plus": "^7.2.0",
-        "node-fetch": "2.6.7",
-        "ramldt2jsonschema": "^1.2.3",
-        "webapi-parser": "^0.5.0"
-      }
-    },
-    "node_modules/@asyncapi/openapi-schema-parser/node_modules/@asyncapi/specs": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-5.1.0.tgz",
-      "integrity": "sha512-yffhETqehkim43luMnPKOwzY0D0YtU4bKpORIXIaid6p5Y5kDLrMGJaEPkNieQp03HMjhjFrnUPtT8kvqe0+aQ==",
-      "dependencies": {
-        "@types/json-schema": "^7.0.11"
-      }
-    },
-    "node_modules/@asyncapi/openapi-schema-parser/node_modules/@stoplight/json": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/@stoplight/json/-/json-3.21.0.tgz",
-      "integrity": "sha512-5O0apqJ/t4sIevXCO3SBN9AHCEKKR/Zb4gaj7wYe5863jme9g02Q0n/GhM7ZCALkL+vGPTe4ZzTETP8TFtsw3g==",
-      "dependencies": {
-        "@stoplight/ordered-object-literal": "^1.0.3",
-        "@stoplight/path": "^1.3.2",
-        "@stoplight/types": "^13.6.0",
-        "jsonc-parser": "~2.2.1",
-        "lodash": "^4.17.21",
-        "safe-stable-stringify": "^1.1"
-      },
-      "engines": {
-        "node": ">=8.3.0"
-      }
-    },
-    "node_modules/@asyncapi/openapi-schema-parser/node_modules/safe-stable-stringify": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-1.1.1.tgz",
-      "integrity": "sha512-ERq4hUjKDbJfE4+XtZLFPCDi8Vb1JqaxAPTxWFLBx8XcAlf9Bda/ZJdVezs/NAfsMQScyIlUMx+Yeu7P7rx5jw=="
     },
     "node_modules/@asyncapi/parser": {
       "version": "3.1.0",
@@ -413,139 +313,25 @@
       }
     },
     "node_modules/@asyncapi/protobuf-schema-parser": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@asyncapi/protobuf-schema-parser/-/protobuf-schema-parser-3.0.1.tgz",
-      "integrity": "sha512-w6y7/jvnCBwwhAee7/uv6Cb31YAbDm3I6V9s7Jj+MSStA91WOEq1rOFm4YHdJ23oYFbWaQmc5+8MLTnQBGfc4Q==",
+      "version": "3.2.14",
+      "resolved": "https://registry.npmjs.org/@asyncapi/protobuf-schema-parser/-/protobuf-schema-parser-3.2.14.tgz",
+      "integrity": "sha512-7v64Jxhz2IBfaQECUhfwuLRMFQTysvmqtvT+Esgd9NooIPRnkEzgCbBnC25oGjzSB6Sju28G406lQpO15HHaEw==",
       "dependencies": {
-        "@asyncapi/parser": "^2.1.1",
+        "@asyncapi/parser": "^3.1.0",
         "@types/protocol-buffers-schema": "^3.4.1",
-        "protocol-buffers-schema": "^3.6.0"
+        "protobufjs": "^7.2.6"
       }
-    },
-    "node_modules/@asyncapi/protobuf-schema-parser/node_modules/@asyncapi/parser": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-2.1.1.tgz",
-      "integrity": "sha512-FnJ5Du9iMu9MEb5mF90gF7z1ZkdnazisBsm3GHVFr7VaiF8luAoB+bklGYFwoMb+9QWKWr1099orY5VyXULAcQ==",
-      "dependencies": {
-        "@asyncapi/specs": "^5.1.0",
-        "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
-        "@stoplight/json": "^3.20.2",
-        "@stoplight/json-ref-readers": "^1.2.2",
-        "@stoplight/json-ref-resolver": "^3.1.5",
-        "@stoplight/spectral-core": "^1.16.1",
-        "@stoplight/spectral-functions": "^1.7.2",
-        "@stoplight/spectral-parsers": "^1.0.2",
-        "@stoplight/spectral-ref-resolver": "^1.0.3",
-        "@stoplight/types": "^13.12.0",
-        "@types/json-schema": "^7.0.11",
-        "@types/urijs": "^1.19.19",
-        "ajv": "^8.11.0",
-        "ajv-errors": "^3.0.0",
-        "ajv-formats": "^2.1.1",
-        "avsc": "^5.7.5",
-        "js-yaml": "^4.1.0",
-        "jsonpath-plus": "^7.2.0",
-        "node-fetch": "2.6.7",
-        "ramldt2jsonschema": "^1.2.3",
-        "webapi-parser": "^0.5.0"
-      }
-    },
-    "node_modules/@asyncapi/protobuf-schema-parser/node_modules/@asyncapi/specs": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-5.1.0.tgz",
-      "integrity": "sha512-yffhETqehkim43luMnPKOwzY0D0YtU4bKpORIXIaid6p5Y5kDLrMGJaEPkNieQp03HMjhjFrnUPtT8kvqe0+aQ==",
-      "dependencies": {
-        "@types/json-schema": "^7.0.11"
-      }
-    },
-    "node_modules/@asyncapi/protobuf-schema-parser/node_modules/@stoplight/json": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/@stoplight/json/-/json-3.21.0.tgz",
-      "integrity": "sha512-5O0apqJ/t4sIevXCO3SBN9AHCEKKR/Zb4gaj7wYe5863jme9g02Q0n/GhM7ZCALkL+vGPTe4ZzTETP8TFtsw3g==",
-      "dependencies": {
-        "@stoplight/ordered-object-literal": "^1.0.3",
-        "@stoplight/path": "^1.3.2",
-        "@stoplight/types": "^13.6.0",
-        "jsonc-parser": "~2.2.1",
-        "lodash": "^4.17.21",
-        "safe-stable-stringify": "^1.1"
-      },
-      "engines": {
-        "node": ">=8.3.0"
-      }
-    },
-    "node_modules/@asyncapi/protobuf-schema-parser/node_modules/safe-stable-stringify": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-1.1.1.tgz",
-      "integrity": "sha512-ERq4hUjKDbJfE4+XtZLFPCDi8Vb1JqaxAPTxWFLBx8XcAlf9Bda/ZJdVezs/NAfsMQScyIlUMx+Yeu7P7rx5jw=="
     },
     "node_modules/@asyncapi/raml-dt-schema-parser": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@asyncapi/raml-dt-schema-parser/-/raml-dt-schema-parser-4.0.4.tgz",
-      "integrity": "sha512-kKam4jwYYdwqoV5zkEb3YEb8VOrN0785fc4ByazxRd+BT/RnkQTLspjTY/akdDs9DLmU4ChP73Z0vqpek6wojA==",
+      "version": "4.0.24",
+      "resolved": "https://registry.npmjs.org/@asyncapi/raml-dt-schema-parser/-/raml-dt-schema-parser-4.0.24.tgz",
+      "integrity": "sha512-Fy9IwCXPpXoG4Mkm7sXgWucSwYg8POwdx16xuHAmV6AerpcM8nk5mT/tARLtR3wrMst3OBwReEVYzwT3esSb8g==",
       "dependencies": {
-        "@asyncapi/parser": "^2.1.0",
+        "@asyncapi/parser": "^3.1.0",
         "js-yaml": "^4.1.0",
         "ramldt2jsonschema": "^1.2.3",
         "webapi-parser": "^0.5.0"
       }
-    },
-    "node_modules/@asyncapi/raml-dt-schema-parser/node_modules/@asyncapi/parser": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-2.1.1.tgz",
-      "integrity": "sha512-FnJ5Du9iMu9MEb5mF90gF7z1ZkdnazisBsm3GHVFr7VaiF8luAoB+bklGYFwoMb+9QWKWr1099orY5VyXULAcQ==",
-      "dependencies": {
-        "@asyncapi/specs": "^5.1.0",
-        "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
-        "@stoplight/json": "^3.20.2",
-        "@stoplight/json-ref-readers": "^1.2.2",
-        "@stoplight/json-ref-resolver": "^3.1.5",
-        "@stoplight/spectral-core": "^1.16.1",
-        "@stoplight/spectral-functions": "^1.7.2",
-        "@stoplight/spectral-parsers": "^1.0.2",
-        "@stoplight/spectral-ref-resolver": "^1.0.3",
-        "@stoplight/types": "^13.12.0",
-        "@types/json-schema": "^7.0.11",
-        "@types/urijs": "^1.19.19",
-        "ajv": "^8.11.0",
-        "ajv-errors": "^3.0.0",
-        "ajv-formats": "^2.1.1",
-        "avsc": "^5.7.5",
-        "js-yaml": "^4.1.0",
-        "jsonpath-plus": "^7.2.0",
-        "node-fetch": "2.6.7",
-        "ramldt2jsonschema": "^1.2.3",
-        "webapi-parser": "^0.5.0"
-      }
-    },
-    "node_modules/@asyncapi/raml-dt-schema-parser/node_modules/@asyncapi/specs": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-5.1.0.tgz",
-      "integrity": "sha512-yffhETqehkim43luMnPKOwzY0D0YtU4bKpORIXIaid6p5Y5kDLrMGJaEPkNieQp03HMjhjFrnUPtT8kvqe0+aQ==",
-      "dependencies": {
-        "@types/json-schema": "^7.0.11"
-      }
-    },
-    "node_modules/@asyncapi/raml-dt-schema-parser/node_modules/@stoplight/json": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/@stoplight/json/-/json-3.21.0.tgz",
-      "integrity": "sha512-5O0apqJ/t4sIevXCO3SBN9AHCEKKR/Zb4gaj7wYe5863jme9g02Q0n/GhM7ZCALkL+vGPTe4ZzTETP8TFtsw3g==",
-      "dependencies": {
-        "@stoplight/ordered-object-literal": "^1.0.3",
-        "@stoplight/path": "^1.3.2",
-        "@stoplight/types": "^13.6.0",
-        "jsonc-parser": "~2.2.1",
-        "lodash": "^4.17.21",
-        "safe-stable-stringify": "^1.1"
-      },
-      "engines": {
-        "node": ">=8.3.0"
-      }
-    },
-    "node_modules/@asyncapi/raml-dt-schema-parser/node_modules/safe-stable-stringify": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-1.1.1.tgz",
-      "integrity": "sha512-ERq4hUjKDbJfE4+XtZLFPCDi8Vb1JqaxAPTxWFLBx8XcAlf9Bda/ZJdVezs/NAfsMQScyIlUMx+Yeu7P7rx5jw=="
     },
     "node_modules/@asyncapi/specs": {
       "version": "4.1.2",
@@ -2105,6 +1891,60 @@
         "url": "https://opencollective.com/unts"
       }
     },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+    },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -2121,20 +1961,6 @@
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
-      }
-    },
-    "node_modules/@smoya/multi-parser": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@smoya/multi-parser/-/multi-parser-5.0.1.tgz",
-      "integrity": "sha512-MT3683glXqnsJ5vOKDCMiS/MNwt+LXyuL844LOvl4YbtR9PEe2zyECTmHLw/hbUpXFFmQXlzGs/sLSXdUh+Org==",
-      "dependencies": {
-        "@asyncapi/avro-schema-parser": "^3.0.3",
-        "@asyncapi/openapi-schema-parser": "^3.0.4",
-        "@asyncapi/protobuf-schema-parser": "^3.0.0",
-        "@asyncapi/raml-dt-schema-parser": "^4.0.4",
-        "parserapiv1": "npm:@asyncapi/parser@^2.1.0",
-        "parserapiv2": "npm:@asyncapi/parser@3.0.0-next-major-spec.8",
-        "parserapiv3": "npm:@asyncapi/parser@^3.0.1"
       }
     },
     "node_modules/@stoplight/better-ajv-errors": {
@@ -2615,9 +2441,9 @@
       "dev": true
     },
     "node_modules/@types/protocol-buffers-schema": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@types/protocol-buffers-schema/-/protocol-buffers-schema-3.4.2.tgz",
-      "integrity": "sha512-GaQpfsfFk4wGU3//d7uCGy9zy6B8QBEyWYd6+maZH+S6m861QrFvLWS5RyHj4UfIiON9tmqCz9C+oNpebDgGIw==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/protocol-buffers-schema/-/protocol-buffers-schema-3.4.3.tgz",
+      "integrity": "sha512-8cCg6BiIj4jS0LXUFq3sndmd46yyPLYqMzvXLcTM1MRubh3sfZlQiehoCjGDxSHTqGSjjx8EtVNryIAl0njQWg==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -4012,6 +3838,14 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/concat-map": {
@@ -9216,6 +9050,11 @@
       "integrity": "sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==",
       "dev": true
     },
+    "node_modules/long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+    },
     "node_modules/lower-case": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
@@ -9834,9 +9673,9 @@
       }
     },
     "node_modules/parserapiv1/node_modules/@stoplight/json": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/@stoplight/json/-/json-3.21.0.tgz",
-      "integrity": "sha512-5O0apqJ/t4sIevXCO3SBN9AHCEKKR/Zb4gaj7wYe5863jme9g02Q0n/GhM7ZCALkL+vGPTe4ZzTETP8TFtsw3g==",
+      "version": "3.21.6",
+      "resolved": "https://registry.npmjs.org/@stoplight/json/-/json-3.21.6.tgz",
+      "integrity": "sha512-KGisXfNigoYdWIj1jA4p3IAAIW5YFpU9BdoECdjyDLBbhWGGHzs77e0STSCBmXQ/K3ApxfED2R7mQ79ymjzlvQ==",
       "dependencies": {
         "@stoplight/ordered-object-literal": "^1.0.3",
         "@stoplight/path": "^1.3.2",
@@ -9880,68 +9719,12 @@
       }
     },
     "node_modules/parserapiv2/node_modules/@asyncapi/specs": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.4.0.tgz",
-      "integrity": "sha512-hTw0xF09i+eoSGP8LKo6aM+XOkvWsgV7kYpFHXd45VX9RcVZl5cADFIYDnPZkd52WaDJ4S+8Nrwkt/1vDb6SrQ==",
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.7.1.tgz",
+      "integrity": "sha512-jEaW2vgAwD9GboCdO/TI1zN2k+iowL8YFYwiZwTIr4U4KDmsgo3BLypScl6Jl4+IvY9RdsWE67nuzVX7jooiqQ==",
       "dependencies": {
         "@types/json-schema": "^7.0.11"
       }
-    },
-    "node_modules/parserapiv3": {
-      "name": "@asyncapi/parser",
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.5.tgz",
-      "integrity": "sha512-Kc/hwCyb2/YzcIfQlY9lwjUDV/9cXMjVewQz9WvPVAaFlOr83bdHpccfnl2sQNXDcC+zCcpEDBjs41ATowPE3Q==",
-      "dependencies": {
-        "@asyncapi/specs": "^6.4.0",
-        "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
-        "@stoplight/json": "^3.20.2",
-        "@stoplight/json-ref-readers": "^1.2.2",
-        "@stoplight/json-ref-resolver": "^3.1.5",
-        "@stoplight/spectral-core": "^1.16.1",
-        "@stoplight/spectral-functions": "^1.7.2",
-        "@stoplight/spectral-parsers": "^1.0.2",
-        "@stoplight/spectral-ref-resolver": "^1.0.3",
-        "@stoplight/types": "^13.12.0",
-        "@types/json-schema": "^7.0.11",
-        "@types/urijs": "^1.19.19",
-        "ajv": "^8.11.0",
-        "ajv-errors": "^3.0.0",
-        "ajv-formats": "^2.1.1",
-        "avsc": "^5.7.5",
-        "js-yaml": "^4.1.0",
-        "jsonpath-plus": "^7.2.0",
-        "node-fetch": "2.6.7"
-      }
-    },
-    "node_modules/parserapiv3/node_modules/@asyncapi/specs": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.4.0.tgz",
-      "integrity": "sha512-hTw0xF09i+eoSGP8LKo6aM+XOkvWsgV7kYpFHXd45VX9RcVZl5cADFIYDnPZkd52WaDJ4S+8Nrwkt/1vDb6SrQ==",
-      "dependencies": {
-        "@types/json-schema": "^7.0.11"
-      }
-    },
-    "node_modules/parserapiv3/node_modules/@stoplight/json": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/@stoplight/json/-/json-3.21.0.tgz",
-      "integrity": "sha512-5O0apqJ/t4sIevXCO3SBN9AHCEKKR/Zb4gaj7wYe5863jme9g02Q0n/GhM7ZCALkL+vGPTe4ZzTETP8TFtsw3g==",
-      "dependencies": {
-        "@stoplight/ordered-object-literal": "^1.0.3",
-        "@stoplight/path": "^1.3.2",
-        "@stoplight/types": "^13.6.0",
-        "jsonc-parser": "~2.2.1",
-        "lodash": "^4.17.21",
-        "safe-stable-stringify": "^1.1"
-      },
-      "engines": {
-        "node": ">=8.3.0"
-      }
-    },
-    "node_modules/parserapiv3/node_modules/safe-stable-stringify": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-1.1.1.tgz",
-      "integrity": "sha512-ERq4hUjKDbJfE4+XtZLFPCDi8Vb1JqaxAPTxWFLBx8XcAlf9Bda/ZJdVezs/NAfsMQScyIlUMx+Yeu7P7rx5jw=="
     },
     "node_modules/pascal-case": {
       "version": "3.1.2",
@@ -10205,10 +9988,28 @@
         "node": ">= 6"
       }
     },
-    "node_modules/protocol-buffers-schema": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
-      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw=="
+    "node_modules/protobufjs": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.3.2.tgz",
+      "integrity": "sha512-RXyHaACeqXeqAKGLDl68rQKbmObRsTIn4TYVUUug1KfS47YWCo5MacGITEryugIgZqORCvJWEk4l449POg5Txg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/psl": {
       "version": "1.8.0",
@@ -10270,14 +10071,6 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dependencies": {
         "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/ramldt2jsonschema/node_modules/commander": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/ramldt2jsonschema/node_modules/js-yaml": {

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^11.1.0",
     "@apidevtools/swagger-parser": "^10.1.0",
+    "@asyncapi/multi-parser": "^2.1.1",
     "@asyncapi/parser": "^3.1.0",
-    "@smoya/multi-parser": "^5.0.1",
     "@swc/core": "^1.3.5",
     "@swc/jest": "^0.2.23",
     "@types/node": "^20.3.3",

--- a/src/processors/AsyncAPIInputProcessor.ts
+++ b/src/processors/AsyncAPIInputProcessor.ts
@@ -21,7 +21,7 @@ import { fileURLToPath } from 'url';
 import {
   ConvertDocumentParserAPIVersion,
   NewParser
-} from '@smoya/multi-parser';
+} from '@asyncapi/multi-parser';
 import { createDetailedAsyncAPI } from '@asyncapi/parser/cjs/utils';
 
 /**


### PR DESCRIPTION
## Description
[@smoya/multi-parser](https://github.com/smoya/multi-parser-js) has been deprecated. Now its source code is included and released as part of https://github.com/asyncapi/parser-js monorepo.

## Checklist
- [x] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [ ] Tests have been added or updated to cover the changes.
- [ ] Documentation has been updated to reflect the changes.
- [x] All tests pass successfully locally.(`npm run test`).