### PR TITLE
feat: support common properties in unions for java generator

### DIFF
--- a/docs/internal-model.md
+++ b/docs/internal-model.md
@@ -62,6 +62,7 @@ classDiagram
     class UnionModel{
         <<class>>
         MetaModel[] unionModels
+        &lt;String, ObjectPropertyModel&gt; properties
     }
 
     class EnumValueModel{
@@ -180,7 +181,7 @@ classDiagram
 
     class ConstrainedObjectModel{
         <<class>>
-        &lt;String, ObjectPropertyModel&gt; properties
+        &lt;String, ConstrainedObjectPropertyModel&gt; properties
     }
 
     class ConstrainedObjectPropertyModel{
@@ -198,6 +199,7 @@ classDiagram
     class ConstrainedUnionModel{
         <<class>>
         ConstrainedMetaModel[] unionModels
+        &lt;String, ConstrainedObjectPropertyModel&gt; properties
     }
 
     class ConstrainedEnumValueModel{

--- a/src/generators/cplusplus/constrainer/PropertyKeyConstrainer.ts
+++ b/src/generators/cplusplus/constrainer/PropertyKeyConstrainer.ts
@@ -1,4 +1,9 @@
-import { ConstrainedObjectModel, ObjectModel } from '../../../models';
+import {
+  ConstrainedObjectModel,
+  ConstrainedUnionModel,
+  ObjectModel,
+  UnionModel
+} from '../../../models';
 import {
   NO_NUMBER_START_CHAR,
   NO_DUPLICATE_PROPERTIES,
@@ -12,8 +17,8 @@ export type PropertyKeyConstraintOptions = {
   NO_SPECIAL_CHAR: (value: string) => string;
   NO_NUMBER_START_CHAR: (value: string) => string;
   NO_DUPLICATE_PROPERTIES: (
-    constrainedObjectModel: ConstrainedObjectModel,
-    objectModel: ObjectModel,
+    constrainedObjectModel: ConstrainedObjectModel | ConstrainedUnionModel,
+    objectModel: ObjectModel | UnionModel,
     propertyName: string,
     namingFormatter: (value: string) => string
   ) => string;

--- a/src/generators/csharp/constrainer/PropertyKeyConstrainer.ts
+++ b/src/generators/csharp/constrainer/PropertyKeyConstrainer.ts
@@ -1,4 +1,9 @@
-import { ConstrainedObjectModel, ObjectModel } from '../../../models';
+import {
+  ConstrainedObjectModel,
+  ConstrainedUnionModel,
+  ObjectModel,
+  UnionModel
+} from '../../../models';
 import {
   NO_NUMBER_START_CHAR,
   NO_DUPLICATE_PROPERTIES,
@@ -13,8 +18,8 @@ export type PropertyKeyConstraintOptions = {
   NO_SPECIAL_CHAR: (value: string) => string;
   NO_NUMBER_START_CHAR: (value: string) => string;
   NO_DUPLICATE_PROPERTIES: (
-    constrainedObjectModel: ConstrainedObjectModel,
-    objectModel: ObjectModel,
+    constrainedObjectModel: ConstrainedObjectModel | ConstrainedUnionModel,
+    objectModel: ObjectModel | UnionModel,
     propertyName: string,
     namingFormatter: (value: string) => string
   ) => string;
@@ -22,7 +27,7 @@ export type PropertyKeyConstraintOptions = {
   NAMING_FORMATTER: (value: string) => string;
   NO_RESERVED_KEYWORDS: (value: string) => string;
   NO_ENCLOSING_NAMES: (
-    constrainedObjectModel: ConstrainedObjectModel,
+    constrainedObjectModel: ConstrainedObjectModel | ConstrainedUnionModel,
     value: string
   ) => string;
 };

--- a/src/generators/dart/constrainer/PropertyKeyConstrainer.ts
+++ b/src/generators/dart/constrainer/PropertyKeyConstrainer.ts
@@ -1,4 +1,9 @@
-import { ConstrainedObjectModel, ObjectModel } from '../../../models';
+import {
+  ConstrainedObjectModel,
+  ConstrainedUnionModel,
+  ObjectModel,
+  UnionModel
+} from '../../../models';
 import {
   NO_NUMBER_START_CHAR,
   NO_DUPLICATE_PROPERTIES,
@@ -13,8 +18,8 @@ export type PropertyKeyConstraintOptions = {
   NO_SPECIAL_CHAR: (value: string) => string;
   NO_NUMBER_START_CHAR: (value: string) => string;
   NO_DUPLICATE_PROPERTIES: (
-    constrainedObjectModel: ConstrainedObjectModel,
-    objectModel: ObjectModel,
+    constrainedObjectModel: ConstrainedObjectModel | ConstrainedUnionModel,
+    objectModel: ObjectModel | UnionModel,
     propertyName: string,
     namingFormatter: (value: string) => string
   ) => string;

--- a/src/generators/go/constrainer/PropertyKeyConstrainer.ts
+++ b/src/generators/go/constrainer/PropertyKeyConstrainer.ts
@@ -1,4 +1,9 @@
-import { ConstrainedObjectModel, ObjectModel } from '../../../models';
+import {
+  ConstrainedObjectModel,
+  ConstrainedUnionModel,
+  ObjectModel,
+  UnionModel
+} from '../../../models';
 import {
   NO_NUMBER_START_CHAR,
   NO_DUPLICATE_PROPERTIES,
@@ -13,8 +18,8 @@ export type PropertyKeyConstraintOptions = {
   NO_SPECIAL_CHAR: (value: string) => string;
   NO_NUMBER_START_CHAR: (value: string) => string;
   NO_DUPLICATE_PROPERTIES: (
-    constrainedObjectModel: ConstrainedObjectModel,
-    objectModel: ObjectModel,
+    constrainedObjectModel: ConstrainedObjectModel | ConstrainedUnionModel,
+    objectModel: ObjectModel | UnionModel,
     propertyName: string,
     namingFormatter: (value: string) => string
   ) => string;

--- a/src/generators/java/JavaPreset.ts
+++ b/src/generators/java/JavaPreset.ts
@@ -8,7 +8,8 @@ import {
   ConstrainedEnumModel,
   CommonPreset,
   ConstrainedUnionModel,
-  InterfacePreset
+  InterfacePreset,
+  PropertyArgs
 } from '../../models';
 import { JavaOptions } from './JavaGenerator';
 import {
@@ -48,9 +49,12 @@ export interface UnionPreset<R extends AbstractRenderer, O>
   discriminatorGetter?: (
     args: PresetArgs<R, O, ConstrainedUnionModel>
   ) => string;
-  discriminatorSetter?: (
-    args: PresetArgs<R, O, ConstrainedUnionModel>
-  ) => string;
+  getter?: (
+    args: PresetArgs<R, O, ConstrainedUnionModel> & PropertyArgs
+  ) => Promise<string> | string;
+  setter?: (
+    args: PresetArgs<R, O, ConstrainedUnionModel> & PropertyArgs
+  ) => Promise<string> | string;
 }
 
 export type RecordPresetType<O> = InterfacePreset<RecordRenderer, O>;

--- a/src/generators/java/constrainer/PropertyKeyConstrainer.ts
+++ b/src/generators/java/constrainer/PropertyKeyConstrainer.ts
@@ -1,4 +1,9 @@
-import { ConstrainedObjectModel, ObjectModel } from '../../../models';
+import {
+  ConstrainedObjectModel,
+  ConstrainedUnionModel,
+  ObjectModel,
+  UnionModel
+} from '../../../models';
 import {
   NO_NUMBER_START_CHAR,
   NO_DUPLICATE_PROPERTIES,
@@ -13,8 +18,8 @@ export type PropertyKeyConstraintOptions = {
   NO_SPECIAL_CHAR: (value: string) => string;
   NO_NUMBER_START_CHAR: (value: string) => string;
   NO_DUPLICATE_PROPERTIES: (
-    constrainedObjectModel: ConstrainedObjectModel,
-    objectModel: ObjectModel,
+    constrainedObjectModel: ConstrainedObjectModel | ConstrainedUnionModel,
+    objectModel: ObjectModel | UnionModel,
     propertyName: string,
     namingFormatter: (value: string) => string
   ) => string;

--- a/src/generators/java/renderers/UnionRenderer.ts
+++ b/src/generators/java/renderers/UnionRenderer.ts
@@ -86,7 +86,10 @@ export const JAVA_DEFAULT_UNION_PRESET: UnionPresetType<JavaOptions> = {
     )}();`;
   },
   getter({ property, model, options }) {
-    if (property.propertyName === model.options.discriminator?.discriminator) {
+    if (
+      property.unconstrainedPropertyName ===
+      model.options.discriminator?.discriminator
+    ) {
       return '';
     }
     return `${property.property.type} ${getterName(
@@ -95,7 +98,10 @@ export const JAVA_DEFAULT_UNION_PRESET: UnionPresetType<JavaOptions> = {
     )}();`;
   },
   setter({ property, model, options }) {
-    if (property.propertyName === model.options.discriminator?.discriminator) {
+    if (
+      property.unconstrainedPropertyName ===
+      model.options.discriminator?.discriminator
+    ) {
       return '';
     }
     if (options.modelType === 'record') {

--- a/src/generators/javascript/constrainer/PropertyKeyConstrainer.ts
+++ b/src/generators/javascript/constrainer/PropertyKeyConstrainer.ts
@@ -1,4 +1,9 @@
-import { ConstrainedObjectModel, ObjectModel } from '../../../models';
+import {
+  ConstrainedObjectModel,
+  ConstrainedUnionModel,
+  ObjectModel,
+  UnionModel
+} from '../../../models';
 import {
   NO_NUMBER_START_CHAR,
   NO_DUPLICATE_PROPERTIES,
@@ -13,8 +18,8 @@ export type PropertyKeyConstraintOptions = {
   NO_SPECIAL_CHAR: (value: string) => string;
   NO_NUMBER_START_CHAR: (value: string) => string;
   NO_DUPLICATE_PROPERTIES: (
-    constrainedObjectModel: ConstrainedObjectModel,
-    objectModel: ObjectModel,
+    constrainedObjectModel: ConstrainedObjectModel | ConstrainedUnionModel,
+    objectModel: ObjectModel | UnionModel,
     propertyName: string,
     namingFormatter: (value: string) => string
   ) => string;

--- a/src/generators/kotlin/constrainer/PropertyKeyConstrainer.ts
+++ b/src/generators/kotlin/constrainer/PropertyKeyConstrainer.ts
@@ -1,4 +1,9 @@
-import { ConstrainedObjectModel, ObjectModel } from '../../../models';
+import {
+  ConstrainedObjectModel,
+  ConstrainedUnionModel,
+  ObjectModel,
+  UnionModel
+} from '../../../models';
 import {
   NO_NUMBER_START_CHAR,
   NO_DUPLICATE_PROPERTIES,
@@ -13,8 +18,8 @@ export type PropertyKeyConstraintOptions = {
   NO_SPECIAL_CHAR: (value: string) => string;
   NO_NUMBER_START_CHAR: (value: string) => string;
   NO_DUPLICATE_PROPERTIES: (
-    constrainedObjectModel: ConstrainedObjectModel,
-    objectModel: ObjectModel,
+    constrainedObjectModel: ConstrainedObjectModel | ConstrainedUnionModel,
+    objectModel: ObjectModel | UnionModel,
     propertyName: string,
     namingFormatter: (value: string) => string
   ) => string;

--- a/src/generators/php/constrainer/PropertyKeyConstrainer.ts
+++ b/src/generators/php/constrainer/PropertyKeyConstrainer.ts
@@ -1,4 +1,9 @@
-import { ConstrainedObjectModel, ObjectModel } from '../../../models';
+import {
+  ConstrainedObjectModel,
+  ConstrainedUnionModel,
+  ObjectModel,
+  UnionModel
+} from '../../../models';
 import {
   NO_NUMBER_START_CHAR,
   NO_DUPLICATE_PROPERTIES,
@@ -13,8 +18,8 @@ export type PropertyKeyConstraintOptions = {
   NO_SPECIAL_CHAR: (value: string) => string;
   NO_NUMBER_START_CHAR: (value: string) => string;
   NO_DUPLICATE_PROPERTIES: (
-    constrainedObjectModel: ConstrainedObjectModel,
-    objectModel: ObjectModel,
+    constrainedObjectModel: ConstrainedObjectModel | ConstrainedUnionModel,
+    objectModel: ObjectModel | UnionModel,
     propertyName: string,
     namingFormatter: (value: string) => string
   ) => string;

--- a/src/generators/python/constrainer/PropertyKeyConstrainer.ts
+++ b/src/generators/python/constrainer/PropertyKeyConstrainer.ts
@@ -1,4 +1,9 @@
-import { ConstrainedObjectModel, ObjectModel } from '../../../models';
+import {
+  ConstrainedObjectModel,
+  ConstrainedUnionModel,
+  ObjectModel,
+  UnionModel
+} from '../../../models';
 import {
   NO_NUMBER_START_CHAR,
   NO_DUPLICATE_PROPERTIES,
@@ -13,8 +18,8 @@ export type PropertyKeyConstraintOptions = {
   NO_SPECIAL_CHAR: (value: string) => string;
   NO_NUMBER_START_CHAR: (value: string) => string;
   NO_DUPLICATE_PROPERTIES: (
-    constrainedObjectModel: ConstrainedObjectModel,
-    objectModel: ObjectModel,
+    constrainedObjectModel: ConstrainedObjectModel | ConstrainedUnionModel,
+    objectModel: ObjectModel | UnionModel,
     propertyName: string,
     namingFormatter: (value: string) => string
   ) => string;

--- a/src/generators/rust/constrainer/PropertyKeyConstrainer.ts
+++ b/src/generators/rust/constrainer/PropertyKeyConstrainer.ts
@@ -1,4 +1,9 @@
-import { ConstrainedObjectModel, ObjectModel } from '../../../models';
+import {
+  ConstrainedObjectModel,
+  ConstrainedUnionModel,
+  ObjectModel,
+  UnionModel
+} from '../../../models';
 import {
   NO_NUMBER_START_CHAR,
   NO_DUPLICATE_PROPERTIES,
@@ -13,8 +18,8 @@ export type PropertyKeyConstraintOptions = {
   NO_SPECIAL_CHAR: (value: string) => string;
   NO_NUMBER_START_CHAR: (value: string) => string;
   NO_DUPLICATE_PROPERTIES: (
-    constrainedObjectModel: ConstrainedObjectModel,
-    objectModel: ObjectModel,
+    constrainedObjectModel: ConstrainedObjectModel | ConstrainedUnionModel,
+    objectModel: ObjectModel | UnionModel,
     propertyName: string,
     namingFormatter: (value: string) => string
   ) => string;

--- a/src/generators/scala/constrainer/PropertyKeyConstrainer.ts
+++ b/src/generators/scala/constrainer/PropertyKeyConstrainer.ts
@@ -1,4 +1,9 @@
-import { ConstrainedObjectModel, ObjectModel } from '../../../models';
+import {
+  ConstrainedObjectModel,
+  ConstrainedUnionModel,
+  ObjectModel,
+  UnionModel
+} from '../../../models';
 import {
   NO_NUMBER_START_CHAR,
   NO_DUPLICATE_PROPERTIES,
@@ -13,8 +18,8 @@ export type PropertyKeyConstraintOptions = {
   NO_SPECIAL_CHAR: (value: string) => string;
   NO_NUMBER_START_CHAR: (value: string) => string;
   NO_DUPLICATE_PROPERTIES: (
-    constrainedObjectModel: ConstrainedObjectModel,
-    objectModel: ObjectModel,
+    constrainedObjectModel: ConstrainedObjectModel | ConstrainedUnionModel,
+    objectModel: ObjectModel | UnionModel,
     propertyName: string,
     namingFormatter: (value: string) => string
   ) => string;

--- a/src/generators/template/constrainer/PropertyKeyConstrainer.ts
+++ b/src/generators/template/constrainer/PropertyKeyConstrainer.ts
@@ -1,4 +1,4 @@
-import { ConstrainedObjectModel, ObjectModel } from '../../../models';
+import { ConstrainedObjectModel, ConstrainedUnionModel, ObjectModel, UnionModel } from '../../../models';
 import {
   NO_NUMBER_START_CHAR,
   NO_DUPLICATE_PROPERTIES,
@@ -13,8 +13,8 @@ export type PropertyKeyConstraintOptions = {
   NO_SPECIAL_CHAR: (value: string) => string;
   NO_NUMBER_START_CHAR: (value: string) => string;
   NO_DUPLICATE_PROPERTIES: (
-    constrainedObjectModel: ConstrainedObjectModel,
-    objectModel: ObjectModel,
+    constrainedObjectModel: ConstrainedObjectModel | ConstrainedUnionModel,
+    objectModel: ObjectModel | UnionModel,
     propertyName: string,
     namingFormatter: (value: string) => string
   ) => string;

--- a/src/generators/typescript/constrainer/PropertyKeyConstrainer.ts
+++ b/src/generators/typescript/constrainer/PropertyKeyConstrainer.ts
@@ -1,4 +1,9 @@
-import { ConstrainedObjectModel, ObjectModel } from '../../../models';
+import {
+  ConstrainedObjectModel,
+  ConstrainedUnionModel,
+  ObjectModel,
+  UnionModel
+} from '../../../models';
 import {
   NO_NUMBER_START_CHAR,
   NO_DUPLICATE_PROPERTIES,
@@ -16,8 +21,8 @@ export type PropertyKeyConstraintOptions = {
   NO_SPECIAL_CHAR: (value: string) => string;
   NO_NUMBER_START_CHAR: (value: string) => string;
   NO_DUPLICATE_PROPERTIES: (
-    constrainedObjectModel: ConstrainedObjectModel,
-    objectModel: ObjectModel,
+    constrainedObjectModel: ConstrainedObjectModel | ConstrainedUnionModel,
+    objectModel: ObjectModel | UnionModel,
     propertyName: string,
     namingFormatter: (value: string) => string
   ) => string;

--- a/src/helpers/AvroToMetaModel.ts
+++ b/src/helpers/AvroToMetaModel.ts
@@ -245,7 +245,8 @@ export function toUnionModel(
     name,
     avroSchemaModel.originalInput,
     getMetaModelOptions(avroSchemaModel),
-    []
+    [],
+    {}
   );
 
   //cache model before continuing

--- a/src/helpers/CommonModelToMetaModel.ts
+++ b/src/helpers/CommonModelToMetaModel.ts
@@ -236,12 +236,27 @@ export function convertToUnionModel(
     name,
     jsonSchemaModel.originalInput,
     getMetaModelOptions(jsonSchemaModel, options),
-    []
+    [],
+    {}
   );
 
   //cache model before continuing
   if (!alreadySeenModels.has(jsonSchemaModel)) {
     alreadySeenModels.set(jsonSchemaModel, unionModel);
+  }
+
+  for (const [propertyName, prop] of Object.entries(
+    jsonSchemaModel.properties || {}
+  )) {
+    const isRequired = jsonSchemaModel.isRequired(propertyName);
+
+    const propertyModel = new ObjectPropertyModel(
+      propertyName,
+      isRequired,
+      convertToMetaModel({ ...context, jsonSchemaModel: prop })
+    );
+
+    unionModel.properties[String(propertyName)] = propertyModel;
   }
 
   // Has multiple types, so convert to union
@@ -513,7 +528,8 @@ function convertAdditionalAndPatterns(context: ConverterContext) {
     name,
     getOriginalInputFromAdditionalAndPatterns(jsonSchemaModel),
     getMetaModelOptions(jsonSchemaModel, options),
-    Array.from(modelsAsValue.values())
+    Array.from(modelsAsValue.values()),
+    {}
   );
 }
 
@@ -669,7 +685,8 @@ export function convertToArrayModel(
     'union',
     jsonSchemaModel.originalInput,
     getMetaModelOptions(jsonSchemaModel, options),
-    []
+    [],
+    {}
   );
   const metaModel = new ArrayModel(
     name,

--- a/src/helpers/ConstrainHelpers.ts
+++ b/src/helpers/ConstrainHelpers.ts
@@ -18,6 +18,7 @@ import {
 import {
   ObjectModel,
   EnumModel,
+  UnionModel,
   MetaModel,
   ObjectPropertyModel
 } from '../models/MetaModel';
@@ -68,8 +69,8 @@ export type ModelNameConstraint<Options> = (
 export type PropertyKeyContext<Options> = {
   constrainedObjectPropertyModel: ConstrainedObjectPropertyModel;
   objectPropertyModel: ObjectPropertyModel;
-  constrainedObjectModel: ConstrainedObjectModel;
-  objectModel: ObjectModel;
+  constrainedObjectModel: ConstrainedObjectModel | ConstrainedUnionModel;
+  objectModel: ObjectModel | UnionModel;
   options: Options;
 };
 

--- a/src/helpers/ConstrainedTypes.ts
+++ b/src/helpers/ConstrainedTypes.ts
@@ -260,6 +260,20 @@ function walkUnionNode<
       // eslint-disable-next-line security/detect-object-injection
       unionModel.union[index] = overwriteUnionModel;
     }
+
+    for (const [propertyKey, propertyModel] of Object.entries({
+      ...unionModel.properties
+    })) {
+      const overWriteModel = applyTypesAndConst({
+        ...context,
+        constrainedModel: propertyModel.property,
+        partOfProperty: propertyModel
+      });
+      if (overWriteModel) {
+        // eslint-disable-next-line security/detect-object-injection
+        unionModel.properties[propertyKey].property = overWriteModel;
+      }
+    }
   }
 }
 

--- a/src/helpers/Constraints.ts
+++ b/src/helpers/Constraints.ts
@@ -1,8 +1,9 @@
 import {
   ConstrainedObjectModel,
-  ConstrainedEnumModel
+  ConstrainedEnumModel,
+  ConstrainedUnionModel
 } from '../models/ConstrainedMetaModel';
-import { ObjectModel, EnumModel } from '../models/MetaModel';
+import { ObjectModel, EnumModel, UnionModel } from '../models/MetaModel';
 
 export function NO_NUMBER_START_CHAR(value: string): string {
   const firstChar = value.charAt(0);
@@ -23,8 +24,8 @@ export function NO_NUMBER_START_CHAR(value: string): string {
  * @param namingFormatter the name formatter which are used to format the property key
  */
 export function NO_DUPLICATE_PROPERTIES(
-  constrainedObjectModel: ConstrainedObjectModel,
-  objectModel: ObjectModel,
+  constrainedObjectModel: ConstrainedObjectModel | ConstrainedUnionModel,
+  objectModel: ObjectModel | UnionModel,
   propertyName: string,
   namingFormatter: (value: string) => string
 ): string {

--- a/src/interpreter/InterpretAllOf.ts
+++ b/src/interpreter/InterpretAllOf.ts
@@ -52,8 +52,7 @@ export default function interpretAllOf(
 
     if (interpreterOptions.allowInheritance === true) {
       const allOfModelWithoutCache = interpreter.interpret(allOfSchema, {
-        ...interpreterOptions,
-        disableCache: true
+        ...interpreterOptions
       });
 
       if (allOfModelWithoutCache && isModelObject(allOfModelWithoutCache)) {

--- a/src/models/CommonModel.ts
+++ b/src/models/CommonModel.ts
@@ -463,7 +463,9 @@ export class CommonModel {
       return;
     }
     this.extend = this.extend ?? [];
-    this.extend.push(extendedModel);
+    if (!this.extend.some((item) => item.$id === extendedModel.$id)) {
+      this.extend.push(extendedModel);
+    }
   }
 
   /**

--- a/src/models/ConstrainedMetaModel.ts
+++ b/src/models/ConstrainedMetaModel.ts
@@ -176,7 +176,8 @@ export class ConstrainedUnionModel extends ConstrainedMetaModel {
     originalInput: any,
     options: ConstrainedMetaModelOptions,
     type: string,
-    public union: ConstrainedMetaModel[]
+    public union: ConstrainedMetaModel[],
+    public properties: { [key: string]: ConstrainedObjectPropertyModel }
   ) {
     super(name, originalInput, options, type);
   }

--- a/src/models/MetaModel.ts
+++ b/src/models/MetaModel.ts
@@ -87,7 +87,8 @@ export class UnionModel extends MetaModel {
     name: string,
     originalInput: any,
     options: MetaModelOptions,
-    public union: MetaModel[]
+    public union: MetaModel[],
+    public properties: { [key: string]: ObjectPropertyModel }
   ) {
     super(name, originalInput, options);
   }

--- a/test/generators/cplusplus/constrainer/PropertyKeyConstrainer.spec.ts
+++ b/test/generators/cplusplus/constrainer/PropertyKeyConstrainer.spec.ts
@@ -2,7 +2,8 @@ import {
   ConstrainedObjectModel,
   ConstrainedObjectPropertyModel,
   ObjectModel,
-  ObjectPropertyModel
+  ObjectPropertyModel,
+  CplusplusGenerator
 } from '../../../../src';
 import {
   PropertyKeyConstraintOptions,
@@ -35,7 +36,8 @@ describe('C++ PropertyKeyConstrainer', () => {
       constrainedObjectModel,
       objectModel,
       objectPropertyModel,
-      constrainedObjectPropertyModel
+      constrainedObjectPropertyModel,
+      options: CplusplusGenerator.defaultOptions
     });
   };
   test('should never render special chars', () => {
@@ -72,7 +74,8 @@ describe('C++ PropertyKeyConstrainer', () => {
       constrainedObjectModel,
       objectModel,
       objectPropertyModel,
-      constrainedObjectPropertyModel
+      constrainedObjectPropertyModel,
+      options: CplusplusGenerator.defaultOptions
     });
     expect(constrainedKey).toEqual('reserved_return');
   });
@@ -96,7 +99,8 @@ describe('C++ PropertyKeyConstrainer', () => {
         '',
         false,
         constrainedObjectModel
-      )
+      ),
+      options: CplusplusGenerator.defaultOptions
     });
 
     expect(constrainedKey).toEqual('_DEFAULT');

--- a/test/generators/java/JavaGenerator.spec.ts
+++ b/test/generators/java/JavaGenerator.spec.ts
@@ -601,6 +601,117 @@ describe('JavaGenerator', () => {
     });
   });
 
+  describe('allowInheritance with common properties and with special character', () => {
+    test('should create interface for Pet with common properties', async () => {
+      const asyncapiDoc = {
+        asyncapi: '2.5.0',
+        info: {
+          title: 'CloudEvent example',
+          version: '1.0.0'
+        },
+        channels: {
+          owner: {
+            publish: {
+              message: {
+                $ref: '#/components/messages/Owner'
+              }
+            }
+          }
+        },
+        components: {
+          messages: {
+            Cat: {
+              payload: {
+                $ref: '#/components/schemas/Cat'
+              }
+            },
+            Owner: {
+              payload: {
+                $ref: '#/components/schemas/Owner'
+              }
+            }
+          },
+          schemas: {
+            Pet: {
+              title: 'Pet',
+              type: 'object',
+              discriminator: '@petType',
+              properties: {
+                '@petType': {
+                  type: 'string'
+                },
+                color: {
+                  type: 'string'
+                }
+              },
+              oneOf: [
+                {
+                  $ref: '#/components/schemas/Cat'
+                },
+                {
+                  $ref: '#/components/schemas/Dog'
+                }
+              ],
+              required: ['@petType', 'color']
+            },
+            Cat: {
+              title: 'Cat',
+              allOf: [
+                {
+                  $ref: '#/components/schemas/Pet'
+                }
+              ]
+            },
+            Dog: {
+              title: 'Dog',
+              allOf: [
+                {
+                  $ref: '#/components/schemas/Pet'
+                }
+              ]
+            },
+            Owner: {
+              title: 'Owner',
+              type: 'object',
+              properties: {
+                name: {
+                  type: 'string'
+                },
+                age: {
+                  type: 'integer'
+                },
+                pet: {
+                  items: {
+                    $ref: '#/components/schemas/Pet'
+                  }
+                }
+              }
+            }
+          }
+        }
+      };
+
+      generator = new JavaGenerator({
+        presets: [
+          JAVA_COMMON_PRESET,
+          JAVA_JACKSON_PRESET,
+          JAVA_DESCRIPTION_PRESET,
+          JAVA_CONSTRAINTS_PRESET
+        ],
+        collectionType: 'List',
+        processorOptions: {
+          jsonSchema: {
+            disableCache: false,
+            allowInheritance: true
+          }
+        }
+      });
+
+      const models = await generator.generate(asyncapiDoc);
+      expect(models.map((model) => model.result)).toMatchSnapshot();
+    });
+  });
+
   describe('allowInheritance with common properties, using asyncapi 3.0', () => {
     test('should create interface for Pet with common properties', async () => {
       const asyncapiDoc = {

--- a/test/generators/java/JavaGenerator.spec.ts
+++ b/test/generators/java/JavaGenerator.spec.ts
@@ -376,7 +376,7 @@ describe('JavaGenerator', () => {
         ],
         collectionType: 'List',
         processorOptions: {
-          interpreter: {
+          jsonSchema: {
             allowInheritance: true
           }
         }
@@ -480,6 +480,359 @@ describe('JavaGenerator', () => {
         collectionType: 'List',
         processorOptions: {
           interpreter: {
+            allowInheritance: true
+          }
+        }
+      });
+
+      const models = await generator.generate(asyncapiDoc);
+      expect(models.map((model) => model.result)).toMatchSnapshot();
+    });
+  });
+
+  describe('allowInheritance with common properties', () => {
+    test('should create interface for Pet with common properties', async () => {
+      const asyncapiDoc = {
+        asyncapi: '2.5.0',
+        info: {
+          title: 'CloudEvent example',
+          version: '1.0.0'
+        },
+        channels: {
+          owner: {
+            publish: {
+              message: {
+                $ref: '#/components/messages/Owner'
+              }
+            }
+          }
+        },
+        components: {
+          messages: {
+            Cat: {
+              payload: {
+                $ref: '#/components/schemas/Cat'
+              }
+            },
+            Owner: {
+              payload: {
+                $ref: '#/components/schemas/Owner'
+              }
+            }
+          },
+          schemas: {
+            Pet: {
+              title: 'Pet',
+              type: 'object',
+              discriminator: 'petType',
+              properties: {
+                petType: {
+                  type: 'string'
+                },
+                color: {
+                  type: 'string'
+                }
+              },
+              oneOf: [
+                {
+                  $ref: '#/components/schemas/Cat'
+                },
+                {
+                  $ref: '#/components/schemas/Dog'
+                }
+              ],
+              required: ['petType', 'color']
+            },
+            Cat: {
+              title: 'Cat',
+              allOf: [
+                {
+                  $ref: '#/components/schemas/Pet'
+                }
+              ]
+            },
+            Dog: {
+              title: 'Dog',
+              allOf: [
+                {
+                  $ref: '#/components/schemas/Pet'
+                }
+              ]
+            },
+            Owner: {
+              title: 'Owner',
+              type: 'object',
+              properties: {
+                name: {
+                  type: 'string'
+                },
+                age: {
+                  type: 'integer'
+                },
+                pet: {
+                  items: {
+                    $ref: '#/components/schemas/Pet'
+                  }
+                }
+              }
+            }
+          }
+        }
+      };
+
+      generator = new JavaGenerator({
+        presets: [
+          JAVA_COMMON_PRESET,
+          JAVA_JACKSON_PRESET,
+          JAVA_DESCRIPTION_PRESET,
+          JAVA_CONSTRAINTS_PRESET
+        ],
+        collectionType: 'List',
+        processorOptions: {
+          jsonSchema: {
+            disableCache: false,
+            allowInheritance: true
+          }
+        }
+      });
+
+      const models = await generator.generate(asyncapiDoc);
+      expect(models.map((model) => model.result)).toMatchSnapshot();
+    });
+  });
+
+  describe('allowInheritance with common properties, using asyncapi 3.0', () => {
+    test('should create interface for Pet with common properties', async () => {
+      const asyncapiDoc = {
+        asyncapi: '3.0.0',
+        info: {
+          title: 'CloudEvent example 3',
+          version: '1.0.0'
+        },
+        channels: {
+          ownerCreated: {
+            address: 'owner-created',
+            messages: {
+              OwnerCreated: {
+                $ref: '#/components/messages/Owner'
+              }
+            }
+          }
+        },
+        operations: {
+          processOwnerCreated: {
+            action: 'receive',
+            channel: {
+              $ref: '#/channels/ownerCreated'
+            }
+          }
+        },
+        components: {
+          messages: {
+            Owner: {
+              payload: {
+                schema: {
+                  $ref: '#/components/schemas/Owner'
+                }
+              }
+            }
+          },
+          schemas: {
+            Pet: {
+              title: 'Pet',
+              type: 'object',
+              discriminator: 'petType',
+              properties: {
+                petType: {
+                  type: 'string'
+                },
+                color: {
+                  type: 'string'
+                }
+              },
+              oneOf: [
+                {
+                  $ref: '#/components/schemas/Cat'
+                },
+                {
+                  $ref: '#/components/schemas/Dog'
+                }
+              ],
+              required: ['petType', 'color']
+            },
+            Cat: {
+              title: 'Cat',
+              allOf: [
+                {
+                  $ref: '#/components/schemas/Pet'
+                }
+              ]
+            },
+            Dog: {
+              title: 'Dog',
+              allOf: [
+                {
+                  $ref: '#/components/schemas/Pet'
+                }
+              ]
+            },
+            Owner: {
+              title: 'Owner',
+              type: 'object',
+              properties: {
+                name: {
+                  type: 'string'
+                },
+                age: {
+                  type: 'integer'
+                },
+                pet: {
+                  items: {
+                    $ref: '#/components/schemas/Pet'
+                  }
+                }
+              }
+            }
+          }
+        }
+      };
+
+      generator = new JavaGenerator({
+        presets: [
+          JAVA_COMMON_PRESET,
+          JAVA_JACKSON_PRESET,
+          JAVA_DESCRIPTION_PRESET,
+          JAVA_CONSTRAINTS_PRESET
+        ],
+        collectionType: 'List',
+        processorOptions: {
+          jsonSchema: {
+            disableCache: false,
+            allowInheritance: true
+          }
+        }
+      });
+
+      const models = await generator.generate(asyncapiDoc);
+      expect(models.map((model) => model.result)).toMatchSnapshot();
+    });
+  });
+
+  describe('allowInheritance with common properties, using records', () => {
+    test('should create interface for Pet with common properties', async () => {
+      const asyncapiDoc = {
+        asyncapi: '3.0.0',
+        info: {
+          title: 'CloudEvent example 3',
+          version: '1.0.0'
+        },
+        channels: {
+          ownerCreated: {
+            address: 'owner-created',
+            messages: {
+              OwnerCreated: {
+                $ref: '#/components/messages/Owner'
+              }
+            }
+          }
+        },
+        operations: {
+          processOwnerCreated: {
+            action: 'receive',
+            channel: {
+              $ref: '#/channels/ownerCreated'
+            }
+          }
+        },
+        components: {
+          messages: {
+            Cat: {
+              payload: {
+                schema: {
+                  $ref: '#/components/schemas/Cat'
+                }
+              }
+            },
+            Owner: {
+              payload: {
+                schema: {
+                  $ref: '#/components/schemas/Owner'
+                }
+              }
+            }
+          },
+          schemas: {
+            Pet: {
+              title: 'Pet',
+              type: 'object',
+              discriminator: 'petType',
+              properties: {
+                petType: {
+                  type: 'string'
+                },
+                color: {
+                  type: 'string'
+                }
+              },
+              oneOf: [
+                {
+                  $ref: '#/components/schemas/Cat'
+                },
+                {
+                  $ref: '#/components/schemas/Dog'
+                }
+              ],
+              required: ['petType', 'color']
+            },
+            Cat: {
+              title: 'Cat',
+              allOf: [
+                {
+                  $ref: '#/components/schemas/Pet'
+                }
+              ]
+            },
+            Dog: {
+              title: 'Dog',
+              allOf: [
+                {
+                  $ref: '#/components/schemas/Pet'
+                }
+              ]
+            },
+            Owner: {
+              title: 'Owner',
+              type: 'object',
+              properties: {
+                name: {
+                  type: 'string'
+                },
+                age: {
+                  type: 'integer'
+                },
+                pet: {
+                  items: {
+                    $ref: '#/components/schemas/Pet'
+                  }
+                }
+              }
+            }
+          }
+        }
+      };
+
+      generator = new JavaGenerator({
+        presets: [
+          JAVA_COMMON_PRESET,
+          JAVA_JACKSON_PRESET,
+          JAVA_DESCRIPTION_PRESET,
+          JAVA_CONSTRAINTS_PRESET
+        ],
+        modelType: 'record',
+        collectionType: 'List',
+        processorOptions: {
+          jsonSchema: {
+            disableCache: false,
             allowInheritance: true
           }
         }

--- a/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
+++ b/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
@@ -373,6 +373,142 @@ public interface Pet {
 ]
 `;
 
+exports[`JavaGenerator allowInheritance with common properties in allOf should create interface for Pet with common properties 1`] = `
+Array [
+  "public class Owner {
+  @JsonProperty(\\"name\\")
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private String name;
+  @JsonProperty(\\"age\\")
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private Integer age;
+  @Valid
+  @JsonProperty(\\"pet\\")
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private List<Pet> pet;
+  @JsonAnySetter
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private Map<String, Object> additionalProperties;
+
+  public String getName() { return this.name; }
+  public void setName(String name) { this.name = name; }
+
+  public Integer getAge() { return this.age; }
+  public void setAge(Integer age) { this.age = age; }
+
+  public List<Pet> getPet() { return this.pet; }
+  public void setPet(List<Pet> pet) { this.pet = pet; }
+
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
+  public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Owner self = (Owner) o;
+      return 
+        Objects.equals(this.name, self.name) &&
+        Objects.equals(this.age, self.age) &&
+        Objects.equals(this.pet, self.pet) &&
+        Objects.equals(this.additionalProperties, self.additionalProperties);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash((Object)name, (Object)age, (Object)pet, (Object)additionalProperties);
+  }
+
+  @Override
+  public String toString() {
+    return \\"class Owner {\\\\n\\" +   
+      \\"    name: \\" + toIndentedString(name) + \\"\\\\n\\" +
+      \\"    age: \\" + toIndentedString(age) + \\"\\\\n\\" +
+      \\"    pet: \\" + toIndentedString(pet) + \\"\\\\n\\" +
+      \\"    additionalProperties: \\" + toIndentedString(additionalProperties) + \\"\\\\n\\" +
+    \\"}\\";
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return \\"null\\";
+    }
+    return o.toString().replace(\\"\\\\n\\", \\"\\\\n    \\");
+  }
+}",
+  "public class Pet {
+  @NotNull
+  @JsonProperty(\\"petType\\")
+  private String petType;
+  @NotNull
+  @JsonProperty(\\"color\\")
+  private String color;
+  @JsonAnySetter
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private Map<String, Object> additionalProperties;
+
+  public String getPetType() { return this.petType; }
+  public void setPetType(String petType) { this.petType = petType; }
+
+  public String getColor() { return this.color; }
+  public void setColor(String color) { this.color = color; }
+
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
+  public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Pet self = (Pet) o;
+      return 
+        Objects.equals(this.petType, self.petType) &&
+        Objects.equals(this.color, self.color) &&
+        Objects.equals(this.additionalProperties, self.additionalProperties);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash((Object)petType, (Object)color, (Object)additionalProperties);
+  }
+
+  @Override
+  public String toString() {
+    return \\"class Pet {\\\\n\\" +   
+      \\"    petType: \\" + toIndentedString(petType) + \\"\\\\n\\" +
+      \\"    color: \\" + toIndentedString(color) + \\"\\\\n\\" +
+      \\"    additionalProperties: \\" + toIndentedString(additionalProperties) + \\"\\\\n\\" +
+    \\"}\\";
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return \\"null\\";
+    }
+    return o.toString().replace(\\"\\\\n\\", \\"\\\\n    \\");
+  }
+}",
+]
+`;
+
 exports[`JavaGenerator allowInheritance with common properties should create interface for Pet with common properties 1`] = `
 Array [
   "@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.EXISTING_PROPERTY, property=\\"petType\\", visible=true)

--- a/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
+++ b/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
@@ -159,6 +159,220 @@ public interface Animal {
 ]
 `;
 
+exports[`JavaGenerator allowInheritance with common properties and with special character should create interface for Pet with common properties 1`] = `
+Array [
+  "@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.EXISTING_PROPERTY, property=\\"@petType\\", visible=true)
+@JsonSubTypes({
+  @JsonSubTypes.Type(value = Cat.class, name = \\"Cat\\"),
+  @JsonSubTypes.Type(value = Dog.class, name = \\"Dog\\")
+})
+/**
+ * Pet represents a union of types: Cat, Dog
+ */
+public interface Pet {
+  String getAtPetType();
+  String getColor();
+  void setColor(String color);
+}",
+  "public class Owner {
+  @JsonProperty(\\"name\\")
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private String name;
+  @JsonProperty(\\"age\\")
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private Integer age;
+  @Valid
+  @JsonProperty(\\"pet\\")
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private List<Pet> pet;
+  @JsonAnySetter
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private Map<String, Object> additionalProperties;
+
+  public String getName() { return this.name; }
+  public void setName(String name) { this.name = name; }
+
+  public Integer getAge() { return this.age; }
+  public void setAge(Integer age) { this.age = age; }
+
+  public List<Pet> getPet() { return this.pet; }
+  public void setPet(List<Pet> pet) { this.pet = pet; }
+
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
+  public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Owner self = (Owner) o;
+      return 
+        Objects.equals(this.name, self.name) &&
+        Objects.equals(this.age, self.age) &&
+        Objects.equals(this.pet, self.pet) &&
+        Objects.equals(this.additionalProperties, self.additionalProperties);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash((Object)name, (Object)age, (Object)pet, (Object)additionalProperties);
+  }
+
+  @Override
+  public String toString() {
+    return \\"class Owner {\\\\n\\" +   
+      \\"    name: \\" + toIndentedString(name) + \\"\\\\n\\" +
+      \\"    age: \\" + toIndentedString(age) + \\"\\\\n\\" +
+      \\"    pet: \\" + toIndentedString(pet) + \\"\\\\n\\" +
+      \\"    additionalProperties: \\" + toIndentedString(additionalProperties) + \\"\\\\n\\" +
+    \\"}\\";
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return \\"null\\";
+    }
+    return o.toString().replace(\\"\\\\n\\", \\"\\\\n    \\");
+  }
+}",
+  "public class Cat implements Pet {
+  @NotNull
+  @JsonProperty(\\"@petType\\")
+  private String atPetType;
+  @NotNull
+  @JsonProperty(\\"color\\")
+  private String color;
+  @JsonAnySetter
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private Map<String, Object> additionalProperties;
+
+  @Override
+  public String getAtPetType() { return this.atPetType; }
+
+  @Override
+  public String getColor() { return this.color; }
+  @Override
+  public void setColor(String color) { this.color = color; }
+
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
+  public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Cat self = (Cat) o;
+      return 
+        Objects.equals(this.atPetType, self.atPetType) &&
+        Objects.equals(this.color, self.color) &&
+        Objects.equals(this.additionalProperties, self.additionalProperties);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash((Object)atPetType, (Object)color, (Object)additionalProperties);
+  }
+
+  @Override
+  public String toString() {
+    return \\"class Cat {\\\\n\\" +   
+      \\"    atPetType: \\" + toIndentedString(atPetType) + \\"\\\\n\\" +
+      \\"    color: \\" + toIndentedString(color) + \\"\\\\n\\" +
+      \\"    additionalProperties: \\" + toIndentedString(additionalProperties) + \\"\\\\n\\" +
+    \\"}\\";
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return \\"null\\";
+    }
+    return o.toString().replace(\\"\\\\n\\", \\"\\\\n    \\");
+  }
+}",
+  "public class Dog implements Pet {
+  @NotNull
+  @JsonProperty(\\"@petType\\")
+  private String atPetType;
+  @NotNull
+  @JsonProperty(\\"color\\")
+  private String color;
+  @JsonAnySetter
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private Map<String, Object> additionalProperties;
+
+  @Override
+  public String getAtPetType() { return this.atPetType; }
+
+  @Override
+  public String getColor() { return this.color; }
+  @Override
+  public void setColor(String color) { this.color = color; }
+
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
+  public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Dog self = (Dog) o;
+      return 
+        Objects.equals(this.atPetType, self.atPetType) &&
+        Objects.equals(this.color, self.color) &&
+        Objects.equals(this.additionalProperties, self.additionalProperties);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash((Object)atPetType, (Object)color, (Object)additionalProperties);
+  }
+
+  @Override
+  public String toString() {
+    return \\"class Dog {\\\\n\\" +   
+      \\"    atPetType: \\" + toIndentedString(atPetType) + \\"\\\\n\\" +
+      \\"    color: \\" + toIndentedString(color) + \\"\\\\n\\" +
+      \\"    additionalProperties: \\" + toIndentedString(additionalProperties) + \\"\\\\n\\" +
+    \\"}\\";
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return \\"null\\";
+    }
+    return o.toString().replace(\\"\\\\n\\", \\"\\\\n    \\");
+  }
+}",
+]
+`;
+
 exports[`JavaGenerator allowInheritance with common properties should create interface for Pet with common properties 1`] = `
 Array [
   "@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.EXISTING_PROPERTY, property=\\"petType\\", visible=true)

--- a/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
+++ b/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
@@ -12,7 +12,6 @@ Array [
  */
 public interface Animal {
   String getPetType();
-  void setPetType(String petType);
 }",
   "public class Boxer implements Animal, Dog {
   @JsonProperty(\\"breed\\")
@@ -107,8 +106,6 @@ public interface Animal {
 
   @Override
   public String getPetType() { return this.petType; }
-  @Override
-  public void setPetType(String petType) { this.petType = petType; }
 
   @Override
   public String getColor() { return this.color; }
@@ -162,6 +159,451 @@ public interface Animal {
 ]
 `;
 
+exports[`JavaGenerator allowInheritance with common properties should create interface for Pet with common properties 1`] = `
+Array [
+  "@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.EXISTING_PROPERTY, property=\\"petType\\", visible=true)
+@JsonSubTypes({
+  @JsonSubTypes.Type(value = Cat.class, name = \\"Cat\\"),
+  @JsonSubTypes.Type(value = Dog.class, name = \\"Dog\\")
+})
+/**
+ * Pet represents a union of types: Cat, Dog
+ */
+public interface Pet {
+  String getPetType();
+  String getColor();
+  void setColor(String color);
+}",
+  "public class Owner {
+  @JsonProperty(\\"name\\")
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private String name;
+  @JsonProperty(\\"age\\")
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private Integer age;
+  @Valid
+  @JsonProperty(\\"pet\\")
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private List<Pet> pet;
+  @JsonAnySetter
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private Map<String, Object> additionalProperties;
+
+  public String getName() { return this.name; }
+  public void setName(String name) { this.name = name; }
+
+  public Integer getAge() { return this.age; }
+  public void setAge(Integer age) { this.age = age; }
+
+  public List<Pet> getPet() { return this.pet; }
+  public void setPet(List<Pet> pet) { this.pet = pet; }
+
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
+  public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Owner self = (Owner) o;
+      return 
+        Objects.equals(this.name, self.name) &&
+        Objects.equals(this.age, self.age) &&
+        Objects.equals(this.pet, self.pet) &&
+        Objects.equals(this.additionalProperties, self.additionalProperties);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash((Object)name, (Object)age, (Object)pet, (Object)additionalProperties);
+  }
+
+  @Override
+  public String toString() {
+    return \\"class Owner {\\\\n\\" +   
+      \\"    name: \\" + toIndentedString(name) + \\"\\\\n\\" +
+      \\"    age: \\" + toIndentedString(age) + \\"\\\\n\\" +
+      \\"    pet: \\" + toIndentedString(pet) + \\"\\\\n\\" +
+      \\"    additionalProperties: \\" + toIndentedString(additionalProperties) + \\"\\\\n\\" +
+    \\"}\\";
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return \\"null\\";
+    }
+    return o.toString().replace(\\"\\\\n\\", \\"\\\\n    \\");
+  }
+}",
+  "public class Cat implements Pet {
+  @NotNull
+  @JsonProperty(\\"petType\\")
+  private String petType;
+  @NotNull
+  @JsonProperty(\\"color\\")
+  private String color;
+  @JsonAnySetter
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private Map<String, Object> additionalProperties;
+
+  @Override
+  public String getPetType() { return this.petType; }
+
+  @Override
+  public String getColor() { return this.color; }
+  @Override
+  public void setColor(String color) { this.color = color; }
+
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
+  public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Cat self = (Cat) o;
+      return 
+        Objects.equals(this.petType, self.petType) &&
+        Objects.equals(this.color, self.color) &&
+        Objects.equals(this.additionalProperties, self.additionalProperties);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash((Object)petType, (Object)color, (Object)additionalProperties);
+  }
+
+  @Override
+  public String toString() {
+    return \\"class Cat {\\\\n\\" +   
+      \\"    petType: \\" + toIndentedString(petType) + \\"\\\\n\\" +
+      \\"    color: \\" + toIndentedString(color) + \\"\\\\n\\" +
+      \\"    additionalProperties: \\" + toIndentedString(additionalProperties) + \\"\\\\n\\" +
+    \\"}\\";
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return \\"null\\";
+    }
+    return o.toString().replace(\\"\\\\n\\", \\"\\\\n    \\");
+  }
+}",
+  "public class Dog implements Pet {
+  @NotNull
+  @JsonProperty(\\"petType\\")
+  private String petType;
+  @NotNull
+  @JsonProperty(\\"color\\")
+  private String color;
+  @JsonAnySetter
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private Map<String, Object> additionalProperties;
+
+  @Override
+  public String getPetType() { return this.petType; }
+
+  @Override
+  public String getColor() { return this.color; }
+  @Override
+  public void setColor(String color) { this.color = color; }
+
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
+  public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Dog self = (Dog) o;
+      return 
+        Objects.equals(this.petType, self.petType) &&
+        Objects.equals(this.color, self.color) &&
+        Objects.equals(this.additionalProperties, self.additionalProperties);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash((Object)petType, (Object)color, (Object)additionalProperties);
+  }
+
+  @Override
+  public String toString() {
+    return \\"class Dog {\\\\n\\" +   
+      \\"    petType: \\" + toIndentedString(petType) + \\"\\\\n\\" +
+      \\"    color: \\" + toIndentedString(color) + \\"\\\\n\\" +
+      \\"    additionalProperties: \\" + toIndentedString(additionalProperties) + \\"\\\\n\\" +
+    \\"}\\";
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return \\"null\\";
+    }
+    return o.toString().replace(\\"\\\\n\\", \\"\\\\n    \\");
+  }
+}",
+]
+`;
+
+exports[`JavaGenerator allowInheritance with common properties, using asyncapi 3.0 should create interface for Pet with common properties 1`] = `
+Array [
+  "@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.EXISTING_PROPERTY, property=\\"petType\\", visible=true)
+@JsonSubTypes({
+  @JsonSubTypes.Type(value = Cat.class, name = \\"Cat\\"),
+  @JsonSubTypes.Type(value = Dog.class, name = \\"Dog\\")
+})
+/**
+ * Pet represents a union of types: Cat, Dog
+ */
+public interface Pet {
+  String getPetType();
+  String getColor();
+  void setColor(String color);
+}",
+  "public class Owner {
+  @JsonProperty(\\"name\\")
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private String name;
+  @JsonProperty(\\"age\\")
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private Integer age;
+  @Valid
+  @JsonProperty(\\"pet\\")
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private List<Pet> pet;
+
+  public String getName() { return this.name; }
+  public void setName(String name) { this.name = name; }
+
+  public Integer getAge() { return this.age; }
+  public void setAge(Integer age) { this.age = age; }
+
+  public List<Pet> getPet() { return this.pet; }
+  public void setPet(List<Pet> pet) { this.pet = pet; }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Owner self = (Owner) o;
+      return 
+        Objects.equals(this.name, self.name) &&
+        Objects.equals(this.age, self.age) &&
+        Objects.equals(this.pet, self.pet);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash((Object)name, (Object)age, (Object)pet);
+  }
+
+  @Override
+  public String toString() {
+    return \\"class Owner {\\\\n\\" +   
+      \\"    name: \\" + toIndentedString(name) + \\"\\\\n\\" +
+      \\"    age: \\" + toIndentedString(age) + \\"\\\\n\\" +
+      \\"    pet: \\" + toIndentedString(pet) + \\"\\\\n\\" +
+    \\"}\\";
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return \\"null\\";
+    }
+    return o.toString().replace(\\"\\\\n\\", \\"\\\\n    \\");
+  }
+}",
+  "public class Cat implements Pet {
+  @NotNull
+  @JsonProperty(\\"petType\\")
+  private String petType;
+  @NotNull
+  @JsonProperty(\\"color\\")
+  private String color;
+  @JsonAnySetter
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private Map<String, Object> additionalProperties;
+
+  @Override
+  public String getPetType() { return this.petType; }
+
+  @Override
+  public String getColor() { return this.color; }
+  @Override
+  public void setColor(String color) { this.color = color; }
+
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
+  public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Cat self = (Cat) o;
+      return 
+        Objects.equals(this.petType, self.petType) &&
+        Objects.equals(this.color, self.color) &&
+        Objects.equals(this.additionalProperties, self.additionalProperties);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash((Object)petType, (Object)color, (Object)additionalProperties);
+  }
+
+  @Override
+  public String toString() {
+    return \\"class Cat {\\\\n\\" +   
+      \\"    petType: \\" + toIndentedString(petType) + \\"\\\\n\\" +
+      \\"    color: \\" + toIndentedString(color) + \\"\\\\n\\" +
+      \\"    additionalProperties: \\" + toIndentedString(additionalProperties) + \\"\\\\n\\" +
+    \\"}\\";
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return \\"null\\";
+    }
+    return o.toString().replace(\\"\\\\n\\", \\"\\\\n    \\");
+  }
+}",
+  "public class Dog implements Pet {
+  @NotNull
+  @JsonProperty(\\"petType\\")
+  private String petType;
+  @NotNull
+  @JsonProperty(\\"color\\")
+  private String color;
+  @JsonAnySetter
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private Map<String, Object> additionalProperties;
+
+  @Override
+  public String getPetType() { return this.petType; }
+
+  @Override
+  public String getColor() { return this.color; }
+  @Override
+  public void setColor(String color) { this.color = color; }
+
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
+  public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Dog self = (Dog) o;
+      return 
+        Objects.equals(this.petType, self.petType) &&
+        Objects.equals(this.color, self.color) &&
+        Objects.equals(this.additionalProperties, self.additionalProperties);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash((Object)petType, (Object)color, (Object)additionalProperties);
+  }
+
+  @Override
+  public String toString() {
+    return \\"class Dog {\\\\n\\" +   
+      \\"    petType: \\" + toIndentedString(petType) + \\"\\\\n\\" +
+      \\"    color: \\" + toIndentedString(color) + \\"\\\\n\\" +
+      \\"    additionalProperties: \\" + toIndentedString(additionalProperties) + \\"\\\\n\\" +
+    \\"}\\";
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return \\"null\\";
+    }
+    return o.toString().replace(\\"\\\\n\\", \\"\\\\n    \\");
+  }
+}",
+]
+`;
+
+exports[`JavaGenerator allowInheritance with common properties, using records should create interface for Pet with common properties 1`] = `
+Array [
+  "@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.EXISTING_PROPERTY, property=\\"petType\\", visible=true)
+@JsonSubTypes({
+  @JsonSubTypes.Type(value = Cat.class, name = \\"Cat\\"),
+  @JsonSubTypes.Type(value = Dog.class, name = \\"Dog\\")
+})
+/**
+ * Pet represents a union of types: Cat, Dog
+ */
+public interface Pet {
+  String petType();
+  String color();
+}",
+  "public record Owner(String name, Integer age, List<Pet> pet) {
+  
+}",
+  "public record Cat(String petType, String color, Map<String, Object> additionalProperties) implements Pet {
+  
+}",
+  "public record Dog(String petType, String color, Map<String, Object> additionalProperties) implements Pet {
+  
+}",
+]
+`;
+
 exports[`JavaGenerator allowInheritance with discriminator containing a special character should create interface for Animal, Pet and Fish 1`] = `
 Array [
   "@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.EXISTING_PROPERTY, property=\\"@petType\\", visible=true)
@@ -174,7 +616,6 @@ Array [
  */
 public interface Animal {
   String getAtPetType();
-  void setAtPetType(String atPetType);
 }",
   "public class FlyingFish implements Animal, Fish {
   @JsonProperty(\\"breed\\")
@@ -254,8 +695,6 @@ public interface Animal {
 
   @Override
   public String getAtPetType() { return this.atPetType; }
-  @Override
-  public void setAtPetType(String atPetType) { this.atPetType = atPetType; }
 
   @JsonAnyGetter
   public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
@@ -309,12 +748,12 @@ Array [
  */
 public interface Vehicle {
   VehicleType getVehicleType();
-  void setVehicleType(VehicleType vehicleType);
 }",
   "public class Car implements Vehicle {
   private final VehicleType vehicleType = VehicleType.CAR;
   private Map<String, Object> additionalProperties;
 
+  @Override
   public VehicleType getVehicleType() { return this.vehicleType; }
 
   public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
@@ -351,6 +790,7 @@ public interface Vehicle {
   private final VehicleType vehicleType = VehicleType.TRUCK;
   private Map<String, Object> additionalProperties;
 
+  @Override
   public VehicleType getVehicleType() { return this.vehicleType; }
 
   public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
@@ -467,7 +907,6 @@ Array [
  */
 public interface Pet {
   CloudEventType getType();
-  void setType(CloudEventType type);
 }",
   "public class Dog implements Pet {
   @NotNull
@@ -972,7 +1411,6 @@ Array [
  */
 public interface Vehicle {
   VehicleType getVehicleType();
-  void setVehicleType(VehicleType vehicleType);
 }",
   "public class Cargo {
   @Valid
@@ -1037,6 +1475,7 @@ public interface Vehicle {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Map<String, Object> additionalProperties;
 
+  @Override
   public VehicleType getVehicleType() { return this.vehicleType; }
 
   @JsonAnyGetter
@@ -1119,6 +1558,7 @@ public interface Vehicle {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Map<String, Object> additionalProperties;
 
+  @Override
   public VehicleType getVehicleType() { return this.vehicleType; }
 
   @JsonAnyGetter

--- a/test/generators/java/presets/__snapshots__/JacksonPreset.spec.ts.snap
+++ b/test/generators/java/presets/__snapshots__/JacksonPreset.spec.ts.snap
@@ -93,7 +93,6 @@ Array [
  */
 public interface Vehicle {
   String getVehicleType();
-  void setVehicleType(String vehicleType);
 }",
   "public class Car implements Vehicle {
   @JsonProperty(\\"vehicle_type\\")
@@ -107,7 +106,6 @@ public interface Vehicle {
   private Map<String, Object> additionalProperties;
 
   public String getVehicleType() { return this.vehicleType; }
-  public void setVehicleType(String vehicleType) { this.vehicleType = vehicleType; }
 
   public String getName() { return this.name; }
   public void setName(String name) { this.name = name; }
@@ -128,7 +126,6 @@ public interface Vehicle {
   private Map<String, Object> additionalProperties;
 
   public String getVehicleType() { return this.vehicleType; }
-  public void setVehicleType(String vehicleType) { this.vehicleType = vehicleType; }
 
   public String getName() { return this.name; }
   public void setName(String name) { this.name = name; }
@@ -152,7 +149,6 @@ Array [
  */
 public interface Vehicle {
   String getVehicleType();
-  void setVehicleType(String vehicleType);
 }",
   "public class Car implements Vehicle {
   @JsonProperty(\\"vehicleType\\")
@@ -163,7 +159,6 @@ public interface Vehicle {
   private Map<String, Object> additionalProperties;
 
   public String getVehicleType() { return this.vehicleType; }
-  public void setVehicleType(String vehicleType) { this.vehicleType = vehicleType; }
 
   @JsonAnyGetter
   public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
@@ -178,7 +173,6 @@ public interface Vehicle {
   private Map<String, Object> additionalProperties;
 
   public String getVehicleType() { return this.vehicleType; }
-  public void setVehicleType(String vehicleType) { this.vehicleType = vehicleType; }
 
   @JsonAnyGetter
   public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
@@ -199,7 +193,6 @@ Array [
  */
 public interface Vehicle {
   String getVehicleType();
-  void setVehicleType(String vehicleType);
 }",
   "public class Car implements Vehicle {
   @JsonProperty(\\"vehicleType\\")
@@ -210,7 +203,6 @@ public interface Vehicle {
   private Map<String, Object> additionalProperties;
 
   public String getVehicleType() { return this.vehicleType; }
-  public void setVehicleType(String vehicleType) { this.vehicleType = vehicleType; }
 
   @JsonAnyGetter
   public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
@@ -225,7 +217,6 @@ public interface Vehicle {
   private Map<String, Object> additionalProperties;
 
   public String getVehicleType() { return this.vehicleType; }
-  public void setVehicleType(String vehicleType) { this.vehicleType = vehicleType; }
 
   @JsonAnyGetter
   public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }

--- a/test/helpers/ConstrainHelpers.spec.ts
+++ b/test/helpers/ConstrainHelpers.spec.ts
@@ -372,7 +372,13 @@ describe('ConstrainHelpers', () => {
   describe('constrain UnionModel', () => {
     test('should constrain correctly', () => {
       const stringModel = new StringModel('', undefined, {});
-      const metaModel = new UnionModel('test2', undefined, {}, [stringModel]);
+      const metaModel = new UnionModel(
+        'test2',
+        undefined,
+        {},
+        [stringModel],
+        {}
+      );
       const constrainedModel = constrainMetaModel(
         mockedTypeMapping,
         mockedConstraints,
@@ -393,7 +399,7 @@ describe('ConstrainHelpers', () => {
       expect(mockedTypeMapping.String).toHaveBeenCalledTimes(1);
     });
     test('should handle recursive models', () => {
-      const metaModel = new UnionModel('test2', undefined, {}, []);
+      const metaModel = new UnionModel('test2', undefined, {}, [], {});
       metaModel.union.push(metaModel);
       const constrainedModel = constrainMetaModel(
         mockedTypeMapping,
@@ -425,7 +431,8 @@ describe('ConstrainHelpers', () => {
         '',
         undefined,
         { discriminator: { discriminator: 'testDiscriminator' } },
-        [refModel]
+        [refModel],
+        {}
       );
       const constrainedModel = constrainMetaModel(
         mockedTypeMapping,
@@ -534,8 +541,8 @@ describe('ConstrainHelpers', () => {
   describe('constrain circular models', () => {
     test('should handle recursive models', () => {
       const stringModel = new StringModel('c', undefined, {});
-      const unionA = new UnionModel('a', undefined, {}, [stringModel]);
-      const unionB = new UnionModel('b', undefined, {}, [stringModel]);
+      const unionA = new UnionModel('a', undefined, {}, [stringModel], {});
+      const unionB = new UnionModel('b', undefined, {}, [stringModel], {});
       unionA.union.push(unionB);
       unionB.union.push(unionA);
       const constrainedModel = constrainMetaModel(

--- a/test/models/ConstrainedMetaModel.spec.ts
+++ b/test/models/ConstrainedMetaModel.spec.ts
@@ -170,10 +170,13 @@ describe('ConstrainedMetaModel', () => {
     test('should return inner reference dependencies', () => {
       const stringModel = new StringModel('', undefined, {});
       const referenceModel = new ReferenceModel('', undefined, {}, stringModel);
-      const unionModel = new UnionModel('union', undefined, {}, [
-        stringModel,
-        referenceModel
-      ]);
+      const unionModel = new UnionModel(
+        'union',
+        undefined,
+        {},
+        [stringModel, referenceModel],
+        {}
+      );
       const unionTupleModel = new TupleValueModel(0, unionModel);
       const stringTupleModel = new TupleValueModel(1, stringModel);
       const rawModel = new TupleModel('test', undefined, {}, [
@@ -243,10 +246,13 @@ describe('ConstrainedMetaModel', () => {
     test('should return inner reference dependencies', () => {
       const stringModel = new StringModel('', undefined, {});
       const referenceModel = new ReferenceModel('', undefined, {}, stringModel);
-      const unionModel = new UnionModel('union', undefined, {}, [
-        stringModel,
-        referenceModel
-      ]);
+      const unionModel = new UnionModel(
+        'union',
+        undefined,
+        {},
+        [stringModel, referenceModel],
+        {}
+      );
       const unionObjectPropertyModel = new ObjectPropertyModel(
         'union',
         false,
@@ -526,10 +532,13 @@ describe('ConstrainedMetaModel', () => {
     test('should return inner reference dependencies', () => {
       const stringModel = new StringModel('', undefined, {});
       const referenceModel = new ReferenceModel('', undefined, {}, stringModel);
-      const unionModel = new UnionModel('union', undefined, {}, [
-        stringModel,
-        referenceModel
-      ]);
+      const unionModel = new UnionModel(
+        'union',
+        undefined,
+        {},
+        [stringModel, referenceModel],
+        {}
+      );
       const rawModel = new DictionaryModel(
         'test',
         undefined,
@@ -634,10 +643,13 @@ describe('ConstrainedMetaModel', () => {
     test('should return inner reference dependencies', () => {
       const stringModel = new StringModel('', undefined, {});
       const referenceModel = new ReferenceModel('', undefined, {}, stringModel);
-      const unionModel = new UnionModel('union', undefined, {}, [
-        stringModel,
-        referenceModel
-      ]);
+      const unionModel = new UnionModel(
+        'union',
+        undefined,
+        {},
+        [stringModel, referenceModel],
+        {}
+      );
       const rawModel = new ArrayModel('', undefined, {}, unionModel);
 
       const model = constrainMetaModel(mockedTypeMapping, mockedConstraints, {
@@ -657,10 +669,13 @@ describe('ConstrainedMetaModel', () => {
     test('should return all reference dependencies', () => {
       const stringModel = new StringModel('', undefined, {});
       const referenceModel = new ReferenceModel('', undefined, {}, stringModel);
-      const rawModel = new UnionModel('test', undefined, {}, [
-        referenceModel,
-        stringModel
-      ]);
+      const rawModel = new UnionModel(
+        'test',
+        undefined,
+        {},
+        [referenceModel, stringModel],
+        {}
+      );
 
       const model = constrainMetaModel(mockedTypeMapping, mockedConstraints, {
         metaModel: rawModel,
@@ -676,10 +691,13 @@ describe('ConstrainedMetaModel', () => {
     test('should not return duplicate dependencies', () => {
       const stringModel = new StringModel('', undefined, {});
       const referenceModel = new ReferenceModel('', undefined, {}, stringModel);
-      const rawModel = new UnionModel('test', undefined, {}, [
-        referenceModel,
-        referenceModel
-      ]);
+      const rawModel = new UnionModel(
+        'test',
+        undefined,
+        {},
+        [referenceModel, referenceModel],
+        {}
+      );
 
       const model = constrainMetaModel(mockedTypeMapping, mockedConstraints, {
         metaModel: rawModel,
@@ -695,7 +713,13 @@ describe('ConstrainedMetaModel', () => {
     test('should handle shallow recursive models', () => {
       const stringModel = new StringModel('', undefined, {});
       const referenceModel = new ReferenceModel('', undefined, {}, stringModel);
-      const rawModel = new UnionModel('test', undefined, {}, [referenceModel]);
+      const rawModel = new UnionModel(
+        'test',
+        undefined,
+        {},
+        [referenceModel],
+        {}
+      );
       rawModel.union.push(rawModel);
 
       const model = constrainMetaModel(mockedTypeMapping, mockedConstraints, {
@@ -712,10 +736,13 @@ describe('ConstrainedMetaModel', () => {
     test('should handle deep recursive models', () => {
       const stringModel = new StringModel('', undefined, {});
       const referenceModel = new ReferenceModel('', undefined, {}, stringModel);
-      const rawModel = new UnionModel('test', undefined, {}, [
-        stringModel,
-        referenceModel
-      ]);
+      const rawModel = new UnionModel(
+        'test',
+        undefined,
+        {},
+        [stringModel, referenceModel],
+        {}
+      );
       rawModel.union.push(rawModel);
       referenceModel.ref = rawModel;
 
@@ -739,10 +766,13 @@ describe('ConstrainedMetaModel', () => {
         {},
         stringModel
       );
-      const rawModel = new UnionModel('test', undefined, {}, [
-        referenceModel,
-        referenceModel2
-      ]);
+      const rawModel = new UnionModel(
+        'test',
+        undefined,
+        {},
+        [referenceModel, referenceModel2],
+        {}
+      );
 
       const model = constrainMetaModel(mockedTypeMapping, mockedConstraints, {
         metaModel: rawModel,


### PR DESCRIPTION
## Description
feat: support common properties in unions for java generator (fix for issue https://github.com/asyncapi/modelina/issues/2227)
fix: records implementing union interface now compile
fix: remove infinite loop when allowInheritance: true in combination with oneOf and allOf
fix: do not generate setter for discriminator fields
fix: apply `@override` when method is from parent or extend correctly

## Related Issue
https://github.com/asyncapi/modelina/issues/2227

## Checklist
- [x] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [x] Tests have been added or updated to cover the changes.
- [x] Documentation has been updated to reflect the changes.
- [x] All tests pass successfully locally.(`npm run test`).

## Additional Notes
<!-- Add any additional information or context that might be relevant to reviewers. -->
