### PR TITLE
fix!: when allowInheritance is true, java now renders setters in interfaces for enums if const is not set by the classes that implements it

### DIFF
--- a/docs/migrations/version-3-to-4.md
+++ b/docs/migrations/version-3-to-4.md
@@ -321,6 +321,6 @@ type info struct {
 
 ## Java
 
-### when allowInheritance is true, Modelina now don't render the setter for enums in interfaces because the classes that implement the interface might use a constant value
+### When `allowInheritance` is true, Modelina no longer renders the setter for enums in interfaces if the enum is implemented by a class and has a constant value
 
-In Java, when a class implements an interface, it must implement all the methods of that interface. Because of that, Modelina now doesn't render the setter for enums in interfaces when allowInheritance is true because the classes that implement the interface might use a constant value.
+In Java, when a class implements an interface, it must implement all the methods of that interface. Therefore, if `allowInheritance` is set to true, Modelina will no longer render the setter for enums in interfaces if the enum is implemented by a class and has a constant value.

--- a/docs/migrations/version-3-to-4.md
+++ b/docs/migrations/version-3-to-4.md
@@ -321,6 +321,6 @@ type info struct {
 
 ## Java
 
-### When `allowInheritance` is true, Modelina no longer renders the setter for enums in interfaces if the enum is implemented by a class and has a constant value
+### When `allowInheritance` is true, Modelina no longer renders the setter for enums in interfaces if the property exist in the implemented by class with a constant value
 
-In Java, when a class implements an interface, it must implement all the methods of that interface. Therefore, if `allowInheritance` is set to true, Modelina will no longer render the setter for enums in interfaces if the enum is implemented by a class and has a constant value.
+In Java, when a class implements an interface, it must implement all the methods of that interface. Therefore, if `allowInheritance` is set to true, Modelina will no longer render the setter for enums in interfaces if the property exists in the implemented by class with a constant value.

--- a/src/generators/AbstractGenerator.ts
+++ b/src/generators/AbstractGenerator.ts
@@ -162,6 +162,28 @@ export abstract class AbstractGenerator<
     }
 
     for (const { constrainedModel } of constrainedModelsWithDepManager) {
+      if (constrainedModel.options.extend) {
+        for (const extend of constrainedModel.options.extend) {
+          const extendModel = constrainedModelsWithDepManager.find(
+            (m) => m.constrainedModel.name === extend.name
+          );
+
+          if (!extendModel) {
+            throw new Error(
+              `Could not find the model ${extend.name} to extend in the constrained models`
+            );
+          }
+
+          if (!extendModel.constrainedModel.options.implementedBy) {
+            extendModel.constrainedModel.options.implementedBy = [];
+          }
+
+          extendModel.constrainedModel.options.implementedBy.push(
+            constrainedModel
+          );
+        }
+      }
+
       for (const unionConstrainedModel of unionConstrainedModelsWithDepManager) {
         if (
           unionConstrainedModel.constrainedModel instanceof

--- a/src/generators/AbstractGenerator.ts
+++ b/src/generators/AbstractGenerator.ts
@@ -150,10 +150,10 @@ export abstract class AbstractGenerator<
   }
 
   private setParentsForModels(
-    constrainedModels: ConstrainedMetaModelWithDepManager[],
+    unionConstrainedModelsWithDepManager: ConstrainedMetaModelWithDepManager[],
     constrainedModel: ConstrainedMetaModel
   ) {
-    for (const unionConstrainedModel of constrainedModels) {
+    for (const unionConstrainedModel of unionConstrainedModelsWithDepManager) {
       if (
         unionConstrainedModel.constrainedModel instanceof
           ConstrainedUnionModel &&
@@ -219,7 +219,10 @@ export abstract class AbstractGenerator<
 
     for (const { constrainedModel } of constrainedModels) {
       this.setImplementedByForModels(constrainedModels, constrainedModel);
-      this.setParentsForModels(constrainedModels, constrainedModel);
+      this.setParentsForModels(
+        unionConstrainedModelsWithDepManager,
+        constrainedModel
+      );
     }
 
     return constrainedModels;

--- a/src/generators/java/renderers/ClassRenderer.ts
+++ b/src/generators/java/renderers/ClassRenderer.ts
@@ -165,6 +165,29 @@ export const isDiscriminatorOrDictionary = (
     property.unconstrainedPropertyName ||
   property.property instanceof ConstrainedDictionaryModel;
 
+const isEnumImplementedByConstValue = (
+  model: ConstrainedObjectModel,
+  property: ConstrainedObjectPropertyModel
+): boolean => {
+  if (!isEnum(property)) {
+    return false;
+  }
+
+  if (!model.options.implementedBy) {
+    return false;
+  }
+
+  // if the implementedBy property exist in the model options, check if the property exists in the implementedBy model and check if the property is set with a const value
+  return model.options.implementedBy.some((implementedBy) => {
+    return (
+      implementedBy instanceof ConstrainedObjectModel &&
+      implementedBy.properties[property.propertyName] &&
+      implementedBy.properties[property.propertyName].property.options.const
+        ?.value
+    );
+  });
+};
+
 export const JAVA_DEFAULT_CLASS_PRESET: ClassPresetType<JavaOptions> = {
   self({ renderer }) {
     return renderer.defaultSelf();
@@ -205,16 +228,21 @@ export const JAVA_DEFAULT_CLASS_PRESET: ClassPresetType<JavaOptions> = {
     const setterName = FormatHelpers.toPascalCase(property.propertyName);
 
     if (model.options.isExtended) {
-      // don't render setters for discriminator, dictionary properties, or enums (because they can be set to constants in the models that extend them)
-      if (isDiscriminatorOrDictionary(model, property) || isEnum(property)) {
+      // don't render setters for discriminator, dictionary properties, or enums that are not set with a const value
+      if (
+        isDiscriminatorOrDictionary(model, property) ||
+        isEnumImplementedByConstValue(model, property)
+      ) {
         return '';
       }
 
       return `public void set${setterName}(${property.property.type} ${property.propertyName});`;
     }
 
-    // don't render override for enums because enum setters in the interfaces are not rendered
-    const override = !isEnum(property) ? getOverride(model, property) : '';
+    // don't render override for enums that are not set with a const value
+    const override = !isEnumImplementedByConstValue(model, property)
+      ? getOverride(model, property)
+      : '';
 
     return `${override}public void set${setterName}(${property.property.type} ${property.propertyName}) { this.${property.propertyName} = ${property.propertyName}; }`;
   }

--- a/src/generators/java/renderers/ClassRenderer.ts
+++ b/src/generators/java/renderers/ClassRenderer.ts
@@ -228,7 +228,7 @@ export const JAVA_DEFAULT_CLASS_PRESET: ClassPresetType<JavaOptions> = {
     const setterName = FormatHelpers.toPascalCase(property.propertyName);
 
     if (model.options.isExtended) {
-      // don't render setters for discriminator, dictionary properties, or enums that are not set with a const value
+      // don't render setters for discriminator, dictionary properties, or enums that are set with a const value
       if (
         isDiscriminatorOrDictionary(model, property) ||
         isEnumImplementedByConstValue(model, property)
@@ -239,7 +239,7 @@ export const JAVA_DEFAULT_CLASS_PRESET: ClassPresetType<JavaOptions> = {
       return `public void set${setterName}(${property.property.type} ${property.propertyName});`;
     }
 
-    // don't render override for enums that are not set with a const value
+    // don't render override for enums that are set with a const value
     const override = !isEnumImplementedByConstValue(model, property)
       ? getOverride(model, property)
       : '';

--- a/src/models/ConstrainedMetaModel.ts
+++ b/src/models/ConstrainedMetaModel.ts
@@ -23,6 +23,7 @@ export class ConstrainedMetaModelOptions extends MetaModelOptions {
   discriminator?: ConstrainedMetaModelOptionsDiscriminator;
   parents?: ConstrainedMetaModel[];
   extend?: ConstrainedMetaModel[];
+  implementedBy?: ConstrainedMetaModel[];
 }
 
 export interface GetNearestDependenciesArgument {

--- a/test/generators/java/JavaGenerator.spec.ts
+++ b/test/generators/java/JavaGenerator.spec.ts
@@ -364,10 +364,10 @@ describe('JavaGenerator', () => {
                   type: 'string',
                   description: 'test'
                 },
-                sequencetype: {
+                sequence_type: {
                   title: 'CloudEvent.SequenceType',
                   type: 'string',
-                  enum: ['Integer']
+                  enum: ['Integer', 'StringTest']
                 }
               },
               required: ['id', 'type']
@@ -376,7 +376,7 @@ describe('JavaGenerator', () => {
               title: 'Test',
               type: 'object',
               properties: {
-                testEnum: {
+                test_enum: {
                   title: 'TestEnum',
                   type: 'string',
                   enum: ['FOO', 'BAR']
@@ -390,10 +390,10 @@ describe('JavaGenerator', () => {
                 {
                   type: 'object',
                   properties: {
-                    testEnum: {
+                    test_enum: {
                       const: 'FOO'
                     },
-                    testProp2: {
+                    test_string: {
                       type: 'string'
                     }
                   }

--- a/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
+++ b/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
@@ -20,9 +20,9 @@ public interface Pet {
   @NotNull
   @JsonProperty(\\"type\\")
   private final CloudEventType type = CloudEventType.DOG;
-  @JsonProperty(\\"sequencetype\\")
+  @JsonProperty(\\"sequence_type\\")
   @JsonInclude(JsonInclude.Include.NON_NULL)
-  private CloudEventDotSequenceType sequencetype;
+  private CloudEventDotSequenceType sequenceType;
   @JsonProperty(\\"data\\")
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String data;
@@ -40,8 +40,9 @@ public interface Pet {
   public CloudEventType getType() { return this.type; }
 
   @Override
-  public CloudEventDotSequenceType getSequencetype() { return this.sequencetype; }
-  public void setSequencetype(CloudEventDotSequenceType sequencetype) { this.sequencetype = sequencetype; }
+  public CloudEventDotSequenceType getSequenceType() { return this.sequenceType; }
+  @Override
+  public void setSequenceType(CloudEventDotSequenceType sequenceType) { this.sequenceType = sequenceType; }
 
   public String getData() { return this.data; }
   public void setData(String data) { this.data = data; }
@@ -64,7 +65,7 @@ public interface Pet {
       return 
         Objects.equals(this.id, self.id) &&
         Objects.equals(this.type, self.type) &&
-        Objects.equals(this.sequencetype, self.sequencetype) &&
+        Objects.equals(this.sequenceType, self.sequenceType) &&
         Objects.equals(this.data, self.data) &&
         Objects.equals(this.test, self.test) &&
         Objects.equals(this.additionalProperties, self.additionalProperties);
@@ -72,7 +73,7 @@ public interface Pet {
 
   @Override
   public int hashCode() {
-    return Objects.hash((Object)id, (Object)type, (Object)sequencetype, (Object)data, (Object)test, (Object)additionalProperties);
+    return Objects.hash((Object)id, (Object)type, (Object)sequenceType, (Object)data, (Object)test, (Object)additionalProperties);
   }
 
   @Override
@@ -80,7 +81,7 @@ public interface Pet {
     return \\"class Dog {\\\\n\\" +   
       \\"    id: \\" + toIndentedString(id) + \\"\\\\n\\" +
       \\"    type: \\" + toIndentedString(type) + \\"\\\\n\\" +
-      \\"    sequencetype: \\" + toIndentedString(sequencetype) + \\"\\\\n\\" +
+      \\"    sequenceType: \\" + toIndentedString(sequenceType) + \\"\\\\n\\" +
       \\"    data: \\" + toIndentedString(data) + \\"\\\\n\\" +
       \\"    test: \\" + toIndentedString(test) + \\"\\\\n\\" +
       \\"    additionalProperties: \\" + toIndentedString(additionalProperties) + \\"\\\\n\\" +
@@ -128,7 +129,7 @@ public interface Pet {
   }
 }",
   "public enum CloudEventDotSequenceType {
-  INTEGER((String)\\"Integer\\");
+  INTEGER((String)\\"Integer\\"), STRING_TEST((String)\\"StringTest\\");
 
   private String value;
 
@@ -157,20 +158,20 @@ public interface Pet {
   }
 }",
   "public class TestAllOf implements Test {
-  @JsonProperty(\\"testEnum\\")
+  @JsonProperty(\\"test_enum\\")
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private final TestEnum testEnum = TestEnum.FOO;
-  @JsonProperty(\\"testProp2\\")
+  @JsonProperty(\\"test_string\\")
   @JsonInclude(JsonInclude.Include.NON_NULL)
-  private String testProp2;
+  private String testString;
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Map<String, Object> additionalProperties;
 
   @Override
   public TestEnum getTestEnum() { return this.testEnum; }
 
-  public String getTestProp2() { return this.testProp2; }
-  public void setTestProp2(String testProp2) { this.testProp2 = testProp2; }
+  public String getTestString() { return this.testString; }
+  public void setTestString(String testString) { this.testString = testString; }
 
   public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
   public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
@@ -186,20 +187,20 @@ public interface Pet {
     TestAllOf self = (TestAllOf) o;
       return 
         Objects.equals(this.testEnum, self.testEnum) &&
-        Objects.equals(this.testProp2, self.testProp2) &&
+        Objects.equals(this.testString, self.testString) &&
         Objects.equals(this.additionalProperties, self.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash((Object)testEnum, (Object)testProp2, (Object)additionalProperties);
+    return Objects.hash((Object)testEnum, (Object)testString, (Object)additionalProperties);
   }
 
   @Override
   public String toString() {
     return \\"class TestAllOf {\\\\n\\" +   
       \\"    testEnum: \\" + toIndentedString(testEnum) + \\"\\\\n\\" +
-      \\"    testProp2: \\" + toIndentedString(testProp2) + \\"\\\\n\\" +
+      \\"    testString: \\" + toIndentedString(testString) + \\"\\\\n\\" +
       \\"    additionalProperties: \\" + toIndentedString(additionalProperties) + \\"\\\\n\\" +
     \\"}\\";
   }
@@ -251,7 +252,8 @@ public interface Pet {
   public String getId();
   public void setId(String id);
 
-  public CloudEventDotSequenceType getSequencetype();
+  public CloudEventDotSequenceType getSequenceType();
+  public void setSequenceType(CloudEventDotSequenceType sequenceType);
 }",
   "public class Cat implements Pet, CloudEvent {
   @NotNull
@@ -260,9 +262,9 @@ public interface Pet {
   @NotNull
   @JsonProperty(\\"type\\")
   private final CloudEventType type = CloudEventType.CAT;
-  @JsonProperty(\\"sequencetype\\")
+  @JsonProperty(\\"sequence_type\\")
   @JsonInclude(JsonInclude.Include.NON_NULL)
-  private CloudEventDotSequenceType sequencetype;
+  private CloudEventDotSequenceType sequenceType;
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Map<String, Object> additionalProperties;
 
@@ -274,8 +276,9 @@ public interface Pet {
   public CloudEventType getType() { return this.type; }
 
   @Override
-  public CloudEventDotSequenceType getSequencetype() { return this.sequencetype; }
-  public void setSequencetype(CloudEventDotSequenceType sequencetype) { this.sequencetype = sequencetype; }
+  public CloudEventDotSequenceType getSequenceType() { return this.sequenceType; }
+  @Override
+  public void setSequenceType(CloudEventDotSequenceType sequenceType) { this.sequenceType = sequenceType; }
 
   public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
   public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
@@ -292,13 +295,13 @@ public interface Pet {
       return 
         Objects.equals(this.id, self.id) &&
         Objects.equals(this.type, self.type) &&
-        Objects.equals(this.sequencetype, self.sequencetype) &&
+        Objects.equals(this.sequenceType, self.sequenceType) &&
         Objects.equals(this.additionalProperties, self.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash((Object)id, (Object)type, (Object)sequencetype, (Object)additionalProperties);
+    return Objects.hash((Object)id, (Object)type, (Object)sequenceType, (Object)additionalProperties);
   }
 
   @Override
@@ -306,7 +309,7 @@ public interface Pet {
     return \\"class Cat {\\\\n\\" +   
       \\"    id: \\" + toIndentedString(id) + \\"\\\\n\\" +
       \\"    type: \\" + toIndentedString(type) + \\"\\\\n\\" +
-      \\"    sequencetype: \\" + toIndentedString(sequencetype) + \\"\\\\n\\" +
+      \\"    sequenceType: \\" + toIndentedString(sequenceType) + \\"\\\\n\\" +
       \\"    additionalProperties: \\" + toIndentedString(additionalProperties) + \\"\\\\n\\" +
     \\"}\\";
   }


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes introduced by this pull request. -->

#2068 introduced some breaking changes for the Java code that Java users didn't like. They want setters when they can exist, and this fixes that.

In Java, when a class implements an interface, it must implement all the methods of that interface. Therefore, if `allowInheritance` is set to true, Modelina will no longer render the setter for enums in interfaces if the property exists in the implemented by class with a constant value.


## Related Issue
<!-- If this pull request is related to any existing issue, mention it here. -->

## Checklist
- [x] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [x] Tests have been added or updated to cover the changes.
- [x] Documentation has been updated to reflect the changes.
- [x] All tests pass successfully locally.(`npm run test`).

## Additional Notes
<!-- Add any additional information or context that might be relevant to reviewers. -->
Fixes #2068
