### PR TITLE
fix(csharp-json-generator): remove CanConvert override for Json converters

### DIFF
--- a/examples/csharp-generate-json-serializer/__snapshots__/index.spec.ts.snap
+++ b/examples/csharp-generate-json-serializer/__snapshots__/index.spec.ts.snap
@@ -7,7 +7,7 @@ public partial class Root
 {
   private string? email;
 
-  public string? Email 
+  public string? Email
   {
     get { return email; }
     set { this.email = value; }
@@ -18,7 +18,7 @@ public partial class Root
     {
       return this.Serialize(null);
     }
-    public string Serialize(JsonSerializerOptions options = null) 
+    public string Serialize(JsonSerializerOptions options = null)
     {
       return JsonSerializer.Serialize(this, options);
     }
@@ -32,11 +32,6 @@ public partial class Root
 
 internal class RootConverter : JsonConverter<Root>
 {
-  public override bool CanConvert(System.Type objectType)
-  {
-    // this converter can be applied to any type
-    return true;
-  }
   public override Root Read(ref Utf8JsonReader reader, System.Type typeToConvert, JsonSerializerOptions options)
   {
     if (reader.TokenType != JsonTokenType.StartObject)
@@ -45,7 +40,7 @@ internal class RootConverter : JsonConverter<Root>
     }
 
     var instance = new Root();
-  
+
     while (reader.Read())
     {
       if (reader.TokenType == JsonTokenType.EndObject)
@@ -67,7 +62,7 @@ internal class RootConverter : JsonConverter<Root>
           continue;
         }
     }
-  
+
     throw new JsonException();
   }
   public override void Write(Utf8JsonWriter writer, Root value, JsonSerializerOptions options)
@@ -78,7 +73,7 @@ internal class RootConverter : JsonConverter<Root>
       return;
     }
     var properties = value.GetType().GetProperties();
-  
+
     writer.WriteStartObject();
 
     if(value.Email != null) {

--- a/examples/csharp-generate-json-serializer/__snapshots__/index.spec.ts.snap
+++ b/examples/csharp-generate-json-serializer/__snapshots__/index.spec.ts.snap
@@ -7,7 +7,7 @@ public partial class Root
 {
   private string? email;
 
-  public string? Email
+  public string? Email 
   {
     get { return email; }
     set { this.email = value; }
@@ -18,7 +18,7 @@ public partial class Root
     {
       return this.Serialize(null);
     }
-    public string Serialize(JsonSerializerOptions options = null)
+    public string Serialize(JsonSerializerOptions options = null) 
     {
       return JsonSerializer.Serialize(this, options);
     }
@@ -40,7 +40,7 @@ internal class RootConverter : JsonConverter<Root>
     }
 
     var instance = new Root();
-
+  
     while (reader.Read())
     {
       if (reader.TokenType == JsonTokenType.EndObject)
@@ -62,7 +62,7 @@ internal class RootConverter : JsonConverter<Root>
           continue;
         }
     }
-
+  
     throw new JsonException();
   }
   public override void Write(Utf8JsonWriter writer, Root value, JsonSerializerOptions options)
@@ -73,7 +73,7 @@ internal class RootConverter : JsonConverter<Root>
       return;
     }
     var properties = value.GetType().GetProperties();
-
+  
     writer.WriteStartObject();
 
     if(value.Email != null) {

--- a/src/generators/csharp/presets/JsonSerializerPreset.ts
+++ b/src/generators/csharp/presets/JsonSerializerPreset.ts
@@ -244,11 +244,6 @@ ${content}
 
 internal class ${model.name}Converter : JsonConverter<${model.name}>
 {
-  public override bool CanConvert(System.Type objectType)
-  {
-    // this converter can be applied to any type
-    return true;
-  }
 ${renderer.indent(deserialize)}
 ${renderer.indent(serialize)}
 

--- a/test/generators/csharp/presets/__snapshots__/JsonSerializerPreset.spec.ts.snap
+++ b/test/generators/csharp/presets/__snapshots__/JsonSerializerPreset.spec.ts.snap
@@ -65,11 +65,6 @@ public partial class Test
 
 internal class TestConverter : JsonConverter<Test>
 {
-  public override bool CanConvert(System.Type objectType)
-  {
-    // this converter can be applied to any type
-    return true;
-  }
   public override Test Read(ref Utf8JsonReader reader, System.Type typeToConvert, JsonSerializerOptions options)
   {
     if (reader.TokenType != JsonTokenType.StartObject)
@@ -259,11 +254,6 @@ public partial class NestedTest
 
 internal class NestedTestConverter : JsonConverter<NestedTest>
 {
-  public override bool CanConvert(System.Type objectType)
-  {
-    // this converter can be applied to any type
-    return true;
-  }
   public override NestedTest Read(ref Utf8JsonReader reader, System.Type typeToConvert, JsonSerializerOptions options)
   {
     if (reader.TokenType != JsonTokenType.StartObject)


### PR DESCRIPTION
## Description
I ran into errors where the generated class's custom JsonConverter implementation was applying to objects that it should not be applying to. It applied the same JsonConverter to the properties of the object. For example, lets say we have a class called `Robot` and two properties (`name: string`, and `id: System.Guid`). If `CanConvert` always returns `true`, then when parsing a json string to the `Robot` class, it will use the `RobotConverter` on the `System.Guid` causing it to fail.

According to [Microsoft Documentation](https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/converters-how-to):
```
Override the CanConvert method only if necessary.
The default implementation returns true when the type to convert is of type T.
Therefore, converters that support only type T don't need to override this method.
```

## Related Issue
<!-- If this pull request is related to any existing issue, mention it here. -->

## Checklist
- [x] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [x] Tests have been added or updated to cover the changes.
- [ ] Documentation has been updated to reflect the changes.
- [x] All tests pass successfully locally.(`npm run test`).

## Additional Notes
<!-- Add any additional information or context that might be relevant to reviewers. -->
