### PR TITLE
fix: description preset for any types

### DIFF
--- a/src/helpers/CommonModelToMetaModel.ts
+++ b/src/helpers/CommonModelToMetaModel.ts
@@ -359,9 +359,19 @@ export function convertToAnyModel(
   if (!Array.isArray(jsonSchemaModel.type) || !isAnyType) {
     return undefined;
   }
+  let originalInput = jsonSchemaModel.originalInput;
+  if (typeof jsonSchemaModel.originalInput !== 'object') {
+    originalInput = {
+      value: jsonSchemaModel.originalInput,
+      ...(jsonSchemaModel.originalInput?.description !== undefined && {
+        description: jsonSchemaModel.originalInput.description
+      })
+    };
+  }
+
   return new AnyModel(
     name,
-    jsonSchemaModel.originalInput,
+    originalInput,
     getMetaModelOptions(jsonSchemaModel, options)
   );
 }
@@ -519,9 +529,17 @@ export function convertToDictionaryModel(
     getOriginalInputFromAdditionalAndPatterns(jsonSchemaModel);
   const keyModel = new StringModel(name, originalInput, {});
   const valueModel = convertAdditionalAndPatterns(context);
+
+  const input = {
+    originalInput,
+    ...(jsonSchemaModel.originalInput?.description !== undefined && {
+      description: jsonSchemaModel.originalInput.description
+    })
+  };
+
   return new DictionaryModel(
     name,
-    originalInput,
+    input,
     getMetaModelOptions(jsonSchemaModel, options),
     keyModel,
     valueModel,
@@ -610,6 +628,7 @@ export function convertToObjectModel(
     );
     metaModel.properties[String(propertyName)] = propertyModel;
   }
+  // console.log(metaModel);
   return metaModel;
 }
 

--- a/src/helpers/CommonModelToMetaModel.ts
+++ b/src/helpers/CommonModelToMetaModel.ts
@@ -628,7 +628,6 @@ export function convertToObjectModel(
     );
     metaModel.properties[String(propertyName)] = propertyModel;
   }
-  // console.log(metaModel);
   return metaModel;
 }
 

--- a/test/generators/go/presets/DescriptionPreset.spec.ts
+++ b/test/generators/go/presets/DescriptionPreset.spec.ts
@@ -17,6 +17,12 @@ const doc = {
       additionalProperties: false,
       $id: 'NestedTest',
       properties: { stringProp: { type: 'string', description: 'string prop' } }
+    },
+    anyProp: {
+      type: 'object',
+      $id: 'AnyTest',
+      properties: {},
+      description: 'AnyTest description'
     }
   }
 };

--- a/test/generators/go/presets/__snapshots__/DescriptionPreset.spec.ts.snap
+++ b/test/generators/go/presets/__snapshots__/DescriptionPreset.spec.ts.snap
@@ -7,6 +7,8 @@ type Test struct {
   // Description
   NumberProp float64
   ObjectProp *NestedTest
+  // AnyTest description
+  AnyProp map[string]interface{}
 }"
 `;
 

--- a/test/generators/java/presets/DescriptionPreset.spec.ts
+++ b/test/generators/java/presets/DescriptionPreset.spec.ts
@@ -20,6 +20,12 @@ describe('JAVA_DESCRIPTION_PRESET', () => {
           type: 'string',
           description: 'Description for prop',
           examples: ['exampleValue']
+        },
+        anyProp: {
+          type: 'object',
+          $id: 'AnyTest',
+          properties: {},
+          description: 'AnyTest description'
         }
       }
     };

--- a/test/generators/java/presets/__snapshots__/DescriptionPreset.spec.ts.snap
+++ b/test/generators/java/presets/__snapshots__/DescriptionPreset.spec.ts.snap
@@ -66,6 +66,7 @@ exports[`JAVA_DESCRIPTION_PRESET should render description and examples for clas
  */
 public class Clazz {
   private String prop;
+  private Map<String, Object> anyProp;
   private Map<String, Object> additionalProperties;
 
   /**
@@ -74,6 +75,12 @@ public class Clazz {
    */
   public String getProp() { return this.prop; }
   public void setProp(String prop) { this.prop = prop; }
+
+  /**
+   * AnyTest description
+   */
+  public Map<String, Object> getAnyProp() { return this.anyProp; }
+  public void setAnyProp(Map<String, Object> anyProp) { this.anyProp = anyProp; }
 
   public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
   public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }

--- a/test/generators/kotlin/presets/DescriptionPreset.spec.ts
+++ b/test/generators/kotlin/presets/DescriptionPreset.spec.ts
@@ -20,6 +20,12 @@ describe('KOTLIN_DESCRIPTION_PRESET', () => {
           type: 'string',
           description: 'Description for prop',
           examples: ['exampleValue']
+        },
+        anyProp: {
+          type: 'object',
+          $id: 'AnyTest',
+          properties: {},
+          description: 'AnyTest description'
         }
       }
     };

--- a/test/generators/kotlin/presets/__snapshots__/DescriptionPreset.spec.ts.snap
+++ b/test/generators/kotlin/presets/__snapshots__/DescriptionPreset.spec.ts.snap
@@ -5,6 +5,7 @@ exports[`KOTLIN_DESCRIPTION_PRESET should render description and examples for cl
  * Description for class
  * 
  * @property prop Description for prop
+ * @property anyProp AnyTest description
  * @property additionalProperties
  * 
  * Examples: 
@@ -12,6 +13,7 @@ exports[`KOTLIN_DESCRIPTION_PRESET should render description and examples for cl
  */
 data class Clazz(
     val prop: String? = null,
+    val anyProp: Map<String, Any>? = null,
     val additionalProperties: Map<String, Any>? = null,
 )"
 `;

--- a/test/generators/php/presets/DescriptionPreset.spec.ts
+++ b/test/generators/php/presets/DescriptionPreset.spec.ts
@@ -22,6 +22,12 @@ describe('PHP_DESCRIPTION_PRESET', () => {
           type: 'string',
           description: 'Description for prop',
           examples: ['exampleValue']
+        },
+        anyProp: {
+          type: 'object',
+          $id: 'AnyTest',
+          properties: {},
+          description: 'AnyTest description'
         }
       }
     };

--- a/test/generators/php/presets/__snapshots__/DescriptionPreset.spec.ts.snap
+++ b/test/generators/php/presets/__snapshots__/DescriptionPreset.spec.ts.snap
@@ -7,10 +7,14 @@ exports[`PHP_DESCRIPTION_PRESET should render description and examples for class
 final class Clazz
 {
   private ?string $prop;
+  private mixed $anyProp;
   private mixed $additionalProperties;
 
   public function getProp(): ?string { return $this->prop; }
   public function setProp(?string $prop): void { $this->prop = $prop; }
+
+  public function getAnyProp(): mixed { return $this->anyProp; }
+  public function setAnyProp(mixed $anyProp): void { $this->anyProp = $anyProp; }
 
   public function getAdditionalProperties(): mixed { return $this->additionalProperties; }
   public function setAdditionalProperties(mixed $additionalProperties): void { $this->additionalProperties = $additionalProperties; }

--- a/test/generators/scala/presets/DescriptionPreset.spec.ts
+++ b/test/generators/scala/presets/DescriptionPreset.spec.ts
@@ -20,6 +20,12 @@ describe('SCALA_DESCRIPTION_PRESET', () => {
           type: 'string',
           description: 'Description for prop',
           examples: ['exampleValue']
+        },
+        anyProp: {
+          type: 'object',
+          $id: 'AnyTest',
+          properties: {},
+          description: 'AnyTest description'
         }
       }
     };

--- a/test/generators/scala/presets/__snapshots__/DescriptionPreset.spec.ts.snap
+++ b/test/generators/scala/presets/__snapshots__/DescriptionPreset.spec.ts.snap
@@ -5,6 +5,7 @@ exports[`SCALA_DESCRIPTION_PRESET should render description and examples for cla
  * Description for class
  * 
  * @property prop Description for prop
+ * @property anyProp AnyTest description
  * @property additionalProperties
  * 
  * Examples: 
@@ -12,6 +13,7 @@ exports[`SCALA_DESCRIPTION_PRESET should render description and examples for cla
  */
 case class Clazz(
   prop: Option[String],
+  anyProp: Option[Map[String, Any]],
   additionalProperties: Option[Map[String, Any]],
 )"
 `;

--- a/test/generators/typescript/preset/DescriptionPreset.spec.ts
+++ b/test/generators/typescript/preset/DescriptionPreset.spec.ts
@@ -18,6 +18,12 @@ const doc = {
       $id: 'NestedTest',
       properties: { stringProp: { type: 'string' } },
       examples: ['Example 1', 'Example 2']
+    },
+    anyProp: {
+      type: 'object',
+      $id: 'AnyTest',
+      properties: {},
+      description: 'AnyTest description'
     }
   }
 };

--- a/test/generators/typescript/preset/__snapshots__/DescriptionPreset.spec.ts.snap
+++ b/test/generators/typescript/preset/__snapshots__/DescriptionPreset.spec.ts.snap
@@ -8,17 +8,20 @@ class Test {
   private _stringProp: string;
   private _numberProp?: number;
   private _objectProp?: NestedTest;
+  private _anyProp?: Map<string, any>;
   private _additionalProperties?: Map<string, any>;
 
   constructor(input: {
     stringProp: string,
     numberProp?: number,
     objectProp?: NestedTest,
+    anyProp?: Map<string, any>,
     additionalProperties?: Map<string, any>,
   }) {
     this._stringProp = input.stringProp;
     this._numberProp = input.numberProp;
     this._objectProp = input.objectProp;
+    this._anyProp = input.anyProp;
     this._additionalProperties = input.additionalProperties;
   }
 
@@ -37,6 +40,12 @@ class Test {
    */
   get objectProp(): NestedTest | undefined { return this._objectProp; }
   set objectProp(objectProp: NestedTest | undefined) { this._objectProp = objectProp; }
+
+  /**
+   * AnyTest description
+   */
+  get anyProp(): Map<string, any> | undefined { return this._anyProp; }
+  set anyProp(anyProp: Map<string, any> | undefined) { this._anyProp = anyProp; }
 
   get additionalProperties(): Map<string, any> | undefined { return this._additionalProperties; }
   set additionalProperties(additionalProperties: Map<string, any> | undefined) { this._additionalProperties = additionalProperties; }

--- a/test/processors/__snapshots__/AsyncAPIInputProcessor.spec.ts.snap
+++ b/test/processors/__snapshots__/AsyncAPIInputProcessor.spec.ts.snap
@@ -52,7 +52,9 @@ Object {
             "options": Object {
               "isNullable": true,
             },
-            "originalInput": true,
+            "originalInput": Object {
+              "value": true,
+            },
           },
         },
         "propertyName": "additionalProperties",
@@ -149,7 +151,9 @@ Object {
             "options": Object {
               "isNullable": true,
             },
-            "originalInput": true,
+            "originalInput": Object {
+              "value": true,
+            },
           },
         },
         "propertyName": "additionalProperties",
@@ -4265,7 +4269,9 @@ InputMetaModel {
               "options": Object {
                 "isNullable": true,
               },
-              "originalInput": true,
+              "originalInput": Object {
+                "value": true,
+              },
             },
           },
           "propertyName": "additionalProperties",
@@ -4438,7 +4444,9 @@ InputMetaModel {
               "options": Object {
                 "isNullable": true,
               },
-              "originalInput": true,
+              "originalInput": Object {
+                "value": true,
+              },
             },
           },
           "propertyName": "additionalProperties",
@@ -4611,7 +4619,9 @@ InputMetaModel {
               "options": Object {
                 "isNullable": true,
               },
-              "originalInput": true,
+              "originalInput": Object {
+                "value": true,
+              },
             },
           },
           "propertyName": "additionalProperties",


### PR DESCRIPTION
## Description
When a spec has a property that defines an open object like:
```
anyProp: {
      type: 'object',
      $id: 'AnyTest',
      properties: {},
      description: 'AnyTest description'
    }
```
it does not add the description to the generated models.

This PR fixes this issue.

## Related Issue
<!-- If this pull request is related to any existing issue, mention it here. -->

## Checklist
- [x] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [x] Tests have been added or updated to cover the changes.
- [ ] Documentation has been updated to reflect the changes.
- [x] All tests pass successfully locally.(`npm run test`).

## Additional Notes
<!-- Add any additional information or context that might be relevant to reviewers. -->
