### PR TITLE
feat golang: enabled and fixed data tags, added comments from logs, added -i flag

### DIFF
--- a/modelina-cli/src/commands/generate.ts
+++ b/modelina-cli/src/commands/generate.ts
@@ -16,13 +16,18 @@ export default class Models extends ModelinaCommand {
     } catch {
       if (flags.input) {
         try {
-          document = await readFile(flags.input ? flags.input : "", 'utf8');
+          let fname = ""
+          if (flags.input) {
+            fname = flags.input
+          }
+
+          document = await readFile(fname, 'utf8');
         } catch {
-          throw new Error('Unable to read input file content: "' + flags.input + '"');
+          throw new Error(`Unable to read input file content: ${flags.input}`);
         }
       }
       else {
-        throw new Error('Unable to read input file content: "' + file + '"');
+        throw new Error(`Unable to read input file content: ${file}`);
       }
     }
 

--- a/modelina-cli/src/commands/generate.ts
+++ b/modelina-cli/src/commands/generate.ts
@@ -14,9 +14,18 @@ export default class Models extends ModelinaCommand {
     try {
       document = await readFile(file, 'utf8');
     } catch {
-      throw new Error('Unable to read input file content.');
+      if (flags.input) {
+        try {
+          document = await readFile(flags.input ? flags.input : "", 'utf8');
+        } catch {
+          throw new Error('Unable to read input file content: "' + flags.input + '"');
+        }
+      }
+      else {
+        throw new Error('Unable to read input file content: "' + file + '"');
+      }
     }
-    
+
     const logger = {
       info: (message: string) => {
         this.log(message);

--- a/modelina-cli/src/helpers/generate.ts
+++ b/modelina-cli/src/helpers/generate.ts
@@ -60,6 +60,11 @@ export const ModelinaFlags = {
     description: 'The output directory where the models should be written to. Omitting this flag will write the models to `stdout`.',
     required: false
   }),
+  input: Flags.string({
+    char: 'i',
+    description: 'The input file with the API definition.',
+    required: false
+  }),
   /**
    * Go and Java specific package name to use for the generated models
    */

--- a/modelina-cli/src/helpers/go.ts
+++ b/modelina-cli/src/helpers/go.ts
@@ -22,6 +22,7 @@ export function buildGoGenerator(flags: any): BuilderReturnType {
   if (packageName === undefined) {
     throw new Error('In order to generate models to Go, we need to know which package they are under. Add `--packageName=PACKAGENAME` to set the desired package name.');
   }
+
   const presets = []
   const options: GoCommonPresetOptions = { addJsonTag: true };
   presets.push({ preset: GO_COMMON_PRESET, options })

--- a/modelina-cli/src/helpers/go.ts
+++ b/modelina-cli/src/helpers/go.ts
@@ -1,7 +1,14 @@
-import { GoFileGenerator } from "@asyncapi/modelina";
+import { GO_DESCRIPTION_PRESET, GoFileGenerator } from "@asyncapi/modelina";
 import { BuilderReturnType } from "./generate";
+import { Flags } from "@oclif/core";
 
-export const GoOclifFlags = { }
+export const GoOclifFlags = {
+  goIncludeComments: Flags.boolean({
+    description: 'Golang specific, if enabled add comments while generating models.',
+    required: false,
+    default: false,
+  }),
+}
 
 /**
  * This function builds all the relevant information for the main generate command
@@ -10,13 +17,14 @@ export const GoOclifFlags = { }
  * @returns 
  */
 export function buildGoGenerator(flags: any): BuilderReturnType {
-  const { packageName } = flags;
-  
+  const { packageName, goIncludeComments } = flags;
+
   if (packageName === undefined) {
     throw new Error('In order to generate models to Go, we need to know which package they are under. Add `--packageName=PACKAGENAME` to set the desired package name.');
   }
-
-  const fileGenerator = new GoFileGenerator();
+  const presets = []
+  if (goIncludeComments) { presets.push(GO_DESCRIPTION_PRESET); }
+  const fileGenerator = new GoFileGenerator({ presets });
   const fileOptions = {
     packageName
   };

--- a/modelina-cli/src/helpers/go.ts
+++ b/modelina-cli/src/helpers/go.ts
@@ -1,4 +1,4 @@
-import { GO_DESCRIPTION_PRESET, GoFileGenerator } from "@asyncapi/modelina";
+import { GO_DESCRIPTION_PRESET, GO_COMMON_PRESET, GoCommonPresetOptions, GoFileGenerator } from "@asyncapi/modelina";
 import { BuilderReturnType } from "./generate";
 import { Flags } from "@oclif/core";
 
@@ -23,6 +23,8 @@ export function buildGoGenerator(flags: any): BuilderReturnType {
     throw new Error('In order to generate models to Go, we need to know which package they are under. Add `--packageName=PACKAGENAME` to set the desired package name.');
   }
   const presets = []
+  const options: GoCommonPresetOptions = { addJsonTag: true };
+  presets.push({ preset: GO_COMMON_PRESET, options })
   if (goIncludeComments) { presets.push(GO_DESCRIPTION_PRESET); }
   const fileGenerator = new GoFileGenerator({ presets });
   const fileOptions = {

--- a/src/generators/go/presets/CommonPreset.ts
+++ b/src/generators/go/presets/CommonPreset.ts
@@ -21,6 +21,9 @@ function renderJSONTag({
   ) {
     return `json:"-,omitempty"`;
   }
+  if (field.required) {
+    return `json:"${field.unconstrainedPropertyName}" binding:"required"`;
+  }
   return `json:"${field.unconstrainedPropertyName},omitempty"`;
 }
 

--- a/src/generators/go/presets/DescriptionPreset.ts
+++ b/src/generators/go/presets/DescriptionPreset.ts
@@ -1,0 +1,40 @@
+import { ConstrainedMetaModel } from '../../../models';
+import { GoPreset } from '../GoPreset';
+import { GoRenderer } from '../GoRenderer';
+
+const renderDescription = ({
+  renderer,
+  content,
+  item
+}: {
+  renderer: GoRenderer<ConstrainedMetaModel>;
+  content: string;
+  item: ConstrainedMetaModel;
+}): string => {
+
+  const desc = item.originalInput.description?.trim();
+  const formattedDesc = desc ? renderer.renderComments(desc) + '\n' : '';
+  return formattedDesc + content;
+};
+
+/**
+ * Preset which adds descriptions
+ *
+ * @implements {GoPreset}
+ */
+export const GO_DESCRIPTION_PRESET: GoPreset = {
+
+  struct: {
+    self({ renderer, model, content }) {
+      return renderDescription({ renderer, content, item: model });
+    },
+    field({ renderer, field, content }) {
+      return renderDescription({ renderer, content, item: field.property });
+    }
+  },
+  enum: {
+    self({ renderer, model, content }) {
+      return renderDescription({ renderer, content, item: model });
+    }
+  }
+};

--- a/src/generators/go/presets/DescriptionPreset.ts
+++ b/src/generators/go/presets/DescriptionPreset.ts
@@ -11,9 +11,12 @@ const renderDescription = ({
   content: string;
   item: ConstrainedMetaModel;
 }): string => {
-
   const desc = item.originalInput.description?.trim();
-  const formattedDesc = desc ? renderer.renderComments(desc) + '\n' : '';
+  let formattedDesc = '';
+  if (desc) {
+    formattedDesc = renderer.renderComments(desc);
+    formattedDesc += '\n';
+  }
   return formattedDesc + content;
 };
 
@@ -23,7 +26,6 @@ const renderDescription = ({
  * @implements {GoPreset}
  */
 export const GO_DESCRIPTION_PRESET: GoPreset = {
-
   struct: {
     self({ renderer, model, content }) {
       return renderDescription({ renderer, content, item: model });

--- a/src/generators/go/presets/index.ts
+++ b/src/generators/go/presets/index.ts
@@ -1,1 +1,2 @@
 export * from './CommonPreset';
+export * from './DescriptionPreset';

--- a/src/generators/go/renderers/EnumRenderer.ts
+++ b/src/generators/go/renderers/EnumRenderer.ts
@@ -16,7 +16,7 @@ import { GoOptions } from '../GoGenerator';
  */
 export class EnumRenderer extends GoRenderer<ConstrainedEnumModel> {
   public async defaultSelf(): Promise<string> {
-    const doc = this.renderCommentForEnumType(this.model.name, this.model.type);
+    const doc = '';
     const enumValues = await this.renderItems();
     const valuesToEnumMap = this.model.values.map((value) => {
       return `${this.model.name}Values[${value.key}]: ${value.key},`;

--- a/src/generators/go/renderers/StructRenderer.ts
+++ b/src/generators/go/renderers/StructRenderer.ts
@@ -34,13 +34,12 @@ export class StructRenderer extends GoRenderer<ConstrainedObjectModel> {
     return `${doc}
 type ${this.model.name} struct {
 ${this.indent(this.renderBlock(content, 2))}
-}${
-      discriminator &&
+}${discriminator &&
       `
 
 ${discriminator}
 `
-    }`;
+      }`;
   }
 
   async renderFields(): Promise<string> {
@@ -78,11 +77,7 @@ export const GO_DEFAULT_STRUCT_PRESET: StructPresetType<GoOptions> = {
     ) {
       fieldType = `*${fieldType}`;
     }
-    const jsonTag = field.required
-      ? `\`json:"${field.unconstrainedPropertyName},required"\``
-      : `\`json:"${field.unconstrainedPropertyName},omitempty"\``;
-
-    return `${field.propertyName} ${fieldType} ${jsonTag}`;
+    return `${field.propertyName} ${fieldType}`;
   },
   discriminator({ model }) {
     const { parents } = model.options;

--- a/src/generators/go/renderers/StructRenderer.ts
+++ b/src/generators/go/renderers/StructRenderer.ts
@@ -20,13 +20,8 @@ export class StructRenderer extends GoRenderer<ConstrainedObjectModel> {
       await this.renderFields(),
       await this.runAdditionalContentPreset()
     ];
-
-    const doc = this.renderComments(
-      `${this.model.name} represents a ${this.model.name} model.`
-    );
-
+    const doc = '';
     let discriminator = '';
-
     if (this.model.options.parents?.length) {
       discriminator = await this.runDiscriminatorFuncPreset();
     }

--- a/src/generators/go/renderers/StructRenderer.ts
+++ b/src/generators/go/renderers/StructRenderer.ts
@@ -78,7 +78,11 @@ export const GO_DEFAULT_STRUCT_PRESET: StructPresetType<GoOptions> = {
     ) {
       fieldType = `*${fieldType}`;
     }
-    return `${field.propertyName} ${fieldType}`;
+    const jsonTag = field.required
+      ? `\`json:"${field.unconstrainedPropertyName},required"\``
+      : `\`json:"${field.unconstrainedPropertyName},omitempty"\``;
+
+    return `${field.propertyName} ${fieldType} ${jsonTag}`;
   },
   discriminator({ model }) {
     const { parents } = model.options;

--- a/src/generators/go/renderers/StructRenderer.ts
+++ b/src/generators/go/renderers/StructRenderer.ts
@@ -27,13 +27,13 @@ export class StructRenderer extends GoRenderer<ConstrainedObjectModel> {
     }
 
     return `${doc}
-type ${this.model.name} struct {
-${this.indent(this.renderBlock(content, 2))}
-}${discriminator &&
+    type ${this.model.name} struct {
+    ${this.indent(this.renderBlock(content, 2))}
+    }${discriminator &&
       `
-
-${discriminator}
-`
+    
+    ${discriminator}
+    `
       }`;
   }
 

--- a/src/generators/go/renderers/UnionRenderer.ts
+++ b/src/generators/go/renderers/UnionRenderer.ts
@@ -28,10 +28,7 @@ const unionIncludesDiscriminator = (model: ConstrainedUnionModel): boolean => {
  */
 export class UnionRenderer extends GoRenderer<ConstrainedUnionModel> {
   public async defaultSelf(): Promise<string> {
-    const doc = this.renderComments(
-      `${this.model.name} represents a ${this.model.name} model.`
-    );
-
+    const doc = '';
     if (unionIncludesDiscriminator(this.model)) {
       const content: string[] = [await this.runDiscriminatorAccessorPreset()];
 


### PR DESCRIPTION
## Description
Anyway, I've managed to fix the Golang generator: I added comments from descriptions, enabled them in the Go helper, fixed the data tags by adding "required", added a flag to include comments in Go, and included the description preset in modelina-cli. I'm not sure why, but modelina-cli refused to accept the file parameter from the command line (even after packing it into a tarball), so I had to add an optional -i flag to specify the input path.


## Related Issue
[FEATURE] Golang generator should include comments from parameter descriptions #2116

## Checklist
- [ ] The code follows the project's coding standards and is properly linted (`npm run lint`): yes, but two prettier issues are in conflict with default vscode ts formatter, so I left as is.
- [ ] Tests have been added or updated to cover the changes: not yet
- [ ] Documentation has been updated to reflect the changes: yes
- [ ] All tests pass successfully locally.(`npm run test`): not yet 

## Additional Notes

I haven't been able to build the CLI correctly yet: it can't use the modelina library directly from the source (or via npm link). Therefore, I had to run npm run build:prod for modelina, copy its lib folder to the modelina-cli node_modules directory (after the initial npm install), and only then was I able to build modelina-cli and run it. Any advice on how to do this correctly would be appreciated. For now, I'll create a PR just for you to take a look.
