### PR TITLE
fix: add aliasing back in for Pydantic generator

### DIFF
--- a/examples/generate-python-pydantic-models/__snapshots__/index.spec.ts.snap
+++ b/examples/generate-python-pydantic-models/__snapshots__/index.spec.ts.snap
@@ -3,11 +3,11 @@
 exports[`Should be able to render python models and should log expected output to console: class-model 1`] = `
 Array [
   "class Root(BaseModel): 
-  optional_field: Optional[str] = Field(description='''this field is optional''', default=None)
-  required_field: str = Field(description='''this field is required''')
-  no_description: Optional[str] = Field(default=None)
+  optional_field: Optional[str] = Field(description='''this field is optional''', default=None, alias='''optionalField''')
+  required_field: str = Field(description='''this field is required''', alias='''requiredField''')
+  no_description: Optional[str] = Field(default=None, alias='''noDescription''')
   options: Optional[Options] = Field(default=None)
-  content_type: Optional[str] = Field(default=None)
+  content_type: Optional[str] = Field(default=None, alias='''content-type''')
 ",
 ]
 `;

--- a/src/generators/python/presets/Pydantic.ts
+++ b/src/generators/python/presets/Pydantic.ts
@@ -63,7 +63,10 @@ const PYTHON_PYDANTIC_CLASS_PRESET: ClassPresetType<PythonOptions> = {
     ) {
       decoratorArgs.push('exclude=True');
     }
-    if (property.propertyName !== property.unconstrainedPropertyName && propertyName !== "additional_properties") {
+    if (
+      property.propertyName !== property.unconstrainedPropertyName &&
+      propertyName !== 'additional_properties'
+    ) {
       decoratorArgs.push(`alias='''${property.unconstrainedPropertyName}'''`);
     }
 

--- a/src/generators/python/presets/Pydantic.ts
+++ b/src/generators/python/presets/Pydantic.ts
@@ -64,9 +64,8 @@ const PYTHON_PYDANTIC_CLASS_PRESET: ClassPresetType<PythonOptions> = {
       decoratorArgs.push('exclude=True');
     }
     if (
-      property.propertyName !== property.unconstrainedPropertyName &&
-      property.property instanceof ConstrainedDictionaryModel &&
-      property.property.serializationType !== 'unwrap'
+  property.propertyName !== property.unconstrainedPropertyName &&
+  (!(property.property instanceof ConstrainedDictionaryModel) || property.property.serializationType !== 'unwrap')
     ) {
       decoratorArgs.push(`alias='''${property.unconstrainedPropertyName}'''`);
     }

--- a/src/generators/python/presets/Pydantic.ts
+++ b/src/generators/python/presets/Pydantic.ts
@@ -64,8 +64,9 @@ const PYTHON_PYDANTIC_CLASS_PRESET: ClassPresetType<PythonOptions> = {
       decoratorArgs.push('exclude=True');
     }
     if (
-  property.propertyName !== property.unconstrainedPropertyName &&
-  (!(property.property instanceof ConstrainedDictionaryModel) || property.property.serializationType !== 'unwrap')
+      property.propertyName !== property.unconstrainedPropertyName &&
+      (!(property.property instanceof ConstrainedDictionaryModel) ||
+        property.property.serializationType !== 'unwrap')
     ) {
       decoratorArgs.push(`alias='''${property.unconstrainedPropertyName}'''`);
     }

--- a/src/generators/python/presets/Pydantic.ts
+++ b/src/generators/python/presets/Pydantic.ts
@@ -65,7 +65,8 @@ const PYTHON_PYDANTIC_CLASS_PRESET: ClassPresetType<PythonOptions> = {
     }
     if (
       property.propertyName !== property.unconstrainedPropertyName &&
-      propertyName !== 'additional_properties'
+      property.property instanceof ConstrainedDictionaryModel &&
+      property.property.serializationType !== 'unwrap'
     ) {
       decoratorArgs.push(`alias='''${property.unconstrainedPropertyName}'''`);
     }

--- a/src/generators/python/presets/Pydantic.ts
+++ b/src/generators/python/presets/Pydantic.ts
@@ -63,6 +63,9 @@ const PYTHON_PYDANTIC_CLASS_PRESET: ClassPresetType<PythonOptions> = {
     ) {
       decoratorArgs.push('exclude=True');
     }
+    if (property.propertyName !== property.unconstrainedPropertyName && propertyName !== "additional_properties") {
+      decoratorArgs.push(`alias='''${property.unconstrainedPropertyName}'''`);
+    }
 
     return `${propertyName}: ${type} = Field(${decoratorArgs.join(', ')})`;
   },

