### PR TITLE
fix: only import List if a list is present for Java

### DIFF
--- a/src/generators/java/renderers/ClassRenderer.ts
+++ b/src/generators/java/renderers/ClassRenderer.ts
@@ -1,5 +1,6 @@
 import { JavaRenderer } from '../JavaRenderer';
 import {
+  ConstrainedArrayModel,
   ConstrainedDictionaryModel,
   ConstrainedObjectModel,
   ConstrainedObjectPropertyModel,
@@ -26,7 +27,7 @@ export class ClassRenderer extends JavaRenderer<ConstrainedObjectModel> {
       await this.runAdditionalContentPreset()
     ];
 
-    if (this.options?.collectionType === 'List') {
+    if (this.model.containsPropertyType(ConstrainedArrayModel) && this.options?.collectionType === 'List') {
       this.dependencyManager.addDependency('import java.util.List;');
     }
     if (this.model.containsPropertyType(ConstrainedDictionaryModel)) {

--- a/src/generators/java/renderers/ClassRenderer.ts
+++ b/src/generators/java/renderers/ClassRenderer.ts
@@ -27,7 +27,10 @@ export class ClassRenderer extends JavaRenderer<ConstrainedObjectModel> {
       await this.runAdditionalContentPreset()
     ];
 
-    if (this.model.containsPropertyType(ConstrainedArrayModel) && this.options?.collectionType === 'List') {
+    if (
+      this.model.containsPropertyType(ConstrainedArrayModel) &&
+      this.options?.collectionType === 'List'
+    ) {
       this.dependencyManager.addDependency('import java.util.List;');
     }
     if (this.model.containsPropertyType(ConstrainedDictionaryModel)) {

--- a/src/generators/java/renderers/RecordRenderer.ts
+++ b/src/generators/java/renderers/RecordRenderer.ts
@@ -22,7 +22,10 @@ export class RecordRenderer extends JavaRenderer<ConstrainedObjectModel> {
       await this.runAdditionalContentPreset()
     ];
 
-    if (this.model.containsPropertyType(ConstrainedArrayModel) && this.options?.collectionType === 'List') {
+    if (
+      this.model.containsPropertyType(ConstrainedArrayModel) &&
+      this.options?.collectionType === 'List'
+    ) {
       this.dependencyManager.addDependency('import java.util.List;');
     }
     if (this.model.containsPropertyType(ConstrainedDictionaryModel)) {

--- a/src/generators/java/renderers/RecordRenderer.ts
+++ b/src/generators/java/renderers/RecordRenderer.ts
@@ -1,5 +1,6 @@
 import { JavaRenderer } from '../JavaRenderer';
 import {
+  ConstrainedArrayModel,
   ConstrainedDictionaryModel,
   ConstrainedObjectModel,
   ConstrainedObjectPropertyModel,
@@ -21,7 +22,7 @@ export class RecordRenderer extends JavaRenderer<ConstrainedObjectModel> {
       await this.runAdditionalContentPreset()
     ];
 
-    if (this.options?.collectionType === 'List') {
+    if (this.model.containsPropertyType(ConstrainedArrayModel) && this.options?.collectionType === 'List') {
       this.dependencyManager.addDependency('import java.util.List;');
     }
     if (this.model.containsPropertyType(ConstrainedDictionaryModel)) {


### PR DESCRIPTION
## Description
Currently `java.util.List` is always imported if `collectionType` is set to `List`, even if no array properties exist in the model. This PR adds a check to ensure the model contains an array property, in addition to having `collectionType` set to `List`.
