### PR TITLE
fix: add AsyncAPI 3.1.0 to supported versions

### DIFF
--- a/src/processors/AsyncAPIInputProcessor.ts
+++ b/src/processors/AsyncAPIInputProcessor.ts
@@ -36,7 +36,8 @@ export class AsyncAPIInputProcessor extends AbstractInputProcessor {
     '2.4.0',
     '2.5.0',
     '2.6.0',
-    '3.0.0'
+    '3.0.0',
+    '3.1.0'
   ];
 
   /**


### PR DESCRIPTION
## Description
Adds support for AsyncAPI 3.1.0 in Modelina by including 3.1.0 in the supportedVersions list of AsyncAPIInputProcessor.

Currently, AsyncAPI 3.1 documents are not recognized as supported input versions, which prevents Modelina from processing specifications that follow the AsyncAPI 3.1 standard.

With this change, Modelina can accept and process AsyncAPI 3.1.0 documents in the same way as other supported AsyncAPI versions.
## Related Issue
Closes #2560

Related to asyncapi/cli#2227
## Checklist
- [x] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [ ] Tests have been added or updated to cover the changes.
- [ ] Documentation has been updated to reflect the changes.
- [x] All tests pass successfully locally.(`npm run test`).

## Additional Notes
<!-- Add any additional information or context that might be relevant to reviewers. -->
