### PR TITLE
ci: fix YAML syntax in runtime-go-testing workflow (#2443)

### DIFF
--- a/docs/fix-runtime-go-testing-workflow.md
+++ b/docs/fix-runtime-go-testing-workflow.md
@@ -1,0 +1,21 @@
+# Fix for #2443: runtime-go-testing.yml YAML syntax error
+
+## Problem
+Line 29 and 31 have `-name:` instead of `  - name:` (missing space after dash)
+
+## Patch
+```diff
+--- a/.github/workflows/runtime-go-testing.yml
++++ b/.github/workflows/runtime-go-testing.yml
+@@ -26,11 +26,11 @@
+       with:
+         go-version: 1.20
+-    -name: Generate Go Models
++    - name: Generate Go Models
+       run: npm run generate:runtime:go
+-    -name: Run runtime Tests
++    - name: Run runtime Tests
+       run: npm run test:runtime:go
+```
+
+Also recommended: upgrade `actions/checkout@v2` → `v4`, `actions/setup-node@v1` → `v4`, `actions/setup-go@v2` → `v5`


### PR DESCRIPTION
## Problem

**Fixes #2443**

The `.github/workflows/runtime-go-testing.yml` workflow fails with:

```
Error: Line 29: Mapping values are not allowed in this context
```

## Root Cause

Two step definitions missing required space after dash (`-`):

| Line | Broken | Fixed |
|---|---|---|
| 29 | `-name: Generate Go Models` | `  - name: Generate Go Models` |
| 31 | `-name: Run runtime Tests` | `  - name: Run runtime Tests` |

YAML requires `- key:` (dash + **space** + key) for list items. Without space, it's parsed as a mapping value.

## Complete Fix

Please apply this diff to `.github/workflows/runtime-go-testing.yml`:

```diff
@@ -15,18 +15,18 @@
   runs-on: ubuntu-latest
   steps: 
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Setup Node.js
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: 20
     - name: Build Library
       run: npm install && npm run build:prod
     - name: Setup Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
         go-version: 1.20
-    -name: Generate Go Models
+    - name: Generate Go Models
       run: npm run generate:runtime:go
-    -name: Run runtime Tests
+    - name: Run runtime Tests
       run: npm run test:runtime:go
```

> Note: This PR includes a docs file with these instructions because my PAT lacks the `workflow` scope needed to push workflow files. The fix is 5 characters total — two added spaces. Feel free to apply directly or grant me workflow scope and I'll push the fix.