### PR TITLE
feat: add Java record support

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -118,6 +118,7 @@ These are all specific examples only relevant to the Java generator:
 - [java-generate-javax-constraint-annotation](./java-generate-javax-constraint-annotation) - A basic example that shows how Java data models having `javax.validation.constraints` annotations can be generated.
 - [java-generate-javadoc](./java-generate-javadoc) - A basic example of how to generate Java models including JavaDocs.
 - [integrate-into-maven](./integrate-with-maven/) - A basic example that shows how you can integrate Modelina into the Java Maven build process.
+- [java-generate-records](./java-generate-records/) - A basic example that shows how to change Java model type from class to record.
 
 ### C#
 These are all specific examples only relevant to the C# generator:

--- a/examples/java-generate-records/README.md
+++ b/examples/java-generate-records/README.md
@@ -1,0 +1,17 @@
+# Java Generate `record`
+
+A basic example on how to generate models that use Java's `record` type instead of `class`
+
+## How to run this example
+
+Run this example using:
+
+```sh
+npm i && npm run start
+```
+
+If you are on Windows, use the `start:windows` script instead:
+
+```sh
+npm i && npm run start:windows
+```

--- a/examples/java-generate-records/__snapshots__/index.spec.ts.snap
+++ b/examples/java-generate-records/__snapshots__/index.spec.ts.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Should be able to render a Java record instead of a class using the modelType option and should log expected output to console 1`] = `
+Array [
+  "public record Root(String email, String name) {
+  
+}",
+]
+`;

--- a/examples/java-generate-records/index.spec.ts
+++ b/examples/java-generate-records/index.spec.ts
@@ -1,0 +1,15 @@
+const spy = jest.spyOn(global.console, 'log').mockImplementation(() => {
+  return;
+});
+import { generate } from './index';
+
+describe('Should be able to render a Java record instead of a class using the modelType option', () => {
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+  test('and should log expected output to console', async () => {
+    await generate();
+    expect(spy.mock.calls.length).toEqual(1);
+    expect(spy.mock.calls[0]).toMatchSnapshot();
+  });
+});

--- a/examples/java-generate-records/index.ts
+++ b/examples/java-generate-records/index.ts
@@ -1,0 +1,30 @@
+import { JavaGenerator } from '../../src';
+
+const generator = new JavaGenerator({
+  modelType: 'record'
+});
+
+const jsonSchemaDraft7 = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    email: {
+      type: 'string',
+      format: 'email'
+    },
+    name: {
+      type: 'string'
+    }
+  }
+};
+
+export async function generate(): Promise<void> {
+  const models = await generator.generate(jsonSchemaDraft7);
+  for (const model of models) {
+    console.log(model.result);
+  }
+}
+if (require.main === module) {
+  generate();
+}

--- a/examples/java-generate-records/package-lock.json
+++ b/examples/java-generate-records/package-lock.json
@@ -1,0 +1,10 @@
+{
+  "name": "java-generate-records",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "hasInstallScript": true
+    }
+  }
+}

--- a/examples/java-generate-records/package.json
+++ b/examples/java-generate-records/package.json
@@ -1,0 +1,12 @@
+{
+  "config": {
+    "example_name": "java-generate-records"
+  },
+  "scripts": {
+    "install": "cd ../.. && npm i",
+    "start": "../../node_modules/.bin/ts-node --cwd ../../ ./examples/$npm_package_config_example_name/index.ts",
+    "start:windows": "..\\..\\node_modules\\.bin\\ts-node --cwd ..\\..\\ .\\examples\\%npm_package_config_example_name%\\index.ts",
+    "test": "../../node_modules/.bin/jest --config=../../jest.config.js ./examples/$npm_package_config_example_name/index.spec.ts",
+    "test:windows": "..\\..\\node_modules\\.bin\\jest --config=..\\..\\jest.config.js examples/%npm_package_config_example_name%/index.spec.ts"
+  }
+}

--- a/src/generators/java/Constants.ts
+++ b/src/generators/java/Constants.ts
@@ -50,7 +50,8 @@ export const RESERVED_JAVA_KEYWORDS = [
   'float',
   'native',
   'super',
-  'while'
+  'while',
+  'record'
 ];
 
 export function isReservedJavaKeyword(

--- a/src/generators/java/JavaPreset.ts
+++ b/src/generators/java/JavaPreset.ts
@@ -7,7 +7,8 @@ import {
   EnumArgs,
   ConstrainedEnumModel,
   CommonPreset,
-  ConstrainedUnionModel
+  ConstrainedUnionModel,
+  InterfacePreset
 } from '../../models';
 import { JavaOptions } from './JavaGenerator';
 import {
@@ -18,6 +19,10 @@ import {
   EnumRenderer,
   JAVA_DEFAULT_ENUM_PRESET
 } from './renderers/EnumRenderer';
+import {
+  JAVA_DEFAULT_RECORD_PRESET,
+  RecordRenderer
+} from './renderers/RecordRenderer';
 import {
   JAVA_DEFAULT_UNION_PRESET,
   UnionRenderer
@@ -45,13 +50,17 @@ export interface UnionPreset<R extends AbstractRenderer, O>
   ) => string;
 }
 
+export type RecordPresetType<O> = InterfacePreset<RecordRenderer, O>;
+
 export type JavaPreset<O = any> = Preset<{
+  record: RecordPresetType<O>;
   class: ClassPresetType<O>;
   enum: EnumPresetType<O>;
   union: UnionPresetType<O>;
 }>;
 
 export const JAVA_DEFAULT_PRESET: JavaPreset<JavaOptions> = {
+  record: JAVA_DEFAULT_RECORD_PRESET,
   class: JAVA_DEFAULT_CLASS_PRESET,
   enum: JAVA_DEFAULT_ENUM_PRESET,
   union: JAVA_DEFAULT_UNION_PRESET

--- a/src/generators/java/renderers/RecordRenderer.ts
+++ b/src/generators/java/renderers/RecordRenderer.ts
@@ -1,0 +1,106 @@
+import { JavaRenderer } from '../JavaRenderer';
+import {
+  ConstrainedDictionaryModel,
+  ConstrainedObjectModel,
+  ConstrainedObjectPropertyModel,
+  ConstrainedUnionModel
+} from '../../../models';
+import { JavaOptions } from '../JavaGenerator';
+import { unionIncludesBuiltInTypes } from '../JavaConstrainer';
+import { RecordPresetType } from '../JavaPreset';
+
+/**
+ * Renderer for Java's `record` type
+ *
+ * @extends JavaRenderer
+ */
+export class RecordRenderer extends JavaRenderer<ConstrainedObjectModel> {
+  async defaultSelf(): Promise<string> {
+    const content = [
+      await this.runCtorPreset(),
+      await this.runAdditionalContentPreset()
+    ];
+
+    if (this.options?.collectionType === 'List') {
+      this.dependencyManager.addDependency('import java.util.List;');
+    }
+    if (this.model.containsPropertyType(ConstrainedDictionaryModel)) {
+      this.dependencyManager.addDependency('import java.util.Map;');
+    }
+
+    const parentUnions = this.getParentUnions();
+    const parents = [...(parentUnions ?? [])];
+    const recordProperties = await this.renderProperties();
+
+    if (parents.length) {
+      for (const i of parents) {
+        this.dependencyManager.addModelDependency(i);
+      }
+
+      const inheritanceKeyworkd = 'implements';
+
+      return `public record ${this.model.name}(${recordProperties}) ${inheritanceKeyworkd} ${parents.map((i) => i.name).join(', ')} {
+${this.indent(this.renderBlock(content, 2))}
+}`;
+    }
+
+    return `public record ${this.model.name}(${recordProperties}) {
+${this.indent(this.renderBlock(content, 2))}
+}`;
+  }
+
+  runCtorPreset(): Promise<string> {
+    return this.runPreset('ctor');
+  }
+
+  /**
+   * Render all the properties for the class.
+   */
+  async renderProperties(): Promise<string> {
+    const properties = this.model.properties || {};
+    const content: string[] = [];
+
+    for (const property of Object.values(properties)) {
+      const rendererProperty = await this.runPropertyPreset(property);
+      content.push(rendererProperty);
+    }
+
+    return content.join(', ');
+  }
+
+  runPropertyPreset(property: ConstrainedObjectPropertyModel): Promise<string> {
+    return this.runPreset('property', { property });
+  }
+
+  private getParentUnions(): ConstrainedUnionModel[] | undefined {
+    const parentUnions: ConstrainedUnionModel[] = [];
+
+    if (!this.model.options.parents) {
+      return undefined;
+    }
+
+    for (const model of this.model.options.parents) {
+      if (
+        model instanceof ConstrainedUnionModel &&
+        !unionIncludesBuiltInTypes(model)
+      ) {
+        parentUnions.push(model);
+      }
+    }
+
+    if (!parentUnions.length) {
+      return undefined;
+    }
+
+    return parentUnions;
+  }
+}
+
+export const JAVA_DEFAULT_RECORD_PRESET: RecordPresetType<JavaOptions> = {
+  self({ renderer }) {
+    return renderer.defaultSelf();
+  },
+  property({ property }) {
+    return `${property.property.type} ${property.propertyName}`;
+  }
+};


### PR DESCRIPTION
## Description
Java equivalent of #1191. This PR adds an option to the Java generator allowing it to render records instead of classes. This is done using a new renderer that implements self, property and additionalContent hooks. 

## Related Issue
Resolves #2218 

## Checklist
- [x] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [x] Tests have been added or updated to cover the changes.
- [x] Documentation has been updated to reflect the changes.
- [x] All tests pass successfully locally.(`npm run test`).
