### PR TITLE
feat: added support for type fixed and bytes

### DIFF
--- a/src/helpers/AvroToMetaModel.ts
+++ b/src/helpers/AvroToMetaModel.ts
@@ -176,9 +176,15 @@ export function toStringModel(
   name: string
 ): StringModel | undefined {
   if (
-    (typeof avroSchemaModel.type === 'string' ||
+    ((typeof avroSchemaModel.type === 'string' ||
       Array.isArray(avroSchemaModel.type)) &&
-    avroSchemaModel.type.includes('string')
+      avroSchemaModel.type.includes('string')) ||
+    ((typeof avroSchemaModel.type === 'string' ||
+      Array.isArray(avroSchemaModel.type)) &&
+      avroSchemaModel.type.includes('fixed')) ||
+    ((typeof avroSchemaModel.type === 'string' ||
+      Array.isArray(avroSchemaModel.type)) &&
+      avroSchemaModel.type.includes('bytes'))
   ) {
     return new StringModel(
       name,

--- a/test/helpers/AvroToMetaModel.spec.ts
+++ b/test/helpers/AvroToMetaModel.spec.ts
@@ -178,6 +178,26 @@ describe('AvroToMetaModel', () => {
     expect(model).not.toBeUndefined();
     expect(model instanceof ArrayModel).toBeTruthy();
   });
+  test('should handle AvroSchema value of type fixed', () => {
+    const av = new AvroSchema();
+    av.name = 'test';
+    av.type = { name: 'test1', type: 'fixed' };
+
+    const model = AvroToMetaModel(av);
+
+    expect(model).not.toBeUndefined();
+    expect(model instanceof StringModel).toBeTruthy();
+  });
+  test('should handle AvroSchema value of type bytes', () => {
+    const av = new AvroSchema();
+    av.name = 'test';
+    av.type = { name: 'test1', type: 'bytes' };
+
+    const model = AvroToMetaModel(av);
+
+    expect(model).not.toBeUndefined();
+    expect(model instanceof StringModel).toBeTruthy();
+  });
   test('should handle AvroSchema value of type', () => {
     const av = new AvroSchema();
     av.name = 'test';


### PR DESCRIPTION
Based on what's said in #1974, I assume fixed and byte type should convert to string. let me know if my assumption is wrong 
`String Model for fixed and byte data type: need to update the toStringModel function`