### PR TITLE
fix(go): emit pointer types for nullable and optional fields

### DIFF
--- a/src/generators/go/GoConstrainer.ts
+++ b/src/generators/go/GoConstrainer.ts
@@ -83,8 +83,10 @@ function getType({
   typeWhenNullableOrOptional: string;
   type: string;
 }) {
-  const required = partOfProperty ? partOfProperty.required : false;
-  if (constrainedModel.options.isNullable && !required) {
+  if (constrainedModel.options.isNullable) {
+    return typeWhenNullableOrOptional;
+  }
+  if (partOfProperty !== undefined && !partOfProperty.required) {
     return typeWhenNullableOrOptional;
   }
   return type;

--- a/test/generators/go/GoConstrainer.spec.ts
+++ b/test/generators/go/GoConstrainer.spec.ts
@@ -96,6 +96,26 @@ describe('GoConstrainer', () => {
       });
       expect(type).toEqual('float64');
     });
+
+    test('nullable and required', () => {
+      const model = new ConstrainedFloatModel(
+        'test',
+        undefined,
+        { isNullable: true },
+        ''
+      );
+      const type = GoDefaultTypeMapping.Float({
+        constrainedModel: model,
+        partOfProperty: new ConstrainedObjectPropertyModel(
+          'object',
+          '',
+          true,
+          model
+        ),
+        ...defaultOptions
+      });
+      expect(type).toEqual('*float64');
+    });
   });
   describe('Integer', () => {
     test('should render type', () => {
@@ -133,6 +153,26 @@ describe('GoConstrainer', () => {
         ...defaultOptions
       });
       expect(type).toEqual('int');
+    });
+
+    test('nullable and required', () => {
+      const model = new ConstrainedIntegerModel(
+        'test',
+        undefined,
+        { isNullable: true },
+        ''
+      );
+      const type = GoDefaultTypeMapping.Integer({
+        constrainedModel: model,
+        partOfProperty: new ConstrainedObjectPropertyModel(
+          'object',
+          '',
+          true,
+          model
+        ),
+        ...defaultOptions
+      });
+      expect(type).toEqual('*int');
     });
   });
   describe('String', () => {
@@ -173,6 +213,26 @@ describe('GoConstrainer', () => {
       });
       expect(type).toEqual('string');
     });
+
+    test('nullable and required', () => {
+      const model = new ConstrainedStringModel(
+        'test',
+        undefined,
+        { isNullable: true },
+        ''
+      );
+      const type = GoDefaultTypeMapping.String({
+        constrainedModel: model,
+        partOfProperty: new ConstrainedObjectPropertyModel(
+          'object',
+          '',
+          true,
+          model
+        ),
+        ...defaultOptions
+      });
+      expect(type).toEqual('*string');
+    });
   });
   describe('Boolean', () => {
     test('should render type', () => {
@@ -211,6 +271,26 @@ describe('GoConstrainer', () => {
         ...defaultOptions
       });
       expect(type).toEqual('bool');
+    });
+
+    test('nullable and required', () => {
+      const model = new ConstrainedBooleanModel(
+        'test',
+        undefined,
+        { isNullable: true },
+        ''
+      );
+      const type = GoDefaultTypeMapping.Boolean({
+        constrainedModel: model,
+        partOfProperty: new ConstrainedObjectPropertyModel(
+          'object',
+          '',
+          true,
+          model
+        ),
+        ...defaultOptions
+      });
+      expect(type).toEqual('*bool');
     });
   });
 

--- a/test/generators/go/__snapshots__/GoGenerator.spec.ts.snap
+++ b/test/generators/go/__snapshots__/GoGenerator.spec.ts.snap
@@ -43,7 +43,7 @@ type Address struct {
   City string
   State string
   HouseNumber float64
-  Marriage bool
+  Marriage *bool
   Members *Members
   ArrayType []Union
   OtherModel *OtherModel
@@ -58,7 +58,7 @@ import (
   \\"time\\"
 )
 type OtherModel struct {
-  StreetName string
+  StreetName *string
   AdditionalProperties map[string]interface{}
 }"
 `;
@@ -104,7 +104,7 @@ type Address struct {
   City string
   State string
   HouseNumber float64
-  Marriage bool
+  Marriage *bool
   Members *Members
   ArrayType []Union
   OtherModel *OtherModel
@@ -117,7 +117,7 @@ exports[`GoGenerator generateCompleteModels() should render models 5`] = `
 package some_package
 
 type OtherModel struct {
-  StreetName string
+  StreetName *string
   AdditionalProperties map[string]interface{}
 }"
 `;
@@ -263,9 +263,9 @@ var ValuesToThings = map[any]Things{
 
 exports[`GoGenerator should render \`required\` for required properties 1`] = `
 "type ExampleStruct struct {
-  Id int \`json:\\"id,omitempty\\"\`
+  Id *int \`json:\\"id,omitempty\\"\`
   MsgUid string \`json:\\"msgUid\\" binding:\\"required\\"\`
-  EvtName string \`json:\\"evtName,omitempty\\"\`
+  EvtName *string \`json:\\"evtName,omitempty\\"\`
 }"
 `;
 
