### PR TITLE
fix: Kotlin Constraint Generator omits @Valid annotation

### DIFF
--- a/examples/kotlin-generate-jakarta-constraint-annotation/__snapshots__/index.spec.ts.snap
+++ b/examples/kotlin-generate-jakarta-constraint-annotation/__snapshots__/index.spec.ts.snap
@@ -11,6 +11,7 @@ Array [
     val maxNumberProp: Double,
     @get:Min(101)
     val minNumberPropExclusive: Double? = null,
+    @get:Valid
     @get:Size(min=2, max=3)
     val arrayProp: List<Any>? = null,
     @get:Pattern(regexp=\\"^I_\\")

--- a/examples/kotlin-generate-javax-constraint-annotation/__snapshots__/index.spec.ts.snap
+++ b/examples/kotlin-generate-javax-constraint-annotation/__snapshots__/index.spec.ts.snap
@@ -11,6 +11,7 @@ Array [
     val maxNumberProp: Double,
     @get:Min(101)
     val minNumberPropExclusive: Double? = null,
+    @get:Valid
     @get:Size(min=2, max=3)
     val arrayProp: List<Any>? = null,
     @get:Pattern(regexp=\\"^I_\\")

--- a/src/generators/kotlin/presets/ConstraintsPreset.ts
+++ b/src/generators/kotlin/presets/ConstraintsPreset.ts
@@ -3,6 +3,8 @@ import {
   ConstrainedFloatModel,
   ConstrainedIntegerModel,
   ConstrainedMetaModel,
+  ConstrainedObjectModel,
+  ConstrainedReferenceModel,
   ConstrainedStringModel
 } from '../../../models';
 import { KotlinPreset } from '../KotlinPreset';
@@ -20,10 +22,21 @@ export const KOTLIN_CONSTRAINTS_PRESET: KotlinPreset = {
       renderer.dependencyManager.addDependency(
         `${importFrom}.validation.constraints.*`
       );
+      renderer.dependencyManager.addDependency(
+        `${importFrom}.validation.Valid`
+      );
       return content;
     },
     property({ renderer, property, content }) {
       const annotations: string[] = [];
+
+      if (
+        property.property instanceof ConstrainedReferenceModel ||
+        property.property instanceof ConstrainedObjectModel ||
+        property.property instanceof ConstrainedArrayModel
+      ) {
+        annotations.push(renderer.renderAnnotation('Valid', null, 'get:'));
+      }
 
       if (property.required) {
         annotations.push(renderer.renderAnnotation('NotNull', null, 'get:'));

--- a/test/generators/kotlin/presets/ConstraintsPreset.spec.ts
+++ b/test/generators/kotlin/presets/ConstraintsPreset.spec.ts
@@ -16,7 +16,10 @@ describe('KOTLIN_CONSTRAINTS_PRESET', () => {
     const generator = new KotlinGenerator({
       presets: [KOTLIN_CONSTRAINTS_PRESET]
     });
-    const expectedDependencies = ['import javax.validation.constraints.*'];
+    const expectedDependencies = [
+      'import javax.validation.constraints.*',
+      'import javax.validation.Valid'
+    ];
 
     const models = await generator.generate(doc);
     expect(models).toHaveLength(1);
@@ -36,7 +39,10 @@ describe('KOTLIN_CONSTRAINTS_PRESET', () => {
       ]
     });
 
-    const expectedDependencies = ['import javax.validation.constraints.*'];
+    const expectedDependencies = [
+      'import javax.validation.constraints.*',
+      'import javax.validation.Valid'
+    ];
 
     const models = await generator.generate(doc);
     expect(models).toHaveLength(1);
@@ -56,7 +62,10 @@ describe('KOTLIN_CONSTRAINTS_PRESET', () => {
       ]
     });
 
-    const expectedDependencies = ['import jakarta.validation.constraints.*'];
+    const expectedDependencies = [
+      'import jakarta.validation.constraints.*',
+      'import jakarta.validation.Valid'
+    ];
 
     const models = await generator.generate(doc);
     expect(models).toHaveLength(1);

--- a/test/generators/kotlin/presets/__snapshots__/ConstraintsPreset.spec.ts.snap
+++ b/test/generators/kotlin/presets/__snapshots__/ConstraintsPreset.spec.ts.snap
@@ -8,6 +8,7 @@ exports[`KOTLIN_CONSTRAINTS_PRESET should render jakarta constraints annotations
     @get:NotNull
     @get:Max(99)
     val maxNumberProp: Double,
+    @get:Valid
     @get:Size(min=2, max=3)
     val arrayProp: List<Any>? = null,
     @get:Pattern(regexp=\\"^I_\\")
@@ -25,6 +26,7 @@ exports[`KOTLIN_CONSTRAINTS_PRESET should render javax constraints annotations b
     @get:NotNull
     @get:Max(99)
     val maxNumberProp: Double,
+    @get:Valid
     @get:Size(min=2, max=3)
     val arrayProp: List<Any>? = null,
     @get:Pattern(regexp=\\"^I_\\")
@@ -42,6 +44,7 @@ exports[`KOTLIN_CONSTRAINTS_PRESET should render javax constraints annotations w
     @get:NotNull
     @get:Max(99)
     val maxNumberProp: Double,
+    @get:Valid
     @get:Size(min=2, max=3)
     val arrayProp: List<Any>? = null,
     @get:Pattern(regexp=\\"^I_\\")


### PR DESCRIPTION
## Description

- Update Kotlin Constraints Preset to add Valid annotation for array/object fields
- Update relevant tests

## Related Issue
Closes #2573

## Checklist
- [x] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [x] Tests have been added or updated to cover the changes.
- [x] Documentation has been updated to reflect the changes.
- [x] All tests pass successfully locally.(`npm run test`).

## Additional Notes
<!-- Add any additional information or context that might be relevant to reviewers. -->
