### PR TITLE
fix: update `openapi-types` to `^v12.1.3`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "alterschema": "^1.1.2",
         "change-case": "^4.1.2",
         "js-yaml": "^4.1.0",
-        "openapi-types": "9.3.0",
+        "openapi-types": "^12.1.3",
         "typescript-json-schema": "^0.58.1"
       },
       "devDependencies": {
@@ -8595,9 +8595,9 @@
       }
     },
     "node_modules/openapi-types": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-9.3.0.tgz",
-      "integrity": "sha512-sR23YjmuwDSMsQVZDHbV9mPgi0RyniQlqR0AQxTC2/F3cpSjRFMH3CFPjoWvNqhC4OxPkDYNb2l8Mc1Me6D/KQ=="
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw=="
     },
     "node_modules/optionator": {
       "version": "0.9.4",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@asyncapi/multi-parser": "^2.2.0",
     "alterschema": "^1.1.2",
     "change-case": "^4.1.2",
-    "openapi-types": "9.3.0",
+    "openapi-types": "^12.1.3",
     "typescript-json-schema": "^0.58.1",
     "js-yaml": "^4.1.0"
   },


### PR DESCRIPTION
## Description

In one of our project we have a project where `tsconfig.json` option `skipLibCheck` is `false` _(disabled by default)_.
In this project our type check part of the CI is failing due to type issues inside the old version `openapi-types`, which is a direct dependency of `@asyncapi/modelina`.

This is the error we're getting:

```log
TS2344: Type 'T' does not satisfy the constraint '{}'.

16         paths: PathsObject<T>;
                              ~

  <redacted>/node_modules/openapi-types/dist/index.d.ts:15:34
    15     type PathsWebhooksComponents<T> = {
                                        ~
    This type parameter might need an `extends {}` constraint.

Found 1 error in <redacted>/node_modules/openapi-types/dist/index.d.ts:16
```

So, updating `openapi-types` would help us get rid of this problem.

## Checklist

- [x] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [ ] Tests have been added or updated to cover the changes.
- [ ] Documentation has been updated to reflect the changes.
- [x] All tests pass successfully locally.(`npm run test`).

## Additional Notes
