### PR TITLE
feat: add support for all rust number types

### DIFF
--- a/src/generators/rust/RustConstrainer.ts
+++ b/src/generators/rust/RustConstrainer.ts
@@ -289,16 +289,41 @@ export const RustDefaultTypeMapping: RustTypeMapping = {
     }
   },
   Integer({ constrainedModel }): string {
-    const type = 'i32';
     switch (constrainedModel.options.format) {
-      case 'integer':
+      case 'int8':
+      case 'i8':
+        return 'i8';
+      case 'int16':
+      case 'i16':
+        return 'i16';
       case 'int32':
-        return type;
-      case 'long':
+      case 'integer':
+      case 'i32':
+        return 'i32';
       case 'int64':
+      case 'long':
+      case 'i64':
         return 'i64';
+      case 'int128':
+      case 'i128':
+        return 'i128';
+      case 'uint8':
+      case 'u8':
+        return 'u8';
+      case 'uint16':
+      case 'u16':
+        return 'u16';
+      case 'uint32':
+      case 'u32':
+        return 'u32';
+      case 'uint64':
+      case 'u64':
+        return 'u64';
+      case 'uint128':
+      case 'u128':
+        return 'u128';
       default:
-        return type;
+        return 'i32';
     }
   },
   String({ constrainedModel }): string {

--- a/test/generators/rust/RustConstrainer.spec.ts
+++ b/test/generators/rust/RustConstrainer.spec.ts
@@ -149,6 +149,201 @@ describe('RustConstrainer', () => {
       });
       expect(type).toEqual('i64');
     });
+    test('should render u8 when format is u8', () => {
+      const model = new ConstrainedIntegerModel(
+        'test',
+        {},
+        { format: 'u8' },
+        ''
+      );
+      const type = RustDefaultTypeMapping.Integer({
+        constrainedModel: model,
+        ...defaultOptions
+      });
+      expect(type).toEqual('u8');
+    });
+
+    test('should render u16 when format is u16', () => {
+      const model = new ConstrainedIntegerModel(
+        'test',
+        {},
+        { format: 'u16' },
+        ''
+      );
+      const type = RustDefaultTypeMapping.Integer({
+        constrainedModel: model,
+        ...defaultOptions
+      });
+      expect(type).toEqual('u16');
+    });
+
+    test('should render u32 when format is u32', () => {
+      const model = new ConstrainedIntegerModel(
+        'test',
+        {},
+        { format: 'u32' },
+        ''
+      );
+      const type = RustDefaultTypeMapping.Integer({
+        constrainedModel: model,
+        ...defaultOptions
+      });
+      expect(type).toEqual('u32');
+    });
+
+    test('should render u64 when format is u64', () => {
+      const model = new ConstrainedIntegerModel(
+        'test',
+        {},
+        { format: 'u64' },
+        ''
+      );
+      const type = RustDefaultTypeMapping.Integer({
+        constrainedModel: model,
+        ...defaultOptions
+      });
+      expect(type).toEqual('u64');
+    });
+
+    test('should render u128 when format is u128', () => {
+      const model = new ConstrainedIntegerModel(
+        'test',
+        {},
+        { format: 'u128' },
+        ''
+      );
+      const type = RustDefaultTypeMapping.Integer({
+        constrainedModel: model,
+        ...defaultOptions
+      });
+      expect(type).toEqual('u128');
+    });
+
+    test('should render uint32 format as u32', () => {
+      const model = new ConstrainedIntegerModel(
+        'test',
+        {},
+        { format: 'uint32' },
+        ''
+      );
+      const type = RustDefaultTypeMapping.Integer({
+        constrainedModel: model,
+        ...defaultOptions
+      });
+      expect(type).toEqual('u32');
+    });
+
+    test('should render uint64 format as u64', () => {
+      const model = new ConstrainedIntegerModel(
+        'test',
+        {},
+        { format: 'uint64' },
+        ''
+      );
+      const type = RustDefaultTypeMapping.Integer({
+        constrainedModel: model,
+        ...defaultOptions
+      });
+      expect(type).toEqual('u64');
+    });
+
+    test('should render i8 when format is int8', () => {
+      const model = new ConstrainedIntegerModel(
+        'test',
+        {},
+        { format: 'int8' },
+        ''
+      );
+      const type = RustDefaultTypeMapping.Integer({
+        constrainedModel: model,
+        ...defaultOptions
+      });
+      expect(type).toEqual('i8');
+    });
+
+    test('should render i16 when format is int16', () => {
+      const model = new ConstrainedIntegerModel(
+        'test',
+        {},
+        { format: 'int16' },
+        ''
+      );
+      const type = RustDefaultTypeMapping.Integer({
+        constrainedModel: model,
+        ...defaultOptions
+      });
+      expect(type).toEqual('i16');
+    });
+
+    test('should render i128 when format is int128', () => {
+      const model = new ConstrainedIntegerModel(
+        'test',
+        {},
+        { format: 'int128' },
+        ''
+      );
+      const type = RustDefaultTypeMapping.Integer({
+        constrainedModel: model,
+        ...defaultOptions
+      });
+      expect(type).toEqual('i128');
+    });
+
+    test('should render u8 when format is uint8', () => {
+      const model = new ConstrainedIntegerModel(
+        'test',
+        {},
+        { format: 'uint8' },
+        ''
+      );
+      const type = RustDefaultTypeMapping.Integer({
+        constrainedModel: model,
+        ...defaultOptions
+      });
+      expect(type).toEqual('u8');
+    });
+
+    test('should render u16 when format is uint16', () => {
+      const model = new ConstrainedIntegerModel(
+        'test',
+        {},
+        { format: 'uint16' },
+        ''
+      );
+      const type = RustDefaultTypeMapping.Integer({
+        constrainedModel: model,
+        ...defaultOptions
+      });
+      expect(type).toEqual('u16');
+    });
+
+    test('should render u128 when format is uint128', () => {
+      const model = new ConstrainedIntegerModel(
+        'test',
+        {},
+        { format: 'uint128' },
+        ''
+      );
+      const type = RustDefaultTypeMapping.Integer({
+        constrainedModel: model,
+        ...defaultOptions
+      });
+      expect(type).toEqual('u128');
+    });
+
+    test('should render default i32 when format is unknown', () => {
+      const model = new ConstrainedIntegerModel(
+        'test',
+        {},
+        { format: 'unknown' },
+        ''
+      );
+      const type = RustDefaultTypeMapping.Integer({
+        constrainedModel: model,
+        ...defaultOptions
+      });
+      expect(type).toEqual('i32');
+    });
   });
   describe('String', () => {
     test('should render type', () => {


### PR DESCRIPTION
## Description
I added all possible signed and unsigned types to the rust generator

## Related Issue
Fixes https://github.com/asyncapi/modelina/issues/2208

## Checklist
- [x] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [x] Tests have been added or updated to cover the changes.
- [ ] Documentation has been updated to reflect the changes.
- [x] All tests pass successfully locally.(`npm run test`).