--- a/test/generators/python/presets/Pydantic.spec.ts
+++ b/test/generators/python/presets/Pydantic.spec.ts
@@ -177,9 +177,6 @@ describe('PYTHON_PYDANTIC_PRESET', () => {
     };
 
     const models = await generator.generate(doc);
-    // check alias='aliasTest' is set - dunno what model.result yields, tho
-    // in worst case check
-    //expect(models.map((model) => model.result)).toContain("alias='''testAlias'''"); // why multi-line string?
     expect(models.map((model) => model.result)).toMatchSnapshot();
   });
 });

--- a/test/generators/python/presets/Pydantic.spec.ts
+++ b/test/generators/python/presets/Pydantic.spec.ts
@@ -171,7 +171,7 @@ describe('PYTHON_PYDANTIC_PRESET', () => {
       required: ['testAlias'],
       properties: {
         testAlias: {
-            type: 'string'
+          type: 'string'
         }
       }
     };

--- a/test/generators/python/presets/Pydantic.spec.ts
+++ b/test/generators/python/presets/Pydantic.spec.ts
@@ -163,4 +163,23 @@ describe('PYTHON_PYDANTIC_PRESET', () => {
     const models = await generator.generate(doc);
     expect(models.map((model) => model.result)).toMatchSnapshot();
   });
+
+  test('should always set alias', async () => {
+    const doc = {
+      title: 'AliasTest',
+      type: 'object',
+      required: ['testAlias'],
+      properties: {
+        testAlias: {
+            type: 'string'
+        }
+      }
+    };
+
+    const models = await generator.generate(doc);
+    // check alias='aliasTest' is set - dunno what model.result yields, tho
+    // in worst case check
+    //expect(models.map((model) => model.result)).toContain("alias='''testAlias'''"); // why multi-line string?
+    expect(models.map((model) => model.result)).toMatchSnapshot();
+  });
 });

