### PR TITLE
fix: deserialization in pydantic

### DIFF
--- a/src/generators/python/presets/Pydantic.ts
+++ b/src/generators/python/presets/Pydantic.ts
@@ -126,7 +126,7 @@ def unwrap_${dictionaryModel?.propertyName}(cls, data):
     .map((value) => `'${value.unconstrainedPropertyName}'`)
     .join(', ')}]
   ${dictionaryModel?.propertyName} = data.get('${dictionaryModel?.propertyName}', {})
-  for obj_key in list(data.keys()):
+  for obj_key in unknown_object_properties:
     if not known_json_properties.__contains__(obj_key):
       ${dictionaryModel?.propertyName}[obj_key] = data.pop(obj_key, None)
   data['${dictionaryModel?.propertyName}'] = ${dictionaryModel?.propertyName}

--- a/test/generators/python/presets/__snapshots__/Pydantic.spec.ts.snap
+++ b/test/generators/python/presets/__snapshots__/Pydantic.spec.ts.snap
@@ -32,7 +32,7 @@ Array [
   
     known_json_properties = ['testAlias', 'additionalProperties']
     additional_properties = data.get('additional_properties', {})
-    for obj_key in list(data.keys()):
+    for obj_key in unknown_object_properties:
       if not known_json_properties.__contains__(obj_key):
         additional_properties[obj_key] = data.pop(obj_key, None)
     data['additional_properties'] = additional_properties
@@ -76,7 +76,7 @@ Array [
   
     known_json_properties = ['vehicleType', 'length', 'additionalProperties']
     additional_properties = data.get('additional_properties', {})
-    for obj_key in list(data.keys()):
+    for obj_key in unknown_object_properties:
       if not known_json_properties.__contains__(obj_key):
         additional_properties[obj_key] = data.pop(obj_key, None)
     data['additional_properties'] = additional_properties
@@ -117,7 +117,7 @@ Array [
   
     known_json_properties = ['vehicleType', 'length', 'additionalProperties']
     additional_properties = data.get('additional_properties', {})
-    for obj_key in list(data.keys()):
+    for obj_key in unknown_object_properties:
       if not known_json_properties.__contains__(obj_key):
         additional_properties[obj_key] = data.pop(obj_key, None)
     data['additional_properties'] = additional_properties
@@ -159,7 +159,7 @@ Array [
   
     known_json_properties = ['nullableUnionTest', 'additionalProperties']
     additional_properties = data.get('additional_properties', {})
-    for obj_key in list(data.keys()):
+    for obj_key in unknown_object_properties:
       if not known_json_properties.__contains__(obj_key):
         additional_properties[obj_key] = data.pop(obj_key, None)
     data['additional_properties'] = additional_properties
@@ -196,7 +196,7 @@ Array [
   
     known_json_properties = ['testProp1', 'additionalProperties']
     additional_properties = data.get('additional_properties', {})
-    for obj_key in list(data.keys()):
+    for obj_key in unknown_object_properties:
       if not known_json_properties.__contains__(obj_key):
         additional_properties[obj_key] = data.pop(obj_key, None)
     data['additional_properties'] = additional_properties
@@ -240,7 +240,7 @@ exports[`PYTHON_PYDANTIC_PRESET should render pydantic for class 1`] = `
   
     known_json_properties = ['prop', 'additionalProperties']
     additional_properties = data.get('additional_properties', {})
-    for obj_key in list(data.keys()):
+    for obj_key in unknown_object_properties:
       if not known_json_properties.__contains__(obj_key):
         additional_properties[obj_key] = data.pop(obj_key, None)
     data['additional_properties'] = additional_properties
@@ -281,7 +281,7 @@ Array [
   
     known_json_properties = ['unionTest', 'additionalProperties']
     additional_properties = data.get('additional_properties', {})
-    for obj_key in list(data.keys()):
+    for obj_key in unknown_object_properties:
       if not known_json_properties.__contains__(obj_key):
         additional_properties[obj_key] = data.pop(obj_key, None)
     data['additional_properties'] = additional_properties
@@ -318,7 +318,7 @@ Array [
   
     known_json_properties = ['testProp1', 'additionalProperties']
     additional_properties = data.get('additional_properties', {})
-    for obj_key in list(data.keys()):
+    for obj_key in unknown_object_properties:
       if not known_json_properties.__contains__(obj_key):
         additional_properties[obj_key] = data.pop(obj_key, None)
     data['additional_properties'] = additional_properties
@@ -355,7 +355,7 @@ Array [
   
     known_json_properties = ['testProp2', 'additionalProperties']
     additional_properties = data.get('additional_properties', {})
-    for obj_key in list(data.keys()):
+    for obj_key in unknown_object_properties:
       if not known_json_properties.__contains__(obj_key):
         additional_properties[obj_key] = data.pop(obj_key, None)
     data['additional_properties'] = additional_properties


### PR DESCRIPTION
when doing deserialization in pydantic only unknown properties must be added to additional_properties

## Description
current generated code contains a bug, which leads to matched fields appearing in `additional_properties`.
the fix is pretty trivial and straight-forward: we only process unknown properties. 

## Related Issue
it seemed to not worth creating one for such a trivial fix.

## Checklist
- [X] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [X] Tests have been added or updated to cover the changes.
- [ ] Documentation has been updated to reflect the changes.
- [X] All tests pass successfully locally.(`npm run test`).

## Additional Notes
<!-- Add any additional information or context that might be relevant to reviewers. -->
