### PR TITLE
fix: move jsonproperty annotation to getter

### DIFF
--- a/examples/java-generate-jackson-annotation/__snapshots__/index.spec.ts.snap
+++ b/examples/java-generate-jackson-annotation/__snapshots__/index.spec.ts.snap
@@ -3,19 +3,19 @@
 exports[`Should be able to generate data models for jackson annotation and should log expected output to console 1`] = `
 Array [
   "public class Root {
-  @JsonProperty(\\"min_number_prop\\")
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Double minNumberProp;
-  @JsonProperty(\\"max_number_prop\\")
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Double maxNumberProp;
   @JsonAnySetter
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Map<String, Object> additionalProperties;
 
+  @JsonProperty(\\"min_number_prop\\")
   public Double getMinNumberProp() { return this.minNumberProp; }
   public void setMinNumberProp(Double minNumberProp) { this.minNumberProp = minNumberProp; }
 
+  @JsonProperty(\\"max_number_prop\\")
   public Double getMaxNumberProp() { return this.maxNumberProp; }
   public void setMaxNumberProp(Double maxNumberProp) { this.maxNumberProp = maxNumberProp; }
 

--- a/src/generators/java/presets/JacksonPreset.ts
+++ b/src/generators/java/presets/JacksonPreset.ts
@@ -50,13 +50,6 @@ export const JAVA_JACKSON_PRESET: JavaPreset = {
         return renderer.renderBlock(blocks);
       }
 
-      blocks.push(
-        renderer.renderAnnotation(
-          'JsonProperty',
-          `"${property.unconstrainedPropertyName}"`
-        )
-      );
-
       if (!property.required) {
         blocks.push(
           renderer.renderAnnotation(
@@ -84,6 +77,13 @@ export const JAVA_JACKSON_PRESET: JavaPreset = {
       const blocks: string[] = [];
       if (hasUnwrappedOptions) {
         blocks.push(renderer.renderAnnotation('JsonAnyGetter'));
+      } else {
+        blocks.push(
+          renderer.renderAnnotation(
+            'JsonProperty',
+            `"${property.unconstrainedPropertyName}"`
+          )
+        );
       }
       blocks.push(content);
       return renderer.renderBlock(blocks);

--- a/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
+++ b/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
@@ -14,18 +14,18 @@ public interface Animal {
   String getPetType();
 }",
   "public class Boxer implements Animal, Dog {
-  @JsonProperty(\\"breed\\")
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private final String breed = \\"Boxer\\";
-  @JsonProperty(\\"petType\\")
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String petType;
   @JsonAnySetter
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Map<String, Object> additionalProperties;
 
+  @JsonProperty(\\"breed\\")
   public String getBreed() { return this.breed; }
 
+  @JsonProperty(\\"petType\\")
   @Override
   public String getPetType() { return this.petType; }
   @Override
@@ -82,13 +82,13 @@ public interface Animal {
   
 }",
   "public class Cat implements Animal, Pet {
-  @JsonProperty(\\"petType\\")
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String petType;
   @JsonAnySetter
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Map<String, Object> additionalProperties;
 
+  @JsonProperty(\\"petType\\")
   public String getPetType() { return this.petType; }
   public void setPetType(String petType) { this.petType = petType; }
 
@@ -198,18 +198,18 @@ Array [
   "public class Event {
   @Valid
   @NotNull
-  @JsonProperty(\\"action\\")
   private Action action;
-  @JsonProperty(\\"event_time\\")
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private java.time.OffsetDateTime eventTime;
   @JsonAnySetter
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Map<String, Object> additionalProperties;
 
+  @JsonProperty(\\"action\\")
   public Action getAction() { return this.action; }
   public void setAction(Action action) { this.action = action; }
 
+  @JsonProperty(\\"event_time\\")
   public java.time.OffsetDateTime getEventTime() { return this.eventTime; }
   public void setEventTime(java.time.OffsetDateTime eventTime) { this.eventTime = eventTime; }
 
@@ -304,41 +304,41 @@ public interface Pet {
 }",
   "public class Dog implements Pet {
   @NotNull
-  @JsonProperty(\\"id\\")
   private String id;
   @NotNull
-  @JsonProperty(\\"source\\")
   private String source;
   @NotNull
-  @JsonProperty(\\"specversion\\")
   private final String specversion = \\"1.0\\";
   @Valid
   @NotNull
-  @JsonProperty(\\"type\\")
   private final CloudEventType type = CloudEventType.DOG;
-  @JsonProperty(\\"dataschema\\")
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String dataschema;
-  @JsonProperty(\\"time\\")
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private java.time.OffsetDateTime time;
   @JsonAnySetter
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Map<String, Object> additionalProperties;
 
+  @JsonProperty(\\"id\\")
   public String getId() { return this.id; }
   public void setId(String id) { this.id = id; }
 
+  @JsonProperty(\\"source\\")
   public String getSource() { return this.source; }
   public void setSource(String source) { this.source = source; }
 
+  @JsonProperty(\\"specversion\\")
   public String getSpecversion() { return this.specversion; }
 
+  @JsonProperty(\\"type\\")
   public CloudEventType getType() { return this.type; }
 
+  @JsonProperty(\\"dataschema\\")
   public String getDataschema() { return this.dataschema; }
   public void setDataschema(String dataschema) { this.dataschema = dataschema; }
 
+  @JsonProperty(\\"time\\")
   public java.time.OffsetDateTime getTime() { return this.time; }
   public void setTime(java.time.OffsetDateTime time) { this.time = time; }
 
@@ -425,41 +425,41 @@ public interface Pet {
 }",
   "public class Cat implements Pet {
   @NotNull
-  @JsonProperty(\\"id\\")
   private String id;
   @NotNull
-  @JsonProperty(\\"source\\")
   private String source;
   @NotNull
-  @JsonProperty(\\"specversion\\")
   private final String specversion = \\"1.0\\";
   @Valid
   @NotNull
-  @JsonProperty(\\"type\\")
   private final CloudEventType type = CloudEventType.CAT;
-  @JsonProperty(\\"dataschema\\")
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String dataschema;
-  @JsonProperty(\\"time\\")
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private java.time.OffsetDateTime time;
   @JsonAnySetter
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Map<String, Object> additionalProperties;
 
+  @JsonProperty(\\"id\\")
   public String getId() { return this.id; }
   public void setId(String id) { this.id = id; }
 
+  @JsonProperty(\\"source\\")
   public String getSource() { return this.source; }
   public void setSource(String source) { this.source = source; }
 
+  @JsonProperty(\\"specversion\\")
   public String getSpecversion() { return this.specversion; }
 
+  @JsonProperty(\\"type\\")
   public CloudEventType getType() { return this.type; }
 
+  @JsonProperty(\\"dataschema\\")
   public String getDataschema() { return this.dataschema; }
   public void setDataschema(String dataschema) { this.dataschema = dataschema; }
 
+  @JsonProperty(\\"time\\")
   public java.time.OffsetDateTime getTime() { return this.time; }
   public void setTime(java.time.OffsetDateTime time) { this.time = time; }
 
@@ -522,19 +522,19 @@ exports[`JavaGenerator oneOf/discriminator with jackson preset handle one const 
 Array [
   "public class Dog {
   @NotNull
-  @JsonProperty(\\"id\\")
   private String id;
   @Valid
   @NotNull
-  @JsonProperty(\\"type\\")
   private final CloudEventType type = CloudEventType.DOG;
   @JsonAnySetter
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Map<String, Object> additionalProperties;
 
+  @JsonProperty(\\"id\\")
   public String getId() { return this.id; }
   public void setId(String id) { this.id = id; }
 
+  @JsonProperty(\\"type\\")
   public CloudEventType getType() { return this.type; }
 
   @JsonAnyGetter
@@ -629,12 +629,12 @@ public interface Pet {
   "public class Dog implements Pet {
   @Valid
   @NotNull
-  @JsonProperty(\\"type\\")
   private final DogType type = DogType.DOG;
   @JsonAnySetter
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Map<String, Object> additionalProperties;
 
+  @JsonProperty(\\"type\\")
   public DogType getType() { return this.type; }
 
   @JsonAnyGetter
@@ -711,12 +711,12 @@ public interface Pet {
   "public class Cat implements Pet {
   @Valid
   @NotNull
-  @JsonProperty(\\"type\\")
   private final CatType type = CatType.CAT;
   @JsonAnySetter
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Map<String, Object> additionalProperties;
 
+  @JsonProperty(\\"type\\")
   public CatType getType() { return this.type; }
 
   @JsonAnyGetter
@@ -808,13 +808,13 @@ public interface Vehicle {
 }",
   "public class Cargo {
   @Valid
-  @JsonProperty(\\"vehicle\\")
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Vehicle vehicle;
   @JsonAnySetter
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Map<String, Object> additionalProperties;
 
+  @JsonProperty(\\"vehicle\\")
   public Vehicle getVehicle() { return this.vehicle; }
   public void setVehicle(Vehicle vehicle) { this.vehicle = vehicle; }
 
@@ -863,12 +863,12 @@ public interface Vehicle {
   "public class Car implements Vehicle {
   @Valid
   @NotNull
-  @JsonProperty(\\"vehicleType\\")
   private final VehicleType vehicleType = VehicleType.CAR;
   @JsonAnySetter
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Map<String, Object> additionalProperties;
 
+  @JsonProperty(\\"vehicleType\\")
   public VehicleType getVehicleType() { return this.vehicleType; }
 
   @JsonAnyGetter
@@ -945,12 +945,12 @@ public interface Vehicle {
   "public class Truck implements Vehicle {
   @Valid
   @NotNull
-  @JsonProperty(\\"vehicleType\\")
   private final VehicleType vehicleType = VehicleType.TRUCK;
   @JsonAnySetter
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Map<String, Object> additionalProperties;
 
+  @JsonProperty(\\"vehicleType\\")
   public VehicleType getVehicleType() { return this.vehicleType; }
 
   @JsonAnyGetter

--- a/test/generators/java/presets/JacksonPreset.spec.ts
+++ b/test/generators/java/presets/JacksonPreset.spec.ts
@@ -71,6 +71,28 @@ describe('JAVA_JACKSON_PRESET', () => {
     expect(models.map((model) => model.result)).toMatchSnapshot();
   });
 
+  test('should place @JsonProperty annotation on the getter', async () => {
+    const doc = {
+      $id: 'AnnotateGetterWithJsonProperty',
+      type: 'object',
+      properties: {
+        a_property: { type: 'string' }
+      }
+    };
+
+    const generator = new JavaGenerator({
+      presets: [JAVA_JACKSON_PRESET],
+      processorOptions: {
+        interpreter: {
+          ignoreAdditionalProperties: true
+        }
+      }
+    });
+
+    const models = await generator.generate(doc);
+    expect(models[0].result).toMatchSnapshot();
+  });
+
   describe('union', () => {
     test('handle oneOf with AsyncAPI discriminator with Jackson', async () => {
       const asyncapiDoc = {

--- a/test/generators/java/presets/__snapshots__/JacksonPreset.spec.ts.snap
+++ b/test/generators/java/presets/__snapshots__/JacksonPreset.spec.ts.snap
@@ -3,13 +3,13 @@
 exports[`JAVA_JACKSON_PRESET should not render anything when isExtended is true 1`] = `
 Array [
   "public class ExtendDoc implements Extend {
-  @JsonProperty(\\"extendProp\\")
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String extendProp;
   @JsonAnySetter
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Map<String, Object> additionalProperties;
 
+  @JsonProperty(\\"extendProp\\")
   @Override
   public String getExtendProp() { return this.extendProp; }
   @Override
@@ -26,20 +26,31 @@ Array [
 ]
 `;
 
+exports[`JAVA_JACKSON_PRESET should place @JsonProperty annotation on the getter 1`] = `
+"public class AnnotateGetterWithJsonProperty {
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private String aProperty;
+
+  @JsonProperty(\\"a_property\\")
+  public String getAProperty() { return this.aProperty; }
+  public void setAProperty(String aProperty) { this.aProperty = aProperty; }
+}"
+`;
+
 exports[`JAVA_JACKSON_PRESET should render Jackson annotations for class 1`] = `
 "public class Clazz {
-  @JsonProperty(\\"min_number_prop\\")
   private double minNumberProp;
-  @JsonProperty(\\"max_number_prop\\")
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Double maxNumberProp;
   @JsonAnySetter
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Map<String, Object> additionalProperties;
 
+  @JsonProperty(\\"min_number_prop\\")
   public double getMinNumberProp() { return this.minNumberProp; }
   public void setMinNumberProp(double minNumberProp) { this.minNumberProp = minNumberProp; }
 
+  @JsonProperty(\\"max_number_prop\\")
   public Double getMaxNumberProp() { return this.maxNumberProp; }
   public void setMaxNumberProp(Double maxNumberProp) { this.maxNumberProp = maxNumberProp; }
 
@@ -95,19 +106,19 @@ public interface Vehicle {
   String getVehicleType();
 }",
   "public class Car implements Vehicle {
-  @JsonProperty(\\"vehicle_type\\")
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String vehicleType;
-  @JsonProperty(\\"name\\")
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String name;
   @JsonAnySetter
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Map<String, Object> additionalProperties;
 
+  @JsonProperty(\\"vehicle_type\\")
   public String getVehicleType() { return this.vehicleType; }
   public void setVehicleType(String vehicleType) { this.vehicleType = vehicleType; }
 
+  @JsonProperty(\\"name\\")
   public String getName() { return this.name; }
   public void setName(String name) { this.name = name; }
 
@@ -116,19 +127,19 @@ public interface Vehicle {
   public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
 }",
   "public class Truck implements Vehicle {
-  @JsonProperty(\\"vehicle_type\\")
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String vehicleType;
-  @JsonProperty(\\"name\\")
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String name;
   @JsonAnySetter
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Map<String, Object> additionalProperties;
 
+  @JsonProperty(\\"vehicle_type\\")
   public String getVehicleType() { return this.vehicleType; }
   public void setVehicleType(String vehicleType) { this.vehicleType = vehicleType; }
 
+  @JsonProperty(\\"name\\")
   public String getName() { return this.name; }
   public void setName(String name) { this.name = name; }
 
@@ -153,13 +164,13 @@ public interface Vehicle {
   String getVehicleType();
 }",
   "public class Car implements Vehicle {
-  @JsonProperty(\\"vehicleType\\")
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String vehicleType;
   @JsonAnySetter
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Map<String, Object> additionalProperties;
 
+  @JsonProperty(\\"vehicleType\\")
   public String getVehicleType() { return this.vehicleType; }
   public void setVehicleType(String vehicleType) { this.vehicleType = vehicleType; }
 
@@ -168,13 +179,13 @@ public interface Vehicle {
   public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
 }",
   "public class Truck implements Vehicle {
-  @JsonProperty(\\"vehicleType\\")
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String vehicleType;
   @JsonAnySetter
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Map<String, Object> additionalProperties;
 
+  @JsonProperty(\\"vehicleType\\")
   public String getVehicleType() { return this.vehicleType; }
   public void setVehicleType(String vehicleType) { this.vehicleType = vehicleType; }
 
@@ -199,13 +210,13 @@ public interface Vehicle {
   String getVehicleType();
 }",
   "public class Car implements Vehicle {
-  @JsonProperty(\\"vehicleType\\")
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String vehicleType;
   @JsonAnySetter
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Map<String, Object> additionalProperties;
 
+  @JsonProperty(\\"vehicleType\\")
   public String getVehicleType() { return this.vehicleType; }
   public void setVehicleType(String vehicleType) { this.vehicleType = vehicleType; }
 
@@ -214,13 +225,13 @@ public interface Vehicle {
   public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
 }",
   "public class Truck implements Vehicle {
-  @JsonProperty(\\"vehicleType\\")
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String vehicleType;
   @JsonAnySetter
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Map<String, Object> additionalProperties;
 
+  @JsonProperty(\\"vehicleType\\")
   public String getVehicleType() { return this.vehicleType; }
   public void setVehicleType(String vehicleType) { this.vehicleType = vehicleType; }
 
@@ -245,13 +256,13 @@ public interface Vehicle {
   
 }",
   "public class Car implements Vehicle {
-  @JsonProperty(\\"passengers\\")
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String passengers;
   @JsonAnySetter
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Map<String, Object> additionalProperties;
 
+  @JsonProperty(\\"passengers\\")
   public String getPassengers() { return this.passengers; }
   public void setPassengers(String passengers) { this.passengers = passengers; }
 
@@ -260,13 +271,13 @@ public interface Vehicle {
   public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
 }",
   "public class Truck implements Vehicle {
-  @JsonProperty(\\"cargo\\")
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String cargo;
   @JsonAnySetter
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Map<String, Object> additionalProperties;
 
+  @JsonProperty(\\"cargo\\")
   public String getCargo() { return this.cargo; }
   public void setCargo(String cargo) { this.cargo = cargo; }
 


### PR DESCRIPTION
## Description
Jackson handles poorly serialization of properties of names with first word length of 1 (such as `a_name`, `x_min`, `y_max`) when the `@JsonProperty` annotation is put on the field. Putting the annotation on the getter fixes this behavior while retaining the ability to deserialize and serialize properties with names defined by the `@JsonProperty` annotation.

example:
```java
import com.fasterxml.jackson.annotation.JsonProperty;
import com.fasterxml.jackson.databind.ObjectMapper;

public class Example {

  @JsonProperty("a_property")
  private Integer aProperty;

  public Integer getAProperty() {
    return aProperty;
  }

  public void setAProperty(Integer aProperty) {
    this.aProperty = aProperty;
  }

  public static void main(String[] args) {
    ObjectMapper mapper = new ObjectMapper();
    Example example = new Example();
    example.setAProperty(1);
    try {
      String json = mapper.writeValueAsString(example);
      System.out.println(json);
    } catch (Exception e) {
    }
  }
}
```
outputs:
```
{"aproperty":1,"a_property":1}
```

By moving the annotation the serialization works again:
```java
import com.fasterxml.jackson.annotation.JsonProperty;
import com.fasterxml.jackson.databind.ObjectMapper;

public class Example {

  private Integer aProperty;

  @JsonProperty("a_property")
  public Integer getAProperty() {
    return aProperty;
  }

  public void setAProperty(Integer aProperty) {
    this.aProperty = aProperty;
  }

  public static void main(String[] args) {
    ObjectMapper mapper = new ObjectMapper();
    Example example = new Example();
    example.setAProperty(1);
    try {
      String json = mapper.writeValueAsString(example);
      System.out.println(json);
    } catch (Exception e) {
    }
  }
}
```

outputs:
```
{"a_property":1}
```

## Checklist
- [x] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [x] Tests have been added or updated to cover the changes.
- [x] Documentation has been updated to reflect the changes.
- [x] All tests pass successfully locally.(`npm run test`).

## Additional Notes
<!-- Add any additional information or context that might be relevant to reviewers. -->
