### PR TITLE
feat: add missing setter in union interface leading to compile errors in implementing classes

### DIFF
--- a/src/generators/java/JavaPreset.ts
+++ b/src/generators/java/JavaPreset.ts
@@ -48,6 +48,9 @@ export interface UnionPreset<R extends AbstractRenderer, O>
   discriminatorGetter?: (
     args: PresetArgs<R, O, ConstrainedUnionModel>
   ) => string;
+  discriminatorSetter?: (
+    args: PresetArgs<R, O, ConstrainedUnionModel>
+  ) => string;
 }
 
 export type RecordPresetType<O> = InterfacePreset<RecordRenderer, O>;

--- a/src/generators/java/renderers/UnionRenderer.ts
+++ b/src/generators/java/renderers/UnionRenderer.ts
@@ -20,7 +20,8 @@ export class UnionRenderer extends JavaRenderer<ConstrainedUnionModel> {
     const content = [];
 
     if (this.model.options.discriminator) {
-      content.push(await this.runDiscriminatorAccessorPreset());
+      content.push(await this.runDiscriminatorGetterPreset());
+      content.push(await this.runDiscriminatorSetterPreset());
     }
     content.push(await this.runAdditionalContentPreset());
 
@@ -32,8 +33,12 @@ export class UnionRenderer extends JavaRenderer<ConstrainedUnionModel> {
     ]);
   }
 
-  runDiscriminatorAccessorPreset(): Promise<string> {
+  runDiscriminatorGetterPreset(): Promise<string> {
     return this.runPreset('discriminatorGetter');
+  }
+
+  runDiscriminatorSetterPreset(): Promise<string> {
+    return this.runPreset('discriminatorSetter');
   }
 }
 
@@ -49,5 +54,16 @@ export const JAVA_DEFAULT_UNION_PRESET: UnionPresetType<JavaOptions> = {
     return `${model.options.discriminator.type} get${FormatHelpers.toPascalCase(
       model.options.discriminator.discriminator
     )}();`;
+  },
+  discriminatorSetter({ model }) {
+    if (!model.options.discriminator?.type) {
+      return '';
+    }
+
+    return `void set${FormatHelpers.toPascalCase(
+      model.options.discriminator.discriminator
+    )}(${model.options.discriminator.type} ${FormatHelpers.toCamelCase(
+      model.options.discriminator.discriminator
+    )});`;
   }
 };

--- a/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
+++ b/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
@@ -12,6 +12,7 @@ Array [
  */
 public interface Animal {
   String getPetType();
+  void setPetType(String petType);
 }",
   "public class Boxer implements Animal, Dog {
   @JsonProperty(\\"breed\\")
@@ -144,6 +145,7 @@ Array [
  */
 public interface Vehicle {
   VehicleType getVehicleType();
+  void setVehicleType(VehicleType vehicleType);
 }",
   "public class Car implements Vehicle {
   private final VehicleType vehicleType = VehicleType.CAR;

--- a/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
+++ b/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
@@ -303,6 +303,7 @@ Array [
  */
 public interface Pet {
   CloudEventType getType();
+  void setType(CloudEventType type);
 }",
   "public class Dog implements Pet {
   @NotNull
@@ -807,6 +808,7 @@ Array [
  */
 public interface Vehicle {
   VehicleType getVehicleType();
+  void setVehicleType(VehicleType vehicleType);
 }",
   "public class Cargo {
   @Valid

--- a/test/generators/java/presets/__snapshots__/JacksonPreset.spec.ts.snap
+++ b/test/generators/java/presets/__snapshots__/JacksonPreset.spec.ts.snap
@@ -93,6 +93,7 @@ Array [
  */
 public interface Vehicle {
   String getVehicleType();
+  void setVehicleType(String vehicleType);
 }",
   "public class Car implements Vehicle {
   @JsonProperty(\\"vehicle_type\\")
@@ -151,6 +152,7 @@ Array [
  */
 public interface Vehicle {
   String getVehicleType();
+  void setVehicleType(String vehicleType);
 }",
   "public class Car implements Vehicle {
   @JsonProperty(\\"vehicleType\\")
@@ -197,6 +199,7 @@ Array [
  */
 public interface Vehicle {
   String getVehicleType();
+  void setVehicleType(String vehicleType);
 }",
   "public class Car implements Vehicle {
   @JsonProperty(\\"vehicleType\\")


### PR DESCRIPTION
This PR fixes issue https://github.com/asyncapi/modelina/issues/2230

**Another option is to remove the setter on the generated class using the union interface**
If you guys like that more, let me know and I will change it

## Description
<!-- Provide a brief description of the changes introduced by this pull request. -->

## Related Issue
<!-- If this pull request is related to any existing issue, mention it here. -->

## Checklist
- [x] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [x] Tests have been added or updated to cover the changes.
- [x] Documentation has been updated to reflect the changes.
- [x] All tests pass successfully locally.(`npm run test`).

## Additional Notes
<!-- Add any additional information or context that might be relevant to reviewers. -->
