### PR TITLE
fix: remove duplicate import keyword in Kotlin generator example

### DIFF
--- a/modelina-website/src/helpers/GeneratorCode/KotlinGenerator.ts
+++ b/modelina-website/src/helpers/GeneratorCode/KotlinGenerator.ts
@@ -15,7 +15,7 @@ export function getKotlinGeneratorCode(generatorOptions: ModelinaKotlinOptions) 
     optionString.push(`typeMapping: {
   Integer: ({ dependencyManager, constrainedModel, options, partOfProperty }) => {
     // Add custom dependency for your type if required.
-    dependencyManager.addDependency('import kotlinx.datetime.*');
+    dependencyManager.addDependency('kotlinx.datetime.*');
 
     //Return the type for the integer model
     return 'LocalDate';


### PR DESCRIPTION
## Description
When using showTypeMappingExample in the Kotlin generator, the example code includes a import keyword in the dependency string which causes the generated code to have an invalid double import statement.

## Related Issue
fixes https://github.com/asyncapi/modelina/issues/2107

## Checklist
- [✅] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [✅] All tests pass successfully locally.(`npm run test`).
