### PR TITLE
fix: do not use optionals for non-required arrays in Java

### DIFF
--- a/src/generators/java/renderers/ClassRenderer.ts
+++ b/src/generators/java/renderers/ClassRenderer.ts
@@ -149,7 +149,10 @@ ${this.indent(this.renderBlock(content, 2))}
 
   private doesContainOptionalProperties(): boolean {
     const properties = Object.values(this.model.properties);
-    return properties.some((prop) => !prop.required);
+    return properties.some(
+      (prop) =>
+        !prop.required && !(prop.property instanceof ConstrainedArrayModel)
+    );
   }
 
   private addCollectionDependencies() {
@@ -310,7 +313,9 @@ export const JAVA_DEFAULT_CLASS_PRESET: ClassPresetType<JavaOptions> = {
     )}`;
 
     const useOptional =
-      options.useOptionalForNullableProperties && !property.required;
+      options.useOptionalForNullableProperties &&
+      !property.required &&
+      !(property.property instanceof ConstrainedArrayModel);
 
     const returnType = useOptional
       ? `Optional<${property.property.type}>`

--- a/test/generators/java/JavaGenerator.spec.ts
+++ b/test/generators/java/JavaGenerator.spec.ts
@@ -252,6 +252,28 @@ describe('JavaGenerator', () => {
     expect(models[0].dependencies).not.toContain(expectedDependencies);
   });
 
+  test('should not render optional imports when only non-required field of type array', async () => {
+    const doc = {
+      $id: 'OtherClass',
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        tools: { type: 'array', items: { type: 'string' } }
+      }
+    };
+    const expectedDependencies = [
+      'import java.util.Optional;',
+      'import static java.util.Optional.ofNullable;'
+    ];
+
+    generator = new JavaGenerator({ useOptionalForNullableProperties: true });
+
+    const models = await generator.generate(doc);
+    expect(models).toHaveLength(1);
+    expect(models[0].result).toMatchSnapshot();
+    expect(models[0].dependencies).not.toContain(expectedDependencies);
+  });
+
   test('should render models and their dependencies', async () => {
     const doc = {
       $id: 'Address',

--- a/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
+++ b/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
@@ -1653,6 +1653,15 @@ public interface Vehicle {
 ]
 `;
 
+exports[`JavaGenerator should not render optional imports when only non-required field of type array 1`] = `
+"public class OtherClass {
+  private String[] tools;
+
+  public String[] getTools() { return this.tools; }
+  public void setTools(String[] tools) { this.tools = tools; }
+}"
+`;
+
 exports[`JavaGenerator should not render optional imports when only required field 1`] = `
 "public class OtherClass {
   private String color;
@@ -1956,7 +1965,7 @@ exports[`JavaGenerator should render optional for non-required field 1`] = `
   public Optional<String> getColor() { return ofNullable(this.color); }
   public void setColor(String color) { this.color = color; }
 
-  public Optional<String[]> getTools() { return ofNullable(this.tools); }
+  public String[] getTools() { return this.tools; }
   public void setTools(String[] tools) { this.tools = tools; }
 }"
 `;


### PR DESCRIPTION
# Conflicts:
#	examples/java-generate-optionals-for-non-required-fields/README.md

## Description
<!-- Provide a brief description of the changes introduced by this pull request. -->

## Related Issue
<!-- If this pull request is related to any existing issue, mention it here. -->

## Checklist
- [x] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [x] Tests have been added or updated to cover the changes.
- [x] Documentation has been updated to reflect the changes.
- [x] All tests pass successfully locally.(`npm run test`).

## Additional Notes
<!-- Add any additional information or context that might be relevant to reviewers. -->