--- a/test/generators/python/presets/__snapshots__/Pydantic.spec.ts.snap
+++ b/test/generators/python/presets/__snapshots__/Pydantic.spec.ts.snap
@@ -1,10 +1,52 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`PYTHON_PYDANTIC_PRESET should always set alias 1`] = `
+Array [
+  "class AliasTest(BaseModel): 
+  test_alias: str = Field(alias='''testAlias''')
+  additional_properties: Optional[dict[str, Any]] = Field(default=None, exclude=True)
+
+  @model_serializer(mode='wrap')
+  def custom_serializer(self, handler):
+    serialized_self = handler(self)
+    additional_properties = getattr(self, \\"additional_properties\\")
+    if additional_properties is not None:
+      for key, value in additional_properties.items():
+        # Never overwrite existing values, to avoid clashes
+        if not hasattr(serialized_self, key):
+          serialized_self[key] = value
+
+    return serialized_self
+
+  @model_validator(mode='before')
+  @classmethod
+  def unwrap_additional_properties(cls, data):
+    if not isinstance(data, dict):
+      data = data.model_dump()
+    json_properties = list(data.keys())
+    known_object_properties = ['test_alias', 'additional_properties']
+    unknown_object_properties = [element for element in json_properties if element not in known_object_properties]
+    # Ignore attempts that validate regular models, only when unknown input is used we add unwrap extensions
+    if len(unknown_object_properties) == 0: 
+      return data
+  
+    known_json_properties = ['testAlias', 'additionalProperties']
+    additional_properties = data.get('additional_properties', {})
+    for obj_key in list(data.keys()):
+      if not known_json_properties.__contains__(obj_key):
+        additional_properties[obj_key] = data.pop(obj_key, None)
+    data['additional_properties'] = additional_properties
+    return data
+
+",
+]
+`;
+
 exports[`PYTHON_PYDANTIC_PRESET should render default value for discriminator when using polymorphism 1`] = `
 Array [
   "",
   "class Car(BaseModel): 
-  vehicle_type: VehicleType = Field(default=VehicleType.CAR, frozen=True)
+  vehicle_type: VehicleType = Field(default=VehicleType.CAR, frozen=True, alias='''vehicleType''')
   length: Optional[float] = Field(default=None)
   additional_properties: Optional[dict[str, Any]] = Field(default=None, exclude=True)
 
@@ -45,7 +87,7 @@ Array [
   CAR = \\"Car\\"
   TRUCK = \\"Truck\\"",
   "class Truck(BaseModel): 
-  vehicle_type: VehicleType = Field(default=VehicleType.TRUCK, frozen=True)
+  vehicle_type: VehicleType = Field(default=VehicleType.TRUCK, frozen=True, alias='''vehicleType''')
   length: Optional[float] = Field(default=None)
   additional_properties: Optional[dict[str, Any]] = Field(default=None, exclude=True)
 
@@ -88,7 +130,7 @@ Array [
 exports[`PYTHON_PYDANTIC_PRESET should render nullable union 1`] = `
 Array [
   "class NullableUnionTest(BaseModel): 
-  nullable_union_test: Optional[Union[Union1]] = Field(default=None)
+  nullable_union_test: Optional[Union[Union1]] = Field(default=None, alias='''nullableUnionTest''')
   additional_properties: Optional[dict[str, Any]] = Field(default=None, exclude=True)
 
   @model_serializer(mode='wrap')
@@ -125,7 +167,7 @@ Array [
 
 ",
   "class Union1(BaseModel): 
-  test_prop1: Optional[str] = Field(default=None)
+  test_prop1: Optional[str] = Field(default=None, alias='''testProp1''')
   additional_properties: Optional[dict[str, Any]] = Field(default=None, exclude=True)
 
   @model_serializer(mode='wrap')
@@ -210,7 +252,7 @@ exports[`PYTHON_PYDANTIC_PRESET should render pydantic for class 1`] = `
 exports[`PYTHON_PYDANTIC_PRESET should render union to support Python < 3.10 1`] = `
 Array [
   "class UnionTest(BaseModel): 
-  union_test: Optional[Union[Union1, Union2]] = Field(default=None)
+  union_test: Optional[Union[Union1, Union2]] = Field(default=None, alias='''unionTest''')
   additional_properties: Optional[dict[str, Any]] = Field(default=None, exclude=True)
 
   @model_serializer(mode='wrap')
@@ -247,7 +289,7 @@ Array [
 
 ",
   "class Union1(BaseModel): 
-  test_prop1: Optional[str] = Field(default=None)
+  test_prop1: Optional[str] = Field(default=None, alias='''testProp1''')
   additional_properties: Optional[dict[str, Any]] = Field(default=None, exclude=True)
 
   @model_serializer(mode='wrap')
@@ -284,7 +326,7 @@ Array [
 
 ",
   "class Union2(BaseModel): 
-  test_prop2: Optional[str] = Field(default=None)
+  test_prop2: Optional[str] = Field(default=None, alias='''testProp2''')
   additional_properties: Optional[dict[str, Any]] = Field(default=None, exclude=True)
 
   @model_serializer(mode='wrap')


### PR DESCRIPTION
## Description
#2111 removed aliases, which was a breaking (and perhaps unintended) change that broke the API and thus downstream consumers. This change adds auto aliasing back in.

## Related Issue
fixes #2187
partially reverts PR #2111

## Checklist
- [x] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [x] Tests have been added or updated to cover the changes.
- [ ] Documentation has been updated to reflect the changes.
- [ ] All tests pass successfully locally.(`npm run test`).

## Additional Notes
tests on main are red atm; tests for the generator are green (existing + new)
