### PR TITLE
fix: discriminator with special character and default

### DIFF
--- a/src/generators/java/renderers/ClassRenderer.ts
+++ b/src/generators/java/renderers/ClassRenderer.ts
@@ -270,15 +270,15 @@ export const JAVA_DEFAULT_CLASS_PRESET: ClassPresetType<JavaOptions> = {
     }
 
     const isDiscriminatorProperty =
-      property.propertyName === model.options.discriminator?.discriminator;
+      property.unconstrainedPropertyName ===
+      model.options.discriminator?.discriminator;
     if (!isDiscriminatorProperty && property.property.originalInput?.default) {
       return JavaDefaultRendererUtil.renderFieldWithDefault(property);
     }
 
     if (
       options.useModelNameAsConstForDiscriminatorProperty &&
-      property.unconstrainedPropertyName ===
-        model.options.discriminator?.discriminator &&
+      isDiscriminatorProperty &&
       property.property.type === 'String'
     ) {
       return `private final ${property.property.type} ${property.propertyName} = "${model.name}";`;

--- a/test/generators/java/JavaGenerator.spec.ts
+++ b/test/generators/java/JavaGenerator.spec.ts
@@ -932,7 +932,7 @@ describe('JavaGenerator', () => {
               title: 'Pet',
               type: 'object',
               properties: {
-                "@type": {
+                '@type': {
                   type: 'string',
                   default: 'Fish'
                 }

--- a/test/generators/java/JavaGenerator.spec.ts
+++ b/test/generators/java/JavaGenerator.spec.ts
@@ -938,7 +938,7 @@ describe('JavaGenerator', () => {
                     $ref: '#/components/schemas/Pet'
                   }
                 }
-              },
+              }
             },
             Pet: {
               title: 'Pet',

--- a/test/generators/java/JavaGenerator.spec.ts
+++ b/test/generators/java/JavaGenerator.spec.ts
@@ -889,6 +889,94 @@ describe('JavaGenerator', () => {
     });
   });
 
+  describe('renders discriminator containing a special character', () => {
+    test('when discriminator has a default', async () => {
+      // note: the default discriminator value is not used in the output. See JacksonPreset.spec.ts for that.
+
+      const asyncapiDoc = {
+        asyncapi: '3.0.0',
+        info: {
+          title: 'Pet example',
+          version: '1.0.0'
+        },
+        channels: {
+          pet: {
+            address: 'pet',
+            messages: {
+              Pet: {
+                $ref: '#/components/messages/Pet'
+              }
+            }
+          }
+        },
+        operations: {
+          petAvailable: {
+            action: 'receive',
+            channel: {
+              $ref: '#/channels/pet'
+            }
+          }
+        },
+        components: {
+          messages: {
+            Pet: {
+              payload: {
+                schema: {
+                  $ref: '#/components/schemas/Pet'
+                }
+              }
+            }
+          },
+          schemas: {
+            Pet: {
+              title: 'Pet',
+              type: 'object',
+              properties: {
+                "@type": {
+                  type: 'string',
+                  default: 'Fish'
+                }
+              },
+              required: ['@type'],
+              discriminator: '@type',
+              oneOf: [
+                {
+                  $ref: '#/components/schemas/Fish'
+                },
+                {
+                  $ref: '#/components/schemas/Bird'
+                }
+              ]
+            },
+            Bird: {
+              title: 'Bird',
+              type: 'object',
+              allOf: [
+                {
+                  $ref: '#/components/schemas/Pet'
+                }
+              ]
+            },
+            Fish: {
+              title: 'Fish',
+              type: 'object',
+              allOf: [
+                {
+                  $ref: '#/components/schemas/Pet'
+                }
+              ]
+            }
+          }
+        }
+      };
+      const generator = new JavaGenerator({
+        useModelNameAsConstForDiscriminatorProperty: true
+      });
+      const models = await generator.generate(asyncapiDoc);
+      expect(models.map((model) => model.result)).toMatchSnapshot();
+    });
+  });
+
   describe('when collection type is list and unique items is true it should render a set', () => {
     test('should create a set for unique arrays', async () => {
       const asyncapiDoc = {

--- a/test/generators/java/JavaGenerator.spec.ts
+++ b/test/generators/java/JavaGenerator.spec.ts
@@ -896,38 +896,50 @@ describe('JavaGenerator', () => {
       const asyncapiDoc = {
         asyncapi: '3.0.0',
         info: {
-          title: 'Pet example',
+          title: 'Pet Owner example',
           version: '1.0.0'
         },
         channels: {
-          pet: {
-            address: 'pet',
+          owner: {
+            address: 'owner',
             messages: {
               Pet: {
-                $ref: '#/components/messages/Pet'
+                $ref: '#/components/messages/Owner'
               }
             }
           }
         },
         operations: {
-          petAvailable: {
+          ownerAvailable: {
             action: 'receive',
             channel: {
-              $ref: '#/channels/pet'
+              $ref: '#/channels/owner'
             }
           }
         },
         components: {
           messages: {
-            Pet: {
+            Owner: {
               payload: {
                 schema: {
-                  $ref: '#/components/schemas/Pet'
+                  $ref: '#/components/schemas/Owner'
                 }
               }
             }
           },
           schemas: {
+            Owner: {
+              title: 'Owner',
+              type: 'object',
+              properties: {
+                pets: {
+                  type: 'array',
+                  items: {
+                    $ref: '#/components/schemas/Pet'
+                  }
+                }
+              },
+            },
             Pet: {
               title: 'Pet',
               type: 'object',

--- a/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
+++ b/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
@@ -1727,6 +1727,37 @@ Array [
 ]
 `;
 
+exports[`JavaGenerator renders discriminator containing a special character when discriminator has a default 1`] = `
+Array [
+  "/**
+ * Pet represents a union of types: Fish, Bird
+ */
+public interface Pet {
+  
+}",
+  "public class Fish implements Pet {
+  private String atType = \\"Fish\\";
+  private Map<String, Object> additionalProperties;
+
+  public String getAtType() { return this.atType; }
+  public void setAtType(String atType) { this.atType = atType; }
+
+  public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
+  public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
+}",
+  "public class Bird implements Pet {
+  private String atType = \\"Fish\\";
+  private Map<String, Object> additionalProperties;
+
+  public String getAtType() { return this.atType; }
+  public void setAtType(String atType) { this.atType = atType; }
+
+  public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
+  public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
+}",
+]
+`;
+
 exports[`JavaGenerator should not render optional imports when only required field 1`] = `
 "public class OtherClass {
   private String color;

--- a/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
+++ b/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
@@ -1733,14 +1733,19 @@ Array [
  * Pet represents a union of types: Fish, Bird
  */
 public interface Pet {
-  
+  String getAtType();
+}",
+  "public class Owner {
+  private Pet[] pets;
+
+  public Pet[] getPets() { return this.pets; }
+  public void setPets(Pet[] pets) { this.pets = pets; }
 }",
   "public class Fish implements Pet {
   private String atType = \\"Fish\\";
   private Map<String, Object> additionalProperties;
 
   public String getAtType() { return this.atType; }
-  public void setAtType(String atType) { this.atType = atType; }
 
   public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
   public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
@@ -1750,7 +1755,6 @@ public interface Pet {
   private Map<String, Object> additionalProperties;
 
   public String getAtType() { return this.atType; }
-  public void setAtType(String atType) { this.atType = atType; }
 
   public Map<String, Object> getAdditionalProperties() { return this.additionalProperties; }
   public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }

--- a/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
+++ b/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
@@ -1742,7 +1742,7 @@ public interface Pet {
   public void setPets(Pet[] pets) { this.pets = pets; }
 }",
   "public class Fish implements Pet {
-  private String atType = \\"Fish\\";
+  private final String atType = \\"Fish\\";
   private Map<String, Object> additionalProperties;
 
   public String getAtType() { return this.atType; }
@@ -1751,7 +1751,7 @@ public interface Pet {
   public void setAdditionalProperties(Map<String, Object> additionalProperties) { this.additionalProperties = additionalProperties; }
 }",
   "public class Bird implements Pet {
-  private String atType = \\"Fish\\";
+  private final String atType = \\"Bird\\";
   private Map<String, Object> additionalProperties;
 
   public String getAtType() { return this.atType; }


### PR DESCRIPTION
## Description
Test case and fix for Java generator, when a discriminator has a special character, e.g. `"@type"` and a default.

## Related Issue
https://github.com/asyncapi/modelina/issues/2332

## Checklist
- [x] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [x] Tests have been added or updated to cover the changes.
- [x] Documentation has been updated to reflect the changes.
- [x] All tests pass successfully locally.(`npm run test`).

## Additional Notes
Fix to be implemented, test result to change from as-is to fixed.