### PR TITLE
fix: modelina-cli has wrong version of modelina as dependency

### DIFF
--- a/modelina-cli/package-lock.json
+++ b/modelina-cli/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.2.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@asyncapi/modelina": "^4.0.0-next.64",
+        "@asyncapi/modelina": "^5.0.0",
         "@oclif/core": "^3.26.0",
         "@oclif/errors": "^1.3.6",
         "@oclif/plugin-autocomplete": "^3.0.16",
@@ -191,9 +191,9 @@
       }
     },
     "node_modules/@asyncapi/modelina": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/modelina/-/modelina-4.0.0.tgz",
-      "integrity": "sha512-2/O3CqNY4+VdddHe3ek6XT8++vYVd0YS3h+LJSWw1C2D1rTo/KQTwXGZLxYMTvFhDMGJqEKbtP/h0+FVhYVbXA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@asyncapi/modelina/-/modelina-5.2.1.tgz",
+      "integrity": "sha512-kYOX3x5BMN0f+JxiCEnkYBADHxFRt6Bwshib8pn89tfeb4dmk7f+/1m7l5LmUFw1segkrm1SKS9/MNgGZsRWCQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^11.1.0",
@@ -203,7 +203,7 @@
         "alterschema": "^1.1.2",
         "change-case": "^4.1.2",
         "js-yaml": "^4.1.0",
-        "openapi-types": "9.3.0",
+        "openapi-types": "^12.1.3",
         "typescript-json-schema": "^0.58.1"
       },
       "engines": {
@@ -12597,9 +12597,10 @@
       }
     },
     "node_modules/openapi-types": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-9.3.0.tgz",
-      "integrity": "sha512-sR23YjmuwDSMsQVZDHbV9mPgi0RyniQlqR0AQxTC2/F3cpSjRFMH3CFPjoWvNqhC4OxPkDYNb2l8Mc1Me6D/KQ=="
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "license": "MIT"
     },
     "node_modules/optionator": {
       "version": "0.9.3",

--- a/modelina-cli/package.json
+++ b/modelina-cli/package.json
@@ -7,7 +7,7 @@
   },
   "bugs": "https://github.com/asyncapi/modelina/issues",
   "dependencies": {
-    "@asyncapi/modelina": "^4.0.0-next.64",
+    "@asyncapi/modelina": "^5.0.0",
     "@oclif/core": "^3.26.0",
     "@oclif/errors": "^1.3.6",
     "@oclif/plugin-not-found": "^3.1.1",


### PR DESCRIPTION
## Description
Testing after `v5.2.1` release of #2771 showed, that fix is not there, when modelina-cli is used.
It truns out, that CLI was depending on previous major of modelina.

## Related Issue
#2274 

## Checklist
- [x] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [ ] Tests have been added or updated to cover the changes.
- [ ] Documentation has been updated to reflect the changes.
- [x] All tests pass successfully locally.(`npm run test`).

## Additional Notes
<!-- Add any additional information or context that might be relevant to reviewers. -->
