### PR TITLE
fix(csharp): render const properties as valid, compilable C#

### DIFF
--- a/src/generators/csharp/presets/NewtonsoftSerializerPreset.ts
+++ b/src/generators/csharp/presets/NewtonsoftSerializerPreset.ts
@@ -90,6 +90,13 @@ function renderDeserialize({
 
   const corePropsRead = coreProps
     .map((prop) => {
+      // `const` properties are rendered as read-only (a `const` field or a
+      // getter-only property), so assigning to them here would not compile
+      // (CS0200/CS0131). The value is fixed by the schema, so there is nothing
+      // to deserialize into it.
+      if (prop.property.options.const) {
+        return '';
+      }
       const propertyAccessor = pascalCase(prop.propertyName);
       let toValue = `jo["${prop.unconstrainedPropertyName}"].ToObject<${prop.property.type}>(serializer)`;
       if (

--- a/src/generators/csharp/renderers/ClassRenderer.ts
+++ b/src/generators/csharp/renderers/ClassRenderer.ts
@@ -119,7 +119,7 @@ export const CSHARP_DEFAULT_CLASS_PRESET: CsharpClassPreset<CSharpOptions> = {
       if (property.property.options.const) {
         return `public const ${property.property.type} ${pascalCase(
           property.propertyName
-        )} { ${getter} } = ${property.property.options.const.value};`;
+        )} = ${property.property.options.const.value};`;
       }
 
       const semiColon = nullablePropertyEnding !== '' ? ';' : '';

--- a/test/generators/csharp/CSharpGenerator.spec.ts
+++ b/test/generators/csharp/CSharpGenerator.spec.ts
@@ -170,6 +170,30 @@ describe('CSharpGenerator', () => {
     ]);
   });
 
+  test('should generate a valid const property with autoImplementedProperties', async () => {
+    const autoImplementGenerator = new CSharpGenerator({
+      modelType: 'class',
+      autoImplementedProperties: true
+    });
+    const doc = {
+      $id: 'Event',
+      type: 'object',
+      properties: {
+        eventType: { type: 'string', const: 'OnEntryStarted' }
+      },
+      required: ['eventType']
+    };
+
+    const models = await autoImplementGenerator.generate(doc);
+    expect(models).toHaveLength(1);
+    // A C# `const` field cannot have `{ get; }` accessors, so it must be
+    // rendered as a plain const field assignment.
+    expect(models[0].result).toContain(
+      'public const string EventType = "OnEntryStarted";'
+    );
+    expect(models[0].result).not.toContain('public const string EventType {');
+  });
+
   test('should render `enum` type', async () => {
     const doc = {
       $id: 'Things',

--- a/test/generators/csharp/presets/NewtonsoftSerializerPreset.spec.ts
+++ b/test/generators/csharp/presets/NewtonsoftSerializerPreset.spec.ts
@@ -47,4 +47,16 @@ describe('Newtonsoft JSON serializer preset', () => {
     expect(outputModels[1].result).toMatchSnapshot();
     expect(outputModels[2].result).toMatchSnapshot();
   });
+
+  test('should not assign to `const` properties in ReadJson', async () => {
+    const generator = new CSharpGenerator({
+      presets: [CSHARP_NEWTONSOFT_SERIALIZER_PRESET]
+    });
+
+    const outputModels = await generator.generate(doc);
+    // `const` properties are rendered as read-only, so assigning to them in
+    // ReadJson would not compile (CS0200/CS0131). The deserializer must skip
+    // them.
+    expect(outputModels[0].result).not.toContain('value.ConstStringProp =');
+  });
 });

--- a/test/generators/csharp/presets/__snapshots__/NewtonsoftSerializerPreset.spec.ts.snap
+++ b/test/generators/csharp/presets/__snapshots__/NewtonsoftSerializerPreset.spec.ts.snap
@@ -75,9 +75,6 @@ public class TestConverter : JsonConverter<Test>
 }
 value.StringProp = jo[\\"string prop\\"].ToObject<string>(serializer);
 
-if(jo[\\"const string prop\\"] != null) {
-  value.ConstStringProp = jo[\\"const string prop\\"].ToObject<string?>(serializer);
-}
 if(jo[\\"notRequiredStringProp\\"] != null) {
   value.NotRequiredStringProp = jo[\\"notRequiredStringProp\\"].ToObject<string?>(serializer);
 }


### PR DESCRIPTION
## Description

`const` properties produced non-compiling C# in two independent places. This PR fixes both so that schemas using `const` (common for discriminators / tagged messages) generate compilable C#, including under `--csharpNewtonsoft` / `--csharpAutoImplement`.

1. **Invalid declaration with auto-implemented properties** (`ClassRenderer`): a `const` property was emitted as
   ```csharp
   public const string EventType { get; } = "OnEntryStarted";
   ```
   A C# `const` is a field and cannot have property accessors, so this does not compile. It is now rendered as a plain const field (matching the `record` renderer):
   ```csharp
   public const string EventType = "OnEntryStarted";
   ```

2. **Assignment to read-only `const` in the Newtonsoft `ReadJson`** (`NewtonsoftSerializerPreset`): the generated `JsonConverter.ReadJson` assigned to the read-only `const` property, e.g.
   ```csharp
   value.EventType = jo["eventType"].ToObject<string>(serializer); // CS0200 / CS0131
   ```
   The assignment is now skipped for `const` properties, since their value is fixed by the schema and there is nothing to deserialize into them.

## Related Issue

- Closes #2591 — invalid `public const T X { get; } = ...` declaration with auto-implemented properties.
- Closes #2589 — Newtonsoft `ReadJson` assigns to the read-only `const` property (`CS0200`/`CS0131`).

The fix for the Newtonsoft part follows exactly the workaround described by @tkrisztian95 in #2589 (skip the `value.<Prop> = ...;` assignment in `ReadJson` for `const` properties). Thanks for the clear analysis and reproduction there. 🙏

## Checklist

- [x] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [x] Tests have been added or updated to cover the changes.
- [ ] Documentation has been updated to reflect the changes.
- [x] All tests pass successfully locally. (`npm run test`).

## Additional Notes

- Both bugs are independent: fixing only one still leaves the other producing non-compiling output for `const` properties under the Newtonsoft preset.
- New/updated tests:
  - `CSharpGenerator.spec.ts`: a `const` property with `autoImplementedProperties` renders as a valid const field (no accessors).
  - `NewtonsoftSerializerPreset.spec.ts`: `ReadJson` does not assign to `const` properties (plus snapshot update).
- No documentation change is needed as this fixes existing behavior of the C# generator/preset rather than introducing new behavior.
