### PR TITLE
fix(kotlin): add @Valid annotation for cascade validation

### DIFF
--- a/src/generators/kotlin/presets/ConstraintsPreset.ts
+++ b/src/generators/kotlin/presets/ConstraintsPreset.ts
@@ -3,6 +3,8 @@ import {
   ConstrainedFloatModel,
   ConstrainedIntegerModel,
   ConstrainedMetaModel,
+  ConstrainedObjectModel,
+  ConstrainedReferenceModel,
   ConstrainedStringModel
 } from '../../../models';
 import { KotlinPreset } from '../KotlinPreset';
@@ -20,6 +22,9 @@ export const KOTLIN_CONSTRAINTS_PRESET: KotlinPreset = {
       renderer.dependencyManager.addDependency(
         `${importFrom}.validation.constraints.*`
       );
+      renderer.dependencyManager.addDependency(
+        `${importFrom}.validation.Valid`
+      );
       return content;
     },
     property({ renderer, property, content }) {
@@ -27,6 +32,15 @@ export const KOTLIN_CONSTRAINTS_PRESET: KotlinPreset = {
 
       if (property.required) {
         annotations.push(renderer.renderAnnotation('NotNull', null, 'get:'));
+      }
+
+      // Add @Valid for cascade validation on array/object/reference fields
+      if (
+        property.property instanceof ConstrainedReferenceModel ||
+        property.property instanceof ConstrainedObjectModel ||
+        property.property instanceof ConstrainedArrayModel
+      ) {
+        annotations.push(renderer.renderAnnotation('Valid', null, 'get:'));
       }
 
       annotations.push(

--- a/test/generators/kotlin/presets/ConstraintsPreset.spec.ts
+++ b/test/generators/kotlin/presets/ConstraintsPreset.spec.ts
@@ -12,11 +12,23 @@ describe('KOTLIN_CONSTRAINTS_PRESET', () => {
     required: ['min_number_prop', 'max_number_prop']
   };
 
+  const docWithNestedObject = {
+    $id: 'NestedClazz',
+    type: 'object',
+    properties: {
+      array_prop: { type: 'array', items: { type: 'string' } },
+      obj_prop: { type: 'object', properties: { inner: { type: 'string' } } }
+    }
+  };
+
   test('should render javax constraints annotations by default', async () => {
     const generator = new KotlinGenerator({
       presets: [KOTLIN_CONSTRAINTS_PRESET]
     });
-    const expectedDependencies = ['import javax.validation.constraints.*'];
+    const expectedDependencies = [
+      'import javax.validation.constraints.*',
+      'import javax.validation.Valid'
+    ];
 
     const models = await generator.generate(doc);
     expect(models).toHaveLength(1);
@@ -36,7 +48,10 @@ describe('KOTLIN_CONSTRAINTS_PRESET', () => {
       ]
     });
 
-    const expectedDependencies = ['import javax.validation.constraints.*'];
+    const expectedDependencies = [
+      'import javax.validation.constraints.*',
+      'import javax.validation.Valid'
+    ];
 
     const models = await generator.generate(doc);
     expect(models).toHaveLength(1);
@@ -56,11 +71,25 @@ describe('KOTLIN_CONSTRAINTS_PRESET', () => {
       ]
     });
 
-    const expectedDependencies = ['import jakarta.validation.constraints.*'];
+    const expectedDependencies = [
+      'import jakarta.validation.constraints.*',
+      'import jakarta.validation.Valid'
+    ];
 
     const models = await generator.generate(doc);
     expect(models).toHaveLength(1);
     expect(models[0].result).toMatchSnapshot();
     expect(models[0].dependencies).toEqual(expectedDependencies);
+  });
+
+  test('should render @Valid annotation for array and object properties', async () => {
+    const generator = new KotlinGenerator({
+      presets: [KOTLIN_CONSTRAINTS_PRESET]
+    });
+
+    const models = await generator.generate(docWithNestedObject);
+    expect(models.length).toBeGreaterThanOrEqual(1);
+    expect(models[0].result).toContain('@get:Valid');
+    expect(models[0].result).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
## Description

The Kotlin `ConstraintsPreset` was missing the `@Valid` annotation for array, object, and reference properties, effectively disabling cascading validation. This is the same issue that was fixed for the Java generator in #2175.

Without `@Valid`, validation constraints on nested objects and array elements are never triggered, so invalid data in nested structures passes silently.

## Changes

- Add `@Valid` annotation (`@get:Valid` in Kotlin syntax) for `ConstrainedArrayModel`, `ConstrainedObjectModel`, and `ConstrainedReferenceModel` properties
- Add `javax.validation.Valid` (or `jakarta.validation.Valid` when `useJakarta: true`) to imports
- Add test case verifying `@Valid` is rendered for nested object and array properties
- Update existing test snapshots to include new import

## Example output

```kotlin
data class NestedClazz(
    @get:Valid
    val arrayProp: List<String>? = null,
    @get:Valid
    val objProp: ObjProp? = null,
)
```

## Related issue

Fixes #2573