### PR TITLE
fix: remove store link from the website footer

### DIFF
--- a/modelina-website/src/components/layouts/Footer.tsx
+++ b/modelina-website/src/components/layouts/Footer.tsx
@@ -53,16 +53,6 @@ export default function Footer() {
                     </Link>
                   </li>
                   <li className='py-2'>
-                    <a
-                      href='https://www.store.asyncapi.com/collections/all-products'
-                      target='_blank'
-                      rel='noopener noreferrer'
-                      className='text-base leading-6 text-gray-500 transition duration-300 ease-in-out hover:text-white'
-                    >
-                      Shop
-                    </a>
-                  </li>
-                  <li className='py-2'>
                     <Link
                       href='/jobs'
                       className='text-base leading-6 text-cool-gray transition duration-300 ease-in-out hover:text-white'


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes introduced by this pull request. -->
The shop was no longer up and they wanted to remove its link from the footer. Which is what was done in this PR.

## Related Issue
<!-- If this pull request is related to any existing issue, mention it here. -->
Closes #2166 

## Checklist
- [ ] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [ ] Tests have been added or updated to cover the changes.
- [ ] Documentation has been updated to reflect the changes.
- [ ] All tests pass successfully locally.(`npm run test`).

## Additional Notes
<!-- Add any additional information or context that might be relevant to reviewers. -->
