### PR TITLE
fix!: dont render override when the setter doesnt exist in the interface

### DIFF
--- a/src/generators/java/renderers/ClassRenderer.ts
+++ b/src/generators/java/renderers/ClassRenderer.ts
@@ -188,6 +188,28 @@ const isEnumImplementedByConstValue = (
   });
 };
 
+const isEnumOrEnumInExtended = (
+  model: ConstrainedObjectModel,
+  property: ConstrainedObjectPropertyModel
+): boolean => {
+  if (!isEnum(property)) {
+    return false;
+  }
+
+  if (!model.options.extend) {
+    return false;
+  }
+
+  return model.options.extend.some((extend) => {
+    return (
+      extend instanceof ConstrainedReferenceModel &&
+      extend.ref instanceof ConstrainedObjectModel &&
+      extend.ref.properties[property.propertyName] &&
+      isEnum(extend.ref.properties[property.propertyName])
+    );
+  });
+};
+
 export const JAVA_DEFAULT_CLASS_PRESET: ClassPresetType<JavaOptions> = {
   self({ renderer }) {
     return renderer.defaultSelf();
@@ -240,7 +262,7 @@ export const JAVA_DEFAULT_CLASS_PRESET: ClassPresetType<JavaOptions> = {
     }
 
     // don't render override for enums that are set with a const value
-    const override = !isEnumImplementedByConstValue(model, property)
+    const override = !isEnumOrEnumInExtended(model, property)
       ? getOverride(model, property)
       : '';
 

--- a/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
+++ b/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
@@ -41,7 +41,6 @@ public interface Pet {
 
   @Override
   public CloudEventDotSequenceType getSequenceType() { return this.sequenceType; }
-  @Override
   public void setSequenceType(CloudEventDotSequenceType sequenceType) { this.sequenceType = sequenceType; }
 
   public String getData() { return this.data; }
@@ -277,7 +276,6 @@ public interface Pet {
 
   @Override
   public CloudEventDotSequenceType getSequenceType() { return this.sequenceType; }
-  @Override
   public void setSequenceType(CloudEventDotSequenceType sequenceType) { this.sequenceType = sequenceType; }
 
   public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes introduced by this pull request. -->
#2096 introduced a compile error bug in some cases, and this PR fixes that.

## Related Issue
<!-- If this pull request is related to any existing issue, mention it here. -->

## Checklist
- [x] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [x] Tests have been added or updated to cover the changes.
- [x] Documentation has been updated to reflect the changes.
- [x] All tests pass successfully locally.(`npm run test`).

## Additional Notes
<!-- Add any additional information or context that might be relevant to reviewers. -->
Fixes #2096
