### PR TITLE
fix: missing export for default constant contraint of java generator

### DIFF
--- a/src/generators/java/index.ts
+++ b/src/generators/java/index.ts
@@ -4,9 +4,7 @@ export { JAVA_DEFAULT_PRESET } from './JavaPreset';
 export type { JavaPreset } from './JavaPreset';
 export * from './presets';
 
-export {
-  defaultConstantConstraints as javaDefaultConstantConstraints
-} from './constrainer/ConstantConstrainer';
+export { defaultConstantConstraints as javaDefaultConstantConstraints } from './constrainer/ConstantConstrainer';
 
 export {
   defaultEnumKeyConstraints as javaDefaultEnumKeyConstraints,

--- a/src/generators/java/index.ts
+++ b/src/generators/java/index.ts
@@ -5,6 +5,10 @@ export type { JavaPreset } from './JavaPreset';
 export * from './presets';
 
 export {
+  defaultConstantConstraints as javaDefaultConstantConstraints
+} from './constrainer/ConstantConstrainer';
+
+export {
   defaultEnumKeyConstraints as javaDefaultEnumKeyConstraints,
   DefaultEnumKeyConstraints as JavaDefaultEnumKeyConstraints,
   defaultEnumValueConstraints as javaDefaultEnumValueConstraints


### PR DESCRIPTION
## Description
Add export for the default constant constraint

## Related Issue
None

## Checklist
- [x] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [x] Tests have been added or updated to cover the changes.
- [x] Documentation has been updated to reflect the changes.
- [x] All tests pass successfully locally.(`npm run test`).

## Additional Notes
Only adding some visibility to ease override of constrainers.
