### PR TITLE
fix(go): collapse nullable single-member oneOf union to pointer type

### DIFF
--- a/src/generators/go/GoConstrainer.ts
+++ b/src/generators/go/GoConstrainer.ts
@@ -64,6 +64,10 @@ export const GoDefaultTypeMapping: GoTypeMapping = {
     return constrainedModel.name;
   },
   Union({ constrainedModel }): string {
+    // A oneOf:[T, null] schema becomes a single-member nullable union — render as *T.
+    if (constrainedModel.options.isNullable && constrainedModel.union.length === 1) {
+      return `*${constrainedModel.union[0].type}`;
+    }
     //Because Go have no notion of unions (and no custom implementation), we have to render it as any value.
     return constrainedModel.name;
   },

--- a/src/generators/go/renderers/UnionRenderer.ts
+++ b/src/generators/go/renderers/UnionRenderer.ts
@@ -28,6 +28,10 @@ const unionIncludesDiscriminator = (model: ConstrainedUnionModel): boolean => {
  */
 export class UnionRenderer extends GoRenderer<ConstrainedUnionModel> {
   public async defaultSelf(): Promise<string> {
+    // oneOf:[T, null] collapses to *T at the property level; no standalone type needed.
+    if (this.model.options.isNullable && this.model.union.length === 1) {
+      return '';
+    }
     if (unionIncludesDiscriminator(this.model)) {
       const content: string[] = [await this.runDiscriminatorAccessorPreset()];
 

--- a/test/generators/go/GoConstrainer.spec.ts
+++ b/test/generators/go/GoConstrainer.spec.ts
@@ -268,6 +268,54 @@ describe('GoConstrainer', () => {
       });
       expect(type).toEqual('test');
     });
+
+    test('nullable single-member union renders as pointer to member type', () => {
+      const memberModel = new ConstrainedStringModel(
+        'test',
+        undefined,
+        {},
+        'string'
+      );
+      const model = new ConstrainedUnionModel(
+        'NullableString',
+        undefined,
+        { isNullable: true },
+        '',
+        [memberModel]
+      );
+      const type = GoDefaultTypeMapping.Union({
+        constrainedModel: model,
+        ...defaultOptions
+      });
+      expect(type).toEqual('*string');
+    });
+
+    test('nullable multi-member union still renders as union type name', () => {
+      const stringModel = new ConstrainedStringModel(
+        'test',
+        undefined,
+        {},
+        'string'
+      );
+      const intModel = new ConstrainedIntegerModel(
+        'test',
+        undefined,
+        {},
+        'int'
+      );
+      const model = new ConstrainedUnionModel(
+        'NullableMulti',
+        undefined,
+        { isNullable: true },
+        '',
+        [stringModel, intModel]
+      );
+      const type = GoDefaultTypeMapping.Union({
+        constrainedModel: model,
+        ...defaultOptions
+      });
+      expect(type).toEqual('NullableMulti');
+    });
   });
 
   describe('Dictionary', () => {


### PR DESCRIPTION
## Summary

When a JSON Schema uses `oneOf: [{type: T}, {type: null}]`, the conversion layer already does the right thing: it sets `isNullable: true` on the resulting `ConstrainedUnionModel` and strips the null member, leaving a single-item union. But the Go generator ignored this and still rendered the union as a named struct type:

```go
// Before — anonymous wrapper, never used anywhere
type NullableString struct {
    string
}

// After — idiomatic Go pointer, used inline where the field is declared
*string
```

The wrapper type polluted generated output and was functionally useless; consumers had to manually rewrite it to `*string`/`*int`/etc.

## Changes

**`src/generators/go/GoConstrainer.ts`** — Union handler: detect the collapsed-nullable case and return `*T`:

```ts
Union({ constrainedModel }): string {
  // A oneOf:[T, null] schema becomes a single-member nullable union — render as *T.
  if (constrainedModel.options.isNullable && constrainedModel.union.length === 1) {
    return `*${constrainedModel.union[0].type}`;
  }
  return constrainedModel.name;
},
```

**`src/generators/go/renderers/UnionRenderer.ts`** — `defaultSelf`: return empty string for the same condition so no standalone Go type definition is emitted:

```ts
public async defaultSelf(): Promise<string> {
  // oneOf:[T, null] collapses to *T at the property level; no standalone type needed.
  if (this.model.options.isNullable && this.model.union.length === 1) {
    return '';
  }
  // ...
```

Multi-member nullable unions (e.g. `oneOf: [{type: string}, {type: integer}, {type: null}]`) are unaffected — they still render as named union structs.

**`test/generators/go/GoConstrainer.spec.ts`** — two new Union test cases:
- `'nullable single-member union renders as pointer to member type'` → `*string`
- `'nullable multi-member union still renders as union type name'` → `NullableMulti` (no regression)

## Test plan

- [x] `npx jest test/generators/go/GoConstrainer.spec.ts` — 2 new tests pass
- [x] `npx jest test/generators/go/` — 69 tests pass, no snapshot changes

## Related

Companion to #2566 (fix nullable+required fields emitting value types instead of pointer types). Together these two PRs make Go nullable field generation correct for all combinations.