### PR TITLE
fix: add missing Java import for `@Valid` annotation

### DIFF
--- a/src/generators/java/presets/ConstraintsPreset.ts
+++ b/src/generators/java/presets/ConstraintsPreset.ts
@@ -25,6 +25,9 @@ export const JAVA_CONSTRAINTS_PRESET: JavaPreset<JavaConstraintsPresetOptions> =
         renderer.dependencyManager.addDependency(
           `import ${importFrom}.validation.constraints.*;`
         );
+        renderer.dependencyManager.addDependency(
+          `import ${importFrom}.validation.Valid;`
+        );
         return content;
       },
       // eslint-disable-next-line sonarjs/cognitive-complexity

--- a/test/generators/java/presets/ConstraintsPreset.spec.ts
+++ b/test/generators/java/presets/ConstraintsPreset.spec.ts
@@ -24,7 +24,8 @@ describe('JAVA_CONSTRAINTS_PRESET', () => {
     const generator = new JavaGenerator({ presets: [JAVA_CONSTRAINTS_PRESET] });
     const expectedDependencies = [
       'import java.util.Map;',
-      'import javax.validation.constraints.*;'
+      'import javax.validation.constraints.*;',
+      'import javax.validation.Valid;'
     ];
 
     const models = await generator.generate(doc);
@@ -46,7 +47,8 @@ describe('JAVA_CONSTRAINTS_PRESET', () => {
     });
     const expectedDependencies = [
       'import java.util.Map;',
-      'import javax.validation.constraints.*;'
+      'import javax.validation.constraints.*;',
+      'import javax.validation.Valid;'
     ];
 
     const models = await generator.generate(doc);
@@ -68,7 +70,8 @@ describe('JAVA_CONSTRAINTS_PRESET', () => {
     });
     const expectedDependencies = [
       'import java.util.Map;',
-      'import jakarta.validation.constraints.*;'
+      'import jakarta.validation.constraints.*;',
+      'import jakarta.validation.Valid;'
     ];
 
     const models = await generator.generate(doc);


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes introduced by this pull request. -->
- Add missing annotation
- Update tests

## Related Issue
<!-- If this pull request is related to any existing issue, mention it here. -->
#2175

## Checklist
- [x] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [x] Tests have been added or updated to cover the changes.
- [x] Documentation has been updated to reflect the changes.
- [x] All tests pass successfully locally.(`npm run test`).

## Additional Notes
<!-- Add any additional information or context that might be relevant to reviewers. -->
Sorry, just noticed that I have missed to add the import in #2176 (made with my work account).