### PR TITLE
fix: java enum default

### DIFF
--- a/src/generators/java/JavaDefaultRendererUtil.ts
+++ b/src/generators/java/JavaDefaultRendererUtil.ts
@@ -1,4 +1,8 @@
-import { ConstrainedObjectPropertyModel } from '../../models';
+import {
+  ConstrainedEnumModel,
+  ConstrainedObjectPropertyModel,
+  ConstrainedReferenceModel
+} from '../../models';
 
 export class JavaDefaultRendererUtil {
   static renderFieldWithDefault(
@@ -25,6 +29,14 @@ export class JavaDefaultRendererUtil {
     }
     if (property.property.type === 'BigDecimal') {
       return `private ${property.property.type} ${property.propertyName} = new BigDecimal(${property.property.originalInput.default});`;
+    }
+    if (property.property instanceof ConstrainedReferenceModel && property.property.ref instanceof ConstrainedEnumModel) {
+      const defaultEnumValue = property.property.ref.values.find(valueModel => valueModel.originalInput === property.property.originalInput.default);
+      if (defaultEnumValue === undefined) {
+        return `private ${property.property.type} ${property.propertyName};`;
+      } else {
+        return `private ${property.property.type} ${property.propertyName} = ${property.property.type}.${defaultEnumValue.key};`;
+      }
     }
     return `private ${property.property.type} ${property.propertyName} = ${property.property.originalInput.default};`;
   }

--- a/src/generators/java/JavaDefaultRendererUtil.ts
+++ b/src/generators/java/JavaDefaultRendererUtil.ts
@@ -30,13 +30,18 @@ export class JavaDefaultRendererUtil {
     if (property.property.type === 'BigDecimal') {
       return `private ${property.property.type} ${property.propertyName} = new BigDecimal(${property.property.originalInput.default});`;
     }
-    if (property.property instanceof ConstrainedReferenceModel && property.property.ref instanceof ConstrainedEnumModel) {
-      const defaultEnumValue = property.property.ref.values.find(valueModel => valueModel.originalInput === property.property.originalInput.default);
+    if (
+      property.property instanceof ConstrainedReferenceModel &&
+      property.property.ref instanceof ConstrainedEnumModel
+    ) {
+      const defaultEnumValue = property.property.ref.values.find(
+        (valueModel) =>
+          valueModel.originalInput === property.property.originalInput.default
+      );
       if (defaultEnumValue === undefined) {
         return `private ${property.property.type} ${property.propertyName};`;
-      } else {
-        return `private ${property.property.type} ${property.propertyName} = ${property.property.type}.${defaultEnumValue.key};`;
       }
+      return `private ${property.property.type} ${property.propertyName} = ${property.property.type}.${defaultEnumValue.key};`;
     }
     return `private ${property.property.type} ${property.propertyName} = ${property.property.originalInput.default};`;
   }

--- a/test/generators/java/JavaGenerator.spec.ts
+++ b/test/generators/java/JavaGenerator.spec.ts
@@ -1248,6 +1248,61 @@ describe('JavaGenerator', () => {
       const models = await generator.generate(asyncapiDoc);
       expect(models.map((model) => model.result)).toMatchSnapshot();
     });
+
+    test('should create enum field without default if invalid', async () => {
+      const asyncapiDoc = {
+        asyncapi: '3.0.0',
+        info: {
+          title: 'Owner example',
+          version: '1.0.0'
+        },
+        channels: {
+          owner: {
+            address: 'owner',
+            messages: {
+              Pet: {
+                $ref: '#/components/messages/Owner'
+              }
+            }
+          }
+        },
+        operations: {
+          ownerAvailable: {
+            action: 'receive',
+            channel: {
+              $ref: '#/channels/owner'
+            }
+          }
+        },
+        components: {
+          messages: {
+            Owner: {
+              payload: {
+                schema: {
+                  $ref: '#/components/schemas/Owner'
+                }
+              }
+            }
+          },
+          schemas: {
+            Owner: {
+              type: 'object',
+              properties: {
+                legalForm: {
+                  type: 'string',
+                  title: 'LegalForm',
+                  enum: ['PERSON', 'CORPORATION'],
+                  default: 'NON_ENUM_VALUE'
+                }
+              }
+            }
+          }
+        }
+      };
+
+      const models = await generator.generate(asyncapiDoc);
+      expect(models.map((model) => model.result)).toMatchSnapshot();
+    });
   });
 
   describe('when default with custom type mappings is used, render field with default', () => {

--- a/test/generators/java/JavaGenerator.spec.ts
+++ b/test/generators/java/JavaGenerator.spec.ts
@@ -1193,6 +1193,61 @@ describe('JavaGenerator', () => {
       const models = await generator.generate(asyncapiDoc);
       expect(models.map((model) => model.result)).toMatchSnapshot();
     });
+
+    test('should create enum field with default', async () => {
+      const asyncapiDoc = {
+        asyncapi: '3.0.0',
+        info: {
+          title: 'Owner example',
+          version: '1.0.0'
+        },
+        channels: {
+          owner: {
+            address: 'owner',
+            messages: {
+              Pet: {
+                $ref: '#/components/messages/Owner'
+              }
+            }
+          }
+        },
+        operations: {
+          ownerAvailable: {
+            action: 'receive',
+            channel: {
+              $ref: '#/channels/owner'
+            }
+          }
+        },
+        components: {
+          messages: {
+            Owner: {
+              payload: {
+                schema: {
+                  $ref: '#/components/schemas/Owner'
+                }
+              }
+            }
+          },
+          schemas: {
+            Owner: {
+              type: 'object',
+              properties: {
+                legalForm: {
+                  type: 'string',
+                  title: 'LegalForm',
+                  enum: ['UNKNOWN', 'PERSON', 'CORPORATION'],
+                  default: 'UNKNOWN'
+                }
+              }
+            }
+          }
+        }
+      };
+
+      const models = await generator.generate(asyncapiDoc);
+      expect(models.map((model) => model.result)).toMatchSnapshot();
+    });
   });
 
   describe('when default with custom type mappings is used, render field with default', () => {

--- a/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
+++ b/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
@@ -2303,6 +2303,44 @@ Array [
 ]
 `;
 
+exports[`JavaGenerator when default is used, render field with default should create enum field without default if invalid 1`] = `
+Array [
+  "public class Owner {
+  private LegalForm legalForm;
+
+  public LegalForm getLegalForm() { return this.legalForm; }
+  public void setLegalForm(LegalForm legalForm) { this.legalForm = legalForm; }
+}",
+  "public enum LegalForm {
+  PERSON((String)\\"PERSON\\"), CORPORATION((String)\\"CORPORATION\\");
+
+  private final String value;
+
+  LegalForm(String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public static LegalForm fromValue(String value) {
+    for (LegalForm e : LegalForm.values()) {
+      if (e.value.equals(value)) {
+        return e;
+      }
+    }
+    throw new IllegalArgumentException(\\"Unexpected value '\\" + value + \\"'\\");
+  }
+
+  @Override
+  public String toString() {
+    return String.valueOf(value);
+  }
+}",
+]
+`;
+
 exports[`JavaGenerator when default is used, render field with default should create field with default 1`] = `
 Array [
   "public class Owner {

--- a/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
+++ b/test/generators/java/__snapshots__/JavaGenerator.spec.ts.snap
@@ -2265,6 +2265,44 @@ public interface Pet {
 ]
 `;
 
+exports[`JavaGenerator when default is used, render field with default should create enum field with default 1`] = `
+Array [
+  "public class Owner {
+  private LegalForm legalForm = LegalForm.UNKNOWN;
+
+  public LegalForm getLegalForm() { return this.legalForm; }
+  public void setLegalForm(LegalForm legalForm) { this.legalForm = legalForm; }
+}",
+  "public enum LegalForm {
+  UNKNOWN((String)\\"UNKNOWN\\"), PERSON((String)\\"PERSON\\"), CORPORATION((String)\\"CORPORATION\\");
+
+  private final String value;
+
+  LegalForm(String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public static LegalForm fromValue(String value) {
+    for (LegalForm e : LegalForm.values()) {
+      if (e.value.equals(value)) {
+        return e;
+      }
+    }
+    throw new IllegalArgumentException(\\"Unexpected value '\\" + value + \\"'\\");
+  }
+
+  @Override
+  public String toString() {
+    return String.valueOf(value);
+  }
+}",
+]
+`;
+
 exports[`JavaGenerator when default is used, render field with default should create field with default 1`] = `
 Array [
   "public class Owner {


### PR DESCRIPTION
## Description
For Java, this generates valid code for an enum property with default.
Before, the generated code looked ok at first glance but didn't compile. 

The generated code could be fixed in 2 ways:
* add a static import for the default enum value
* add the enum type as prefix

In this PR, the later is implemented.

## Related Issue
/

## Checklist
- [x] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [x] Tests have been added or updated to cover the changes.
- [x] Documentation has been updated to reflect the changes.
- [x] All tests pass successfully locally.(`npm run test`).

## Additional Notes
/