### PR TITLE
feat: add support for typed array unmarshalling in TypeScript

### DIFF
--- a/src/generators/typescript/presets/utils/UnmarshalFunction.ts
+++ b/src/generators/typescript/presets/utils/UnmarshalFunction.ts
@@ -1,12 +1,14 @@
 import { ClassRenderer } from '../../renderers/ClassRenderer';
 import { getDictionary, getNormalProperties } from '../../../../helpers';
 import {
+  ConstrainedArrayModel,
   ConstrainedDictionaryModel,
   ConstrainedEnumModel,
   ConstrainedMetaModel,
   ConstrainedObjectModel,
   ConstrainedObjectPropertyModel,
-  ConstrainedReferenceModel
+  ConstrainedReferenceModel,
+  ConstrainedUnionModel
 } from '../../../../models';
 
 /**
@@ -22,6 +24,16 @@ function renderUnmarshalProperty(
   ) {
     return `${model.type}.unmarshal(${modelInstanceVariable})`;
   }
+
+  if (
+    model instanceof ConstrainedArrayModel &&
+    !(model.valueModel instanceof ConstrainedUnionModel)
+  ) {
+    return `${modelInstanceVariable} == null
+    ? null
+    : ${modelInstanceVariable}.map((item: any) => ${model.valueModel.type}.unmarshal(item))`;
+  }
+
   return `${modelInstanceVariable}`;
 }
 

--- a/test/generators/typescript/preset/__snapshots__/MarshallingPreset.spec.ts.snap
+++ b/test/generators/typescript/preset/__snapshots__/MarshallingPreset.spec.ts.snap
@@ -158,7 +158,9 @@ exports[`Marshalling preset should render un/marshal code 1`] = `
       instance.unionArrayTest = obj[\\"unionArrayTest\\"];
     }
     if (obj[\\"arrayTest\\"] !== undefined) {
-      instance.arrayTest = obj[\\"arrayTest\\"];
+      instance.arrayTest = obj[\\"arrayTest\\"] == null
+        ? null
+        : obj[\\"arrayTest\\"].map((item: any) => NestedTest.unmarshal(item));
     }
     if (obj[\\"tupleTest\\"] !== undefined) {
       instance.tupleTest = obj[\\"tupleTest\\"];


### PR DESCRIPTION
## Description

This PR adds support for properly unmarshalling array types, when using the TypeScript generator. Previously, the JSON array was being passed straight into the resulting object, which causes issues when using the value in another schema object and marshalling that object. The other object expects the array to contain full objects with a callable `marshal` function, not a plain object, giving an error like:

```
err: {
      "type": "TypeError",
      "message": "unionItem.marshal is not a function",
      "stack":
          TypeError: unionItem.marshal is not a function
              at KeywordSearchRequest.marshal
...
```
### Example

Given a type like this:

```yaml
arrayProperty:
  type: array
  items:
    $ref: "#/definitions/SomeObjectType"
```

The generator will now generate unmarshalling code like this:

```typescript
...
instance.arrayProperty = obj["arrayProperty"] == null
  ? null
  : obj["arrayProperty"].map((item: any) => SomeObjectType.unmarshal(item));
```

## Related Issue
<!-- If this pull request is related to any existing issue, mention it here. -->

## Checklist
- [x] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [x] Tests have been added or updated to cover the changes.
- [ ] Documentation has been updated to reflect the changes.
- [] All tests pass successfully locally.(`npm run test`).

## Additional Notes

The tests don't seem to pass even before my changes. I have updated the existing snapshot to cater for this change, and that test runs successfully.
