### PR TITLE
fix: records implement union interface for Java

### DIFF
--- a/src/generators/java/renderers/UnionRenderer.ts
+++ b/src/generators/java/renderers/UnionRenderer.ts
@@ -37,17 +37,24 @@ export class UnionRenderer extends JavaRenderer<ConstrainedUnionModel> {
   }
 }
 
+const getterName = (sanitizedName: string, options: JavaOptions): string => {
+  return options.modelType === 'record'
+    ? FormatHelpers.toCamelCase(sanitizedName)
+    : `get${FormatHelpers.toPascalCase(sanitizedName)}`;
+};
+
 export const JAVA_DEFAULT_UNION_PRESET: UnionPresetType<JavaOptions> = {
   self({ renderer }) {
     return renderer.defaultSelf();
   },
-  discriminatorGetter({ model }) {
+  discriminatorGetter({ model, options }) {
     if (!model.options.discriminator?.type) {
       return '';
     }
 
-    return `${model.options.discriminator.type} get${FormatHelpers.toPascalCase(
-      getSanitizedDiscriminatorName(model)
+    return `${model.options.discriminator.type} ${getterName(
+      getSanitizedDiscriminatorName(model),
+      options
     )}();`;
   }
 };

--- a/test/generators/java/JavaGenerator.spec.ts
+++ b/test/generators/java/JavaGenerator.spec.ts
@@ -1273,4 +1273,120 @@ describe('JavaGenerator', () => {
       });
     });
   });
+
+  describe('with inheritance using records', () => {
+    test('should create interface with getters without "get" prefix', async () => {
+      const asyncapiDoc = {
+        asyncapi: '3.0.0',
+        info: {
+          title: 'Records succesfully implement interfaces',
+          version: '1.0.0'
+        },
+        channels: {
+          ownerCreated: {
+            address: 'owner-created',
+            messages: {
+              OwnerCreated: {
+                $ref: '#/components/messages/Owner'
+              }
+            }
+          }
+        },
+        operations: {
+          processOwnerCreated: {
+            action: 'receive',
+            channel: {
+              $ref: '#/channels/ownerCreated'
+            }
+          }
+        },
+        components: {
+          messages: {
+            Owner: {
+              payload: {
+                schema: {
+                  $ref: '#/components/schemas/Owner'
+                }
+              }
+            }
+          },
+          schemas: {
+            Pet: {
+              title: 'Pet',
+              type: 'object',
+              discriminator: 'petType',
+              properties: {
+                petType: {
+                  type: 'string'
+                },
+                color: {
+                  type: 'string'
+                }
+              },
+              oneOf: [
+                {
+                  $ref: '#/components/schemas/Cat'
+                },
+                {
+                  $ref: '#/components/schemas/Dog'
+                }
+              ],
+              required: ['petType', 'color']
+            },
+            Cat: {
+              title: 'Cat',
+              allOf: [
+                {
+                  $ref: '#/components/schemas/Pet'
+                }
+              ]
+            },
+            Dog: {
+              title: 'Dog',
+              allOf: [
+                {
+                  $ref: '#/components/schemas/Pet'
+                }
+              ]
+            },
+            Owner: {
+              title: 'Owner',
+              type: 'object',
+              properties: {
+                name: {
+                  type: 'string'
+                },
+                pet: {
+                  items: {
+                    $ref: '#/components/schemas/Pet'
+                  }
+                }
+              }
+            }
+          }
+        }
+      };
+
+      generator = new JavaGenerator({
+        presets: [
+          JAVA_COMMON_PRESET,
+          JAVA_JACKSON_PRESET,
+          JAVA_DESCRIPTION_PRESET,
+          JAVA_CONSTRAINTS_PRESET
+        ],
+        modelType: 'record',
+        collectionType: 'List',
+        processorOptions: {
+          jsonSchema: {
+            disableCache: false,
+            allowInheritance: true,
+            ignoreAdditionalProperties: true
+          }
+        }
+      });
+
+      const models = await generator.generate(asyncapiDoc);
+      expect(models.map((model) => model.result)).toMatchSnapshot();
+    });
+  });
 });

--- a/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
+++ b/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
@@ -1709,3 +1709,28 @@ exports[`JavaGenerator should work custom preset for \`class\` type 1`] = `
   public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
 }"
 `;
+
+exports[`JavaGenerator with inheritance using records should create interface with getters without "get" prefix 1`] = `
+Array [
+  "@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.EXISTING_PROPERTY, property=\\"petType\\", visible=true)
+@JsonSubTypes({
+  @JsonSubTypes.Type(value = Cat.class, name = \\"Cat\\"),
+  @JsonSubTypes.Type(value = Dog.class, name = \\"Dog\\")
+})
+/**
+ * Pet represents a union of types: Cat, Dog
+ */
+public interface Pet {
+  String petType();
+}",
+  "public record Owner(String name, List<Pet> pet) {
+  
+}",
+  "public record Cat(String petType, String color) implements Pet {
+  
+}",
+  "public record Dog(String petType, String color) implements Pet {
+  
+}",
+]
+`;


### PR DESCRIPTION
## Description
For Java modelType record when using unions (oneOf), the currently generated code doesn't compile.
It generates an interface with `String getMyDiscriminator();` while the record has an automatic getter with signature `String myDiscriminator()`.

In this PR we don't prefix discriminator getter with "get" in the union renderer.

## Related Issue
/

## Checklist
- [x] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [x] Tests have been added or updated to cover the changes.
- [x] Documentation has been updated to reflect the changes.
- [x] All tests pass successfully locally.(`npm run test`).

## Additional Notes
The test uses asyncapi 3.0.0