@@ -297,7 +297,7 @@ exports[`GoGenerator should render \`struct\` type 4`] = `
   City string
   State string
   HouseNumber float64
-  Marriage bool
+  Marriage *bool
   Members *Members
   TupleType []Union
   ArrayType []string
@@ -328,7 +328,7 @@ type Address struct {
   City string
   State string
   HouseNumber float64
-  Marriage bool
+  Marriage *bool
   Members *Members
   TupleType []Union
   ArrayType []string
@@ -336,11 +336,11 @@ type Address struct {
   AdditionalProperties map[string]AdditionalProperties
 }
 type LocationAdditionalPropertyOneOf_0 struct {
-  Ref string
+  Ref *string
   AdditionalProperties map[string]interface{}
 }
 type LocationAdditionalPropertyOneOf_1 struct {
-  Id string
+  Id *string
   AdditionalProperties map[string]interface{}
 }"
 `;

--- a/test/generators/go/presets/__snapshots__/CommonPreset.spec.ts.snap
+++ b/test/generators/go/presets/__snapshots__/CommonPreset.spec.ts.snap
@@ -2,9 +2,9 @@
 
 exports[`GO_COMMON_PRESET should render json tags for structs 1`] = `
 "type Root struct {
-  StringProp string \`json:\\"stringProp,omitempty\\"\`
-  NumberProp float64 \`json:\\"numberProp,omitempty\\"\`
-  BooleanProp bool \`json:\\"booleanProp,omitempty\\"\`
+  StringProp *string \`json:\\"stringProp,omitempty\\"\`
+  NumberProp *float64 \`json:\\"numberProp,omitempty\\"\`
+  BooleanProp *bool \`json:\\"booleanProp,omitempty\\"\`
 }"
 `;
 

--- a/test/generators/go/presets/__snapshots__/DescriptionPreset.spec.ts.snap
+++ b/test/generators/go/presets/__snapshots__/DescriptionPreset.spec.ts.snap
@@ -5,7 +5,7 @@ exports[`Description generation should render example function for model 1`] = `
 type Test struct {
   StringProp string
   // Description
-  NumberProp float64
+  NumberProp *float64
   ObjectProp *NestedTest
   // AnyTest description
   AnyProp map[string]interface{}
@@ -15,6 +15,6 @@ type Test struct {
 exports[`Description generation should render example function for model 2`] = `
 "type NestedTest struct {
   // string prop
-  StringProp string
+  StringProp *string
 }"
 `;


### PR DESCRIPTION
## Summary

The `getType` helper in `GoConstrainer.ts` used `isNullable && !required` as a combined guard, which produced two bugs:

- **Nullable + required** fields incorrectly emitted value types (`string`, `int`, ...) instead of pointer types (`*string`, `*int`, ...)
- The single condition conflated two independent concerns (nullable vs. optional), obscuring the intent

The parameter is named `typeWhenNullableOrOptional`, which clearly documents that it should apply to *either* condition independently.

## Changes

**`src/generators/go/GoConstrainer.ts`** — split the combined condition into two separate checks:

```ts
// Before (buggy):
const required = partOfProperty ? partOfProperty.required : false;
if (constrainedModel.options.isNullable && !required) {
  return typeWhenNullableOrOptional;
}

// After (fixed):
if (constrainedModel.options.isNullable) {
  return typeWhenNullableOrOptional;
}
if (partOfProperty !== undefined && !partOfProperty.required) {
  return typeWhenNullableOrOptional;
}
```

**`test/generators/go/GoConstrainer.spec.ts`** — added `'nullable and required'` test cases for `Float`, `Integer`, `String`, and `Boolean` that pass `isNullable: true` together with `required: true` in a `ConstrainedObjectPropertyModel` and assert the `*T` pointer form is emitted.

**Snapshots** — updated to reflect that optional (non-required) fields now also correctly render as pointer types, consistent with Go idiom (a nil pointer cleanly represents an absent optional value).

## Motivation

When generating Go structs from schemas where a field is both nullable *and* listed in `required`, the generator produced a value type that cannot represent `null`. This caused issues in practice: downstream JSON unmarshalling would fail silently or panic when the field carried a JSON `null` value.

## Test plan

- [x] `npx jest test/generators/go/GoConstrainer.spec.ts` — 24 tests pass (4 new)
- [x] `npx jest test/generators/go/` — 71 tests pass, 10 snapshots updated