### PR TITLE
fix: gracefully handle unknown properties

### DIFF
--- a/examples/csharp-generate-json-serializer/__snapshots__/index.spec.ts.snap
+++ b/examples/csharp-generate-json-serializer/__snapshots__/index.spec.ts.snap
@@ -62,7 +62,7 @@ internal class RootConverter : JsonConverter<Root>
           continue;
         }
       // Gracefully handle/ignore unknown fields
-      JsonSerilizer.Deserialize(ref reader, options);
+      JsonSerializer.Deserialize<JsonElement>(ref reader, options);
     }
   
     throw new JsonException(\\"Unexpected end of JSON\\");

--- a/examples/csharp-generate-json-serializer/__snapshots__/index.spec.ts.snap
+++ b/examples/csharp-generate-json-serializer/__snapshots__/index.spec.ts.snap
@@ -36,7 +36,7 @@ internal class RootConverter : JsonConverter<Root>
   {
     if (reader.TokenType != JsonTokenType.StartObject)
     {
-      throw new JsonException();
+      throw new JsonException(\\"Unexpected start of JSON\\");
     }
 
     var instance = new Root();
@@ -51,7 +51,7 @@ internal class RootConverter : JsonConverter<Root>
       // Get the key.
       if (reader.TokenType != JsonTokenType.PropertyName)
       {
-        throw new JsonException();
+        throw new JsonException(\\"Unexpected property name token in JSON\\");
       }
 
       string propertyName = reader.GetString();
@@ -61,9 +61,11 @@ internal class RootConverter : JsonConverter<Root>
           instance.Email = value;
           continue;
         }
+      // Gracefully handle/ignore unknown fields
+      JsonSerilizer.Deserialize(ref reader, options);
     }
   
-    throw new JsonException();
+    throw new JsonException(\\"Unexpected end of JSON\\");
   }
   public override void Write(Utf8JsonWriter writer, Root value, JsonSerializerOptions options)
   {

--- a/src/generators/csharp/presets/JsonSerializerPreset.ts
+++ b/src/generators/csharp/presets/JsonSerializerPreset.ts
@@ -177,7 +177,7 @@ function renderDeserialize({
 {
   if (reader.TokenType != JsonTokenType.StartObject)
   {
-    throw new JsonException();
+    throw new JsonException("Unexpected start of JSON");
   }
 
   var instance = new ${model.name}();
@@ -192,14 +192,16 @@ function renderDeserialize({
     // Get the key.
     if (reader.TokenType != JsonTokenType.PropertyName)
     {
-      throw new JsonException();
+      throw new JsonException("Unexpected property name token in JSON");
     }
 
     string propertyName = reader.GetString();
 ${renderer.indent(deserializeProperties, 4)}
+    // Gracefully handle/ignore unknown fields
+    JsonSerilizer.Deserialize(ref reader, options);
   }
   
-  throw new JsonException();
+  throw new JsonException("Unexpected end of JSON");
 }`;
 }
 

--- a/src/generators/csharp/presets/JsonSerializerPreset.ts
+++ b/src/generators/csharp/presets/JsonSerializerPreset.ts
@@ -198,7 +198,7 @@ function renderDeserialize({
     string propertyName = reader.GetString();
 ${renderer.indent(deserializeProperties, 4)}
     // Gracefully handle/ignore unknown fields
-    JsonSerilizer.Deserialize(ref reader, options);
+    JsonSerializer.Deserialize<JsonElement>(ref reader, options);
   }
   
   throw new JsonException("Unexpected end of JSON");

--- a/test/generators/csharp/presets/__snapshots__/JsonSerializerPreset.spec.ts.snap
+++ b/test/generators/csharp/presets/__snapshots__/JsonSerializerPreset.spec.ts.snap
@@ -69,7 +69,7 @@ internal class TestConverter : JsonConverter<Test>
   {
     if (reader.TokenType != JsonTokenType.StartObject)
     {
-      throw new JsonException();
+      throw new JsonException(\\"Unexpected start of JSON\\");
     }
 
     var instance = new Test();
@@ -84,7 +84,7 @@ internal class TestConverter : JsonConverter<Test>
       // Get the key.
       if (reader.TokenType != JsonTokenType.PropertyName)
       {
-        throw new JsonException();
+        throw new JsonException(\\"Unexpected property name token in JSON\\");
       }
 
       string propertyName = reader.GetString();
@@ -116,9 +116,11 @@ internal class TestConverter : JsonConverter<Test>
             var deserializedValue = JsonSerializer.Deserialize<Dictionary<string, dynamic>?>(ref reader, options);
             instance.AdditionalProperties.Add(propertyName, deserializedValue);
             continue;
+      // Gracefully handle/ignore unknown fields
+      JsonSerilizer.Deserialize(ref reader, options);
     }
   
-    throw new JsonException();
+    throw new JsonException(\\"Unexpected end of JSON\\");
   }
   public override void Write(Utf8JsonWriter writer, Test value, JsonSerializerOptions options)
   {
@@ -258,7 +260,7 @@ internal class NestedTestConverter : JsonConverter<NestedTest>
   {
     if (reader.TokenType != JsonTokenType.StartObject)
     {
-      throw new JsonException();
+      throw new JsonException(\\"Unexpected start of JSON\\");
     }
 
     var instance = new NestedTest();
@@ -273,7 +275,7 @@ internal class NestedTestConverter : JsonConverter<NestedTest>
       // Get the key.
       if (reader.TokenType != JsonTokenType.PropertyName)
       {
-        throw new JsonException();
+        throw new JsonException(\\"Unexpected property name token in JSON\\");
       }
 
       string propertyName = reader.GetString();
@@ -287,9 +289,11 @@ internal class NestedTestConverter : JsonConverter<NestedTest>
             var deserializedValue = JsonSerializer.Deserialize<Dictionary<string, dynamic>?>(ref reader, options);
             instance.AdditionalProperties.Add(propertyName, deserializedValue);
             continue;
+      // Gracefully handle/ignore unknown fields
+      JsonSerilizer.Deserialize(ref reader, options);
     }
   
-    throw new JsonException();
+    throw new JsonException(\\"Unexpected end of JSON\\");
   }
   public override void Write(Utf8JsonWriter writer, NestedTest value, JsonSerializerOptions options)
   {

--- a/test/generators/csharp/presets/__snapshots__/JsonSerializerPreset.spec.ts.snap
+++ b/test/generators/csharp/presets/__snapshots__/JsonSerializerPreset.spec.ts.snap
@@ -117,7 +117,7 @@ internal class TestConverter : JsonConverter<Test>
             instance.AdditionalProperties.Add(propertyName, deserializedValue);
             continue;
       // Gracefully handle/ignore unknown fields
-      JsonSerilizer.Deserialize(ref reader, options);
+      JsonSerializer.Deserialize<JsonElement>(ref reader, options);
     }
   
     throw new JsonException(\\"Unexpected end of JSON\\");
@@ -290,7 +290,7 @@ internal class NestedTestConverter : JsonConverter<NestedTest>
             instance.AdditionalProperties.Add(propertyName, deserializedValue);
             continue;
       // Gracefully handle/ignore unknown fields
-      JsonSerilizer.Deserialize(ref reader, options);
+      JsonSerializer.Deserialize<JsonElement>(ref reader, options);
     }
   
     throw new JsonException(\\"Unexpected end of JSON\\");


### PR DESCRIPTION
## Description
I ran into issues where a json string fails to `Deserialize` if there are unknown properties in the json document.

This happens because when an unknown property is read, we do not move the reader forward to the next property token.
For example, `Address.cs`

```
public override Address Read(ref Utf8JsonReader reader, System.Type typeToConvert, JsonSerializerOptions options)
    {
      if (reader.TokenType != JsonTokenType.StartObject)
      {
        throw new JsonException();
      }

      var instance = new Address();
  
      while (reader.Read())
      {
        if (reader.TokenType == JsonTokenType.EndObject)
        {
          return instance;
        }

        // Get the key.
        if (reader.TokenType != JsonTokenType.PropertyName)
        {
          throw new JsonException();
        }

        string propertyName = reader.GetString();
        if (propertyName == "id")
          {
            var value = JsonSerializer.Deserialize<System.Guid?>(ref reader, options);
            instance.Id = value;
            continue;
          }
      }
  
      throw new JsonException();
    }
```

if we have an unknown property say `color` and `backyard`, this snippet will process `id` fine but once it gets to the unknown `color` property, it:
1. Passes the StartObject check
2. Passes the EndObject check
3. Passes the PropertyName check
4. Gets the propertyName of `color`
5. Skips past all if checks
6. Goes back to the while loop `reader.Read()`
7. Passes the EndObject check
8. Fails at the PropertyName check

This fails because when we process a known `propertyName` `JsonSerializer.Deserialize` also calls `reader.Read()` to move the reader forward to the next `propertyName` instead an invalid location (the value)

Adding `JsonSerializer.Deserialize<JsonElement>(ref reader, options);` to the end of the if checks, allows the reader to move forward to the next property token instead of failing. JsonElement is a catch all which can parse primitives, objects, array, nulls.

## Related Issue
<!-- If this pull request is related to any existing issue, mention it here. -->

## Checklist
- [x] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [x] Tests have been added or updated to cover the changes.
- [ ] Documentation has been updated to reflect the changes.
- [x] All tests pass successfully locally.(`npm run test`).

## Additional Notes
<!-- Add any additional information or context that might be relevant to reviewers. -->
