### PR TITLE
feat: add support for special characters in discriminator for java generator

### DIFF
--- a/src/generators/java/renderers/ClassRenderer.ts
+++ b/src/generators/java/renderers/ClassRenderer.ts
@@ -138,10 +138,7 @@ const getOverride = (
   property: ConstrainedObjectPropertyModel
 ) => {
   const isOverride = model.options.extend?.find((extend) => {
-    if (
-      !extend.options.isExtended ||
-      isDiscriminatorOrDictionary(model, property)
-    ) {
+    if (!extend.options.isExtended || isDictionary(model, property)) {
       return false;
     }
 
@@ -169,8 +166,12 @@ export const isDiscriminatorOrDictionary = (
   property: ConstrainedObjectPropertyModel
 ): boolean =>
   model.options.discriminator?.discriminator ===
-    property.unconstrainedPropertyName ||
-  property.property instanceof ConstrainedDictionaryModel;
+    property.unconstrainedPropertyName || isDictionary(model, property);
+
+export const isDictionary = (
+  model: ConstrainedObjectModel,
+  property: ConstrainedObjectPropertyModel
+): boolean => property.property instanceof ConstrainedDictionaryModel;
 
 const isEnumImplementedByConstValue = (
   model: ConstrainedObjectModel,

--- a/src/generators/java/renderers/UnionRenderer.ts
+++ b/src/generators/java/renderers/UnionRenderer.ts
@@ -50,16 +50,9 @@ export const JAVA_DEFAULT_UNION_PRESET: UnionPresetType<JavaOptions> = {
     if (!model.options.discriminator?.type) {
       return '';
     }
-    const sanitizedDiscriminator = FormatHelpers.replaceSpecialCharacters(
-      model.options.discriminator.discriminator,
-      {
-        exclude: [' ', '_'],
-        separator: '_'
-      }
-    );
 
     return `${model.options.discriminator.type} get${FormatHelpers.toPascalCase(
-      sanitizedDiscriminator
+      getSanitizedDiscriminatorName(model)
     )}();`;
   },
   discriminatorSetter({ model }) {
@@ -68,9 +61,19 @@ export const JAVA_DEFAULT_UNION_PRESET: UnionPresetType<JavaOptions> = {
     }
 
     return `void set${FormatHelpers.toPascalCase(
-      model.options.discriminator.discriminator
+      getSanitizedDiscriminatorName(model)
     )}(${model.options.discriminator.type} ${FormatHelpers.toCamelCase(
-      model.options.discriminator.discriminator
+      getSanitizedDiscriminatorName(model)
     )});`;
   }
 };
+
+function getSanitizedDiscriminatorName(model: ConstrainedUnionModel): string {
+  return FormatHelpers.replaceSpecialCharacters(
+    model.options.discriminator!.discriminator,
+    {
+      exclude: [' ', '_'],
+      separator: '_'
+    }
+  );
+}

--- a/src/generators/java/renderers/UnionRenderer.ts
+++ b/src/generators/java/renderers/UnionRenderer.ts
@@ -2,7 +2,8 @@ import { JavaRenderer } from '../JavaRenderer';
 import { ConstrainedUnionModel } from '../../../models';
 import { JavaOptions } from '../JavaGenerator';
 import { UnionPresetType } from '../JavaPreset';
-import { FormatHelpers } from '../../../index';
+import { FormatHelpers } from '../../../helpers';
+
 
 /**
  * Renderer for Java's `union` type
@@ -45,9 +46,16 @@ export const JAVA_DEFAULT_UNION_PRESET: UnionPresetType<JavaOptions> = {
     if (!model.options.discriminator?.type) {
       return '';
     }
+    const sanitizedDiscriminator = FormatHelpers.replaceSpecialCharacters(
+        model.options.discriminator.discriminator,
+        {
+          exclude: [' ', '_'],
+          separator: '_'
+        }
+    );
 
     return `${model.options.discriminator.type} get${FormatHelpers.toPascalCase(
-      model.options.discriminator.discriminator
+        sanitizedDiscriminator
     )}();`;
   }
 };

--- a/src/generators/java/renderers/UnionRenderer.ts
+++ b/src/generators/java/renderers/UnionRenderer.ts
@@ -4,7 +4,6 @@ import { JavaOptions } from '../JavaGenerator';
 import { UnionPresetType } from '../JavaPreset';
 import { FormatHelpers } from '../../../helpers';
 
-
 /**
  * Renderer for Java's `union` type
  *
@@ -47,15 +46,15 @@ export const JAVA_DEFAULT_UNION_PRESET: UnionPresetType<JavaOptions> = {
       return '';
     }
     const sanitizedDiscriminator = FormatHelpers.replaceSpecialCharacters(
-        model.options.discriminator.discriminator,
-        {
-          exclude: [' ', '_'],
-          separator: '_'
-        }
+      model.options.discriminator.discriminator,
+      {
+        exclude: [' ', '_'],
+        separator: '_'
+      }
     );
 
     return `${model.options.discriminator.type} get${FormatHelpers.toPascalCase(
-        sanitizedDiscriminator
+      sanitizedDiscriminator
     )}();`;
   }
 };

--- a/test/generators/java/JavaGenerator.spec.ts
+++ b/test/generators/java/JavaGenerator.spec.ts
@@ -328,7 +328,110 @@ describe('JavaGenerator', () => {
                   type: 'string'
                 }
               },
-              required: ['type']
+              required: ['petType']
+            },
+            Cat: {
+              title: 'Cat',
+              allOf: [
+                {
+                  $ref: '#/components/schemas/Pet'
+                }
+              ]
+            },
+            Dog: {
+              title: 'Dog',
+              allOf: [
+                {
+                  $ref: '#/components/schemas/Pet'
+                }
+              ]
+            },
+            Boxer: {
+              title: 'Boxer',
+              type: 'object',
+              allOf: [
+                {
+                  $ref: '#/components/schemas/Dog'
+                }
+              ],
+              properties: {
+                breed: {
+                  const: 'Boxer'
+                }
+              }
+            }
+          }
+        }
+      };
+
+      generator = new JavaGenerator({
+        presets: [
+          JAVA_COMMON_PRESET,
+          JAVA_JACKSON_PRESET,
+          JAVA_DESCRIPTION_PRESET,
+          JAVA_CONSTRAINTS_PRESET
+        ],
+        collectionType: 'List',
+        processorOptions: {
+          interpreter: {
+            allowInheritance: true
+          }
+        }
+      });
+
+      const models = await generator.generate(asyncapiDoc);
+      expect(models.map((model) => model.result)).toMatchSnapshot();
+    });
+  });
+
+  describe('allowInheritance with discriminator containing a special character', () => {
+    test('should create interface for Animal, Pet and Dog', async () => {
+      const asyncapiDoc = {
+        asyncapi: '2.5.0',
+        info: {
+          title: 'CloudEvent example',
+          version: '1.0.0'
+        },
+        channels: {
+          animal: {
+            publish: {
+              message: {
+                oneOf: [
+                  {
+                    $ref: '#/components/messages/Boxer'
+                  },
+                  {
+                    $ref: '#/components/messages/Cat'
+                  }
+                ]
+              }
+            }
+          }
+        },
+        components: {
+          messages: {
+            Boxer: {
+              payload: {
+                $ref: '#/components/schemas/Boxer'
+              }
+            },
+            Cat: {
+              payload: {
+                $ref: '#/components/schemas/Cat'
+              }
+            }
+          },
+          schemas: {
+            Pet: {
+              title: 'Pet',
+              type: 'object',
+              discriminator: '@petType',
+              properties: {
+                '@petType': {
+                  type: 'string'
+                }
+              },
+              required: ['@petType']
             },
             Cat: {
               title: 'Cat',

--- a/test/generators/java/JavaGenerator.spec.ts
+++ b/test/generators/java/JavaGenerator.spec.ts
@@ -326,6 +326,9 @@ describe('JavaGenerator', () => {
               properties: {
                 petType: {
                   type: 'string'
+                },
+                color: {
+                  type: 'string'
                 }
               },
               required: ['petType']

--- a/test/generators/java/JavaGenerator.spec.ts
+++ b/test/generators/java/JavaGenerator.spec.ts
@@ -385,7 +385,7 @@ describe('JavaGenerator', () => {
   });
 
   describe('allowInheritance with discriminator containing a special character', () => {
-    test('should create interface for Animal, Pet and Dog', async () => {
+    test('should create interface for Animal, Pet and Fish', async () => {
       const asyncapiDoc = {
         asyncapi: '2.5.0',
         info: {
@@ -422,12 +422,12 @@ describe('JavaGenerator', () => {
             }
           },
           schemas: {
-            Animal: {
-              title: 'Animal',
+            Pet: {
+              title: 'Pet',
               type: 'object',
-              discriminator: '@animalType',
+              discriminator: '@petType',
               properties: {
-                '@animalType': {
+                '@petType': {
                   type: 'string'
                 }
               },

--- a/test/generators/java/JavaGenerator.spec.ts
+++ b/test/generators/java/JavaGenerator.spec.ts
@@ -398,10 +398,10 @@ describe('JavaGenerator', () => {
               message: {
                 oneOf: [
                   {
-                    $ref: '#/components/messages/Boxer'
+                    $ref: '#/components/messages/FlyingFish'
                   },
                   {
-                    $ref: '#/components/messages/Cat'
+                    $ref: '#/components/messages/Bird'
                   }
                 ]
               }
@@ -410,56 +410,56 @@ describe('JavaGenerator', () => {
         },
         components: {
           messages: {
-            Boxer: {
+            FlyingFish: {
               payload: {
-                $ref: '#/components/schemas/Boxer'
+                $ref: '#/components/schemas/FlyingFish'
               }
             },
-            Cat: {
+            Bird: {
               payload: {
-                $ref: '#/components/schemas/Cat'
+                $ref: '#/components/schemas/Bird'
               }
             }
           },
           schemas: {
-            Pet: {
-              title: 'Pet',
+            Animal: {
+              title: 'Animal',
               type: 'object',
-              discriminator: '@petType',
+              discriminator: '@animalType',
               properties: {
-                '@petType': {
+                '@animalType': {
                   type: 'string'
                 }
               },
-              required: ['@petType']
+              required: ['@animalType']
             },
-            Cat: {
-              title: 'Cat',
+            Bird: {
+              title: 'Bird',
               allOf: [
                 {
-                  $ref: '#/components/schemas/Pet'
+                  $ref: '#/components/schemas/Animal'
                 }
               ]
             },
-            Dog: {
-              title: 'Dog',
+            Fish: {
+              title: 'Fish',
               allOf: [
                 {
-                  $ref: '#/components/schemas/Pet'
+                  $ref: '#/components/schemas/Animal'
                 }
               ]
             },
-            Boxer: {
-              title: 'Boxer',
+            FlyingFish: {
+              title: 'FlyingFish',
               type: 'object',
               allOf: [
                 {
-                  $ref: '#/components/schemas/Dog'
+                  $ref: '#/components/schemas/Fish'
                 }
               ],
               properties: {
                 breed: {
-                  const: 'Boxer'
+                  const: 'FlyingNemo'
                 }
               }
             }

--- a/test/generators/java/JavaGenerator.spec.ts
+++ b/test/generators/java/JavaGenerator.spec.ts
@@ -431,13 +431,13 @@ describe('JavaGenerator', () => {
                   type: 'string'
                 }
               },
-              required: ['@animalType']
+              required: ['@petType']
             },
             Bird: {
               title: 'Bird',
               allOf: [
                 {
-                  $ref: '#/components/schemas/Animal'
+                  $ref: '#/components/schemas/Pet'
                 }
               ]
             },
@@ -445,7 +445,7 @@ describe('JavaGenerator', () => {
               title: 'Fish',
               allOf: [
                 {
-                  $ref: '#/components/schemas/Animal'
+                  $ref: '#/components/schemas/Pet'
                 }
               ]
             },

--- a/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
+++ b/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
@@ -139,24 +139,24 @@ public interface Animal {
 
 exports[`JavaGenerator allowInheritance with discriminator containing a special character should create interface for Animal, Pet and Dog 1`] = `
 Array [
-  "@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.EXISTING_PROPERTY, property=\\"@petType\\", visible=true)
+  "@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.EXISTING_PROPERTY, property=\\"@animalType\\", visible=true)
 @JsonSubTypes({
-  @JsonSubTypes.Type(value = Boxer.class, name = \\"Boxer\\"),
-  @JsonSubTypes.Type(value = Cat.class, name = \\"Cat\\")
+  @JsonSubTypes.Type(value = FlyingFish.class, name = \\"FlyingFish\\"),
+  @JsonSubTypes.Type(value = Bird.class, name = \\"Bird\\")
 })
 /**
- * Animal represents a union of types: Boxer, Cat
+ * Animal represents a union of types: FlyingFish, Bird
  */
 public interface Animal {
-  String getAtPetType();
+  String getAtAnimalType();
 }",
-  "public class Boxer implements Animal, Dog {
+  "public class FlyingFish implements Animal, Fish {
   @JsonProperty(\\"breed\\")
   @JsonInclude(JsonInclude.Include.NON_NULL)
-  private final String breed = \\"Boxer\\";
+  private final String breed = \\"FlyingNemo\\";
   @NotNull
-  @JsonProperty(\\"@petType\\")
-  private String atPetType;
+  @JsonProperty(\\"@animalType\\")
+  private String atAnimalType;
   @JsonAnySetter
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Map<String, Object> additionalProperties;
@@ -164,9 +164,9 @@ public interface Animal {
   public String getBreed() { return this.breed; }
 
   @Override
-  public String getAtPetType() { return this.atPetType; }
+  public String getAtAnimalType() { return this.atAnimalType; }
   @Override
-  public void setAtPetType(String atPetType) { this.atPetType = atPetType; }
+  public void setAtAnimalType(String atAnimalType) { this.atAnimalType = atAnimalType; }
 
   @JsonAnyGetter
   public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
@@ -180,23 +180,23 @@ public interface Animal {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    Boxer self = (Boxer) o;
+    FlyingFish self = (FlyingFish) o;
       return 
         Objects.equals(this.breed, self.breed) &&
-        Objects.equals(this.atPetType, self.atPetType) &&
+        Objects.equals(this.atAnimalType, self.atAnimalType) &&
         Objects.equals(this.additionalProperties, self.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash((Object)breed, (Object)atPetType, (Object)additionalProperties);
+    return Objects.hash((Object)breed, (Object)atAnimalType, (Object)additionalProperties);
   }
 
   @Override
   public String toString() {
-    return \\"class Boxer {\\\\n\\" +   
+    return \\"class FlyingFish {\\\\n\\" +   
       \\"    breed: \\" + toIndentedString(breed) + \\"\\\\n\\" +
-      \\"    atPetType: \\" + toIndentedString(atPetType) + \\"\\\\n\\" +
+      \\"    atAnimalType: \\" + toIndentedString(atAnimalType) + \\"\\\\n\\" +
       \\"    additionalProperties: \\" + toIndentedString(additionalProperties) + \\"\\\\n\\" +
     \\"}\\";
   }
@@ -212,22 +212,22 @@ public interface Animal {
     return o.toString().replace(\\"\\\\n\\", \\"\\\\n    \\");
   }
 }",
-  "public interface Dog extends Pet {
+  "public interface Fish extends Animal {
   
 }",
-  "public interface Pet {
+  "public interface Animal {
   
 }",
-  "public class Cat implements Animal, Pet {
+  "public class Bird implements Animal, Animal {
   @NotNull
-  @JsonProperty(\\"@petType\\")
-  private String atPetType;
+  @JsonProperty(\\"@animalType\\")
+  private String atAnimalType;
   @JsonAnySetter
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Map<String, Object> additionalProperties;
 
-  public String getAtPetType() { return this.atPetType; }
-  public void setAtPetType(String atPetType) { this.atPetType = atPetType; }
+  public String getAtAnimalType() { return this.atAnimalType; }
+  public void setAtAnimalType(String atAnimalType) { this.atAnimalType = atAnimalType; }
 
   @JsonAnyGetter
   public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
@@ -241,21 +241,21 @@ public interface Animal {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    Cat self = (Cat) o;
+    Bird self = (Bird) o;
       return 
-        Objects.equals(this.atPetType, self.atPetType) &&
+        Objects.equals(this.atAnimalType, self.atAnimalType) &&
         Objects.equals(this.additionalProperties, self.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash((Object)atPetType, (Object)additionalProperties);
+    return Objects.hash((Object)atAnimalType, (Object)additionalProperties);
   }
 
   @Override
   public String toString() {
-    return \\"class Cat {\\\\n\\" +   
-      \\"    atPetType: \\" + toIndentedString(atPetType) + \\"\\\\n\\" +
+    return \\"class Bird {\\\\n\\" +   
+      \\"    atAnimalType: \\" + toIndentedString(atAnimalType) + \\"\\\\n\\" +
       \\"    additionalProperties: \\" + toIndentedString(additionalProperties) + \\"\\\\n\\" +
     \\"}\\";
   }

--- a/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
+++ b/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
@@ -228,7 +228,9 @@ public interface Animal {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Map<String, Object> additionalProperties;
 
+  @Override
   public String getAtPetType() { return this.atPetType; }
+  @Override
   public void setAtPetType(String atPetType) { this.atPetType = atPetType; }
 
   @JsonAnyGetter

--- a/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
+++ b/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
@@ -137,6 +137,143 @@ public interface Animal {
 ]
 `;
 
+exports[`JavaGenerator allowInheritance with discriminator containing a special character should create interface for Animal, Pet and Dog 1`] = `
+Array [
+  "@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.EXISTING_PROPERTY, property=\\"@petType\\", visible=true)
+@JsonSubTypes({
+  @JsonSubTypes.Type(value = Boxer.class, name = \\"Boxer\\"),
+  @JsonSubTypes.Type(value = Cat.class, name = \\"Cat\\")
+})
+/**
+ * Animal represents a union of types: Boxer, Cat
+ */
+public interface Animal {
+  String getAtPetType();
+}",
+  "public class Boxer implements Animal, Dog {
+  @JsonProperty(\\"breed\\")
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private final String breed = \\"Boxer\\";
+  @NotNull
+  @JsonProperty(\\"@petType\\")
+  private String atPetType;
+  @JsonAnySetter
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private Map<String, Object> additionalProperties;
+
+  public String getBreed() { return this.breed; }
+
+  @Override
+  public String getAtPetType() { return this.atPetType; }
+  @Override
+  public void setAtPetType(String atPetType) { this.atPetType = atPetType; }
+
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
+  public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Boxer self = (Boxer) o;
+      return 
+        Objects.equals(this.breed, self.breed) &&
+        Objects.equals(this.atPetType, self.atPetType) &&
+        Objects.equals(this.additionalProperties, self.additionalProperties);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash((Object)breed, (Object)atPetType, (Object)additionalProperties);
+  }
+
+  @Override
+  public String toString() {
+    return \\"class Boxer {\\\\n\\" +   
+      \\"    breed: \\" + toIndentedString(breed) + \\"\\\\n\\" +
+      \\"    atPetType: \\" + toIndentedString(atPetType) + \\"\\\\n\\" +
+      \\"    additionalProperties: \\" + toIndentedString(additionalProperties) + \\"\\\\n\\" +
+    \\"}\\";
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return \\"null\\";
+    }
+    return o.toString().replace(\\"\\\\n\\", \\"\\\\n    \\");
+  }
+}",
+  "public interface Dog extends Pet {
+  
+}",
+  "public interface Pet {
+  
+}",
+  "public class Cat implements Animal, Pet {
+  @NotNull
+  @JsonProperty(\\"@petType\\")
+  private String atPetType;
+  @JsonAnySetter
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private Map<String, Object> additionalProperties;
+
+  public String getAtPetType() { return this.atPetType; }
+  public void setAtPetType(String atPetType) { this.atPetType = atPetType; }
+
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
+  public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Cat self = (Cat) o;
+      return 
+        Objects.equals(this.atPetType, self.atPetType) &&
+        Objects.equals(this.additionalProperties, self.additionalProperties);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash((Object)atPetType, (Object)additionalProperties);
+  }
+
+  @Override
+  public String toString() {
+    return \\"class Cat {\\\\n\\" +   
+      \\"    atPetType: \\" + toIndentedString(atPetType) + \\"\\\\n\\" +
+      \\"    additionalProperties: \\" + toIndentedString(additionalProperties) + \\"\\\\n\\" +
+    \\"}\\";
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return \\"null\\";
+    }
+    return o.toString().replace(\\"\\\\n\\", \\"\\\\n    \\");
+  }
+}",
+]
+`;
+
 exports[`JavaGenerator oneOf/discriminator should create an interface 1`] = `
 Array [
   "/**

--- a/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
+++ b/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
@@ -137,9 +137,9 @@ public interface Animal {
 ]
 `;
 
-exports[`JavaGenerator allowInheritance with discriminator containing a special character should create interface for Animal, Pet and Dog 1`] = `
+exports[`JavaGenerator allowInheritance with discriminator containing a special character should create interface for Animal, Pet and Fish 1`] = `
 Array [
-  "@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.EXISTING_PROPERTY, property=\\"@animalType\\", visible=true)
+  "@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.EXISTING_PROPERTY, property=\\"@petType\\", visible=true)
 @JsonSubTypes({
   @JsonSubTypes.Type(value = FlyingFish.class, name = \\"FlyingFish\\"),
   @JsonSubTypes.Type(value = Bird.class, name = \\"Bird\\")
@@ -148,15 +148,15 @@ Array [
  * Animal represents a union of types: FlyingFish, Bird
  */
 public interface Animal {
-  String getAtAnimalType();
+  String getAtPetType();
 }",
   "public class FlyingFish implements Animal, Fish {
   @JsonProperty(\\"breed\\")
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private final String breed = \\"FlyingNemo\\";
   @NotNull
-  @JsonProperty(\\"@animalType\\")
-  private String atAnimalType;
+  @JsonProperty(\\"@petType\\")
+  private String atPetType;
   @JsonAnySetter
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Map<String, Object> additionalProperties;
@@ -164,9 +164,9 @@ public interface Animal {
   public String getBreed() { return this.breed; }
 
   @Override
-  public String getAtAnimalType() { return this.atAnimalType; }
+  public String getAtPetType() { return this.atPetType; }
   @Override
-  public void setAtAnimalType(String atAnimalType) { this.atAnimalType = atAnimalType; }
+  public void setAtPetType(String atPetType) { this.atPetType = atPetType; }
 
   @JsonAnyGetter
   public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
@@ -183,20 +183,20 @@ public interface Animal {
     FlyingFish self = (FlyingFish) o;
       return 
         Objects.equals(this.breed, self.breed) &&
-        Objects.equals(this.atAnimalType, self.atAnimalType) &&
+        Objects.equals(this.atPetType, self.atPetType) &&
         Objects.equals(this.additionalProperties, self.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash((Object)breed, (Object)atAnimalType, (Object)additionalProperties);
+    return Objects.hash((Object)breed, (Object)atPetType, (Object)additionalProperties);
   }
 
   @Override
   public String toString() {
     return \\"class FlyingFish {\\\\n\\" +   
       \\"    breed: \\" + toIndentedString(breed) + \\"\\\\n\\" +
-      \\"    atAnimalType: \\" + toIndentedString(atAnimalType) + \\"\\\\n\\" +
+      \\"    atPetType: \\" + toIndentedString(atPetType) + \\"\\\\n\\" +
       \\"    additionalProperties: \\" + toIndentedString(additionalProperties) + \\"\\\\n\\" +
     \\"}\\";
   }
@@ -212,22 +212,22 @@ public interface Animal {
     return o.toString().replace(\\"\\\\n\\", \\"\\\\n    \\");
   }
 }",
-  "public interface Fish extends Animal {
+  "public interface Fish extends Pet {
   
 }",
-  "public interface Animal {
+  "public interface Pet {
   
 }",
-  "public class Bird implements Animal, Animal {
+  "public class Bird implements Animal, Pet {
   @NotNull
-  @JsonProperty(\\"@animalType\\")
-  private String atAnimalType;
+  @JsonProperty(\\"@petType\\")
+  private String atPetType;
   @JsonAnySetter
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Map<String, Object> additionalProperties;
 
-  public String getAtAnimalType() { return this.atAnimalType; }
-  public void setAtAnimalType(String atAnimalType) { this.atAnimalType = atAnimalType; }
+  public String getAtPetType() { return this.atPetType; }
+  public void setAtPetType(String atPetType) { this.atPetType = atPetType; }
 
   @JsonAnyGetter
   public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
@@ -243,19 +243,19 @@ public interface Animal {
     }
     Bird self = (Bird) o;
       return 
-        Objects.equals(this.atAnimalType, self.atAnimalType) &&
+        Objects.equals(this.atPetType, self.atPetType) &&
         Objects.equals(this.additionalProperties, self.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash((Object)atAnimalType, (Object)additionalProperties);
+    return Objects.hash((Object)atPetType, (Object)additionalProperties);
   }
 
   @Override
   public String toString() {
     return \\"class Bird {\\\\n\\" +   
-      \\"    atAnimalType: \\" + toIndentedString(atAnimalType) + \\"\\\\n\\" +
+      \\"    atPetType: \\" + toIndentedString(atPetType) + \\"\\\\n\\" +
       \\"    additionalProperties: \\" + toIndentedString(additionalProperties) + \\"\\\\n\\" +
     \\"}\\";
   }

--- a/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
+++ b/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
@@ -150,6 +150,7 @@ Array [
  */
 public interface Animal {
   String getAtPetType();
+  void setAtPetType(String atPetType);
 }",
   "public class FlyingFish implements Animal, Fish {
   @JsonProperty(\\"breed\\")

--- a/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
+++ b/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
@@ -21,6 +21,9 @@ public interface Animal {
   @NotNull
   @JsonProperty(\\"petType\\")
   private String petType;
+  @JsonProperty(\\"color\\")
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private String color;
   @JsonAnySetter
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Map<String, Object> additionalProperties;
@@ -31,6 +34,11 @@ public interface Animal {
   public String getPetType() { return this.petType; }
   @Override
   public void setPetType(String petType) { this.petType = petType; }
+
+  @Override
+  public String getColor() { return this.color; }
+  @Override
+  public void setColor(String color) { this.color = color; }
 
   @JsonAnyGetter
   public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
@@ -48,12 +56,13 @@ public interface Animal {
       return 
         Objects.equals(this.breed, self.breed) &&
         Objects.equals(this.petType, self.petType) &&
+        Objects.equals(this.color, self.color) &&
         Objects.equals(this.additionalProperties, self.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash((Object)breed, (Object)petType, (Object)additionalProperties);
+    return Objects.hash((Object)breed, (Object)petType, (Object)color, (Object)additionalProperties);
   }
 
   @Override
@@ -61,6 +70,7 @@ public interface Animal {
     return \\"class Boxer {\\\\n\\" +   
       \\"    breed: \\" + toIndentedString(breed) + \\"\\\\n\\" +
       \\"    petType: \\" + toIndentedString(petType) + \\"\\\\n\\" +
+      \\"    color: \\" + toIndentedString(color) + \\"\\\\n\\" +
       \\"    additionalProperties: \\" + toIndentedString(additionalProperties) + \\"\\\\n\\" +
     \\"}\\";
   }
@@ -77,21 +87,33 @@ public interface Animal {
   }
 }",
   "public interface Dog extends Pet {
-  
+  public String getColor();
+  public void setColor(String color);
 }",
   "public interface Pet {
-  
+  public String getColor();
+  public void setColor(String color);
 }",
   "public class Cat implements Animal, Pet {
   @NotNull
   @JsonProperty(\\"petType\\")
   private String petType;
+  @JsonProperty(\\"color\\")
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private String color;
   @JsonAnySetter
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Map<String, Object> additionalProperties;
 
+  @Override
   public String getPetType() { return this.petType; }
+  @Override
   public void setPetType(String petType) { this.petType = petType; }
+
+  @Override
+  public String getColor() { return this.color; }
+  @Override
+  public void setColor(String color) { this.color = color; }
 
   @JsonAnyGetter
   public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
@@ -108,18 +130,20 @@ public interface Animal {
     Cat self = (Cat) o;
       return 
         Objects.equals(this.petType, self.petType) &&
+        Objects.equals(this.color, self.color) &&
         Objects.equals(this.additionalProperties, self.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash((Object)petType, (Object)additionalProperties);
+    return Objects.hash((Object)petType, (Object)color, (Object)additionalProperties);
   }
 
   @Override
   public String toString() {
     return \\"class Cat {\\\\n\\" +   
       \\"    petType: \\" + toIndentedString(petType) + \\"\\\\n\\" +
+      \\"    color: \\" + toIndentedString(color) + \\"\\\\n\\" +
       \\"    additionalProperties: \\" + toIndentedString(additionalProperties) + \\"\\\\n\\" +
     \\"}\\";
   }

--- a/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
+++ b/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
@@ -17,8 +17,8 @@ public interface Animal {
   @JsonProperty(\\"breed\\")
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private final String breed = \\"Boxer\\";
+  @NotNull
   @JsonProperty(\\"petType\\")
-  @JsonInclude(JsonInclude.Include.NON_NULL)
   private String petType;
   @JsonAnySetter
   @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -82,8 +82,8 @@ public interface Animal {
   
 }",
   "public class Cat implements Animal, Pet {
+  @NotNull
   @JsonProperty(\\"petType\\")
-  @JsonInclude(JsonInclude.Include.NON_NULL)
   private String petType;
   @JsonAnySetter
   @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/test/generators/java/presets/__snapshots__/DescriptionPreset.spec.ts.snap
+++ b/test/generators/java/presets/__snapshots__/DescriptionPreset.spec.ts.snap
@@ -8,6 +8,7 @@ Array [
   private String test2;
   private Map<String, Object> additionalProperties;
 
+  @Override
   public DiscriminatorTest getType() { return this.type; }
 
   @Override


### PR DESCRIPTION
## Description
This PR fixes issue: https://github.com/asyncapi/modelina/issues/2229

It was partially supported. The overriden getters on the subclasses where generated correct. But the getter on the union was generated in correctly due to no support for special chars. This lead to compile errors in the generated code.

## Related Issue
<!-- If this pull request is related to any existing issue, mention it here. -->

## Checklist
- [x] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [x] Tests have been added or updated to cover the changes.
- [x] Documentation has been updated to reflect the changes.
- [x] All tests pass successfully locally.(`npm run test`).

## Additional Notes
<!-- Add any additional information or context that might be relevant to reviewers. -->
