### PR TITLE
feat: bundle community fixes (jsonbinpack build, nullable, isolatedModules, asyncapi headers)

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -78,7 +78,9 @@ All `generate` functions return an array of `OutputModel`s, which contains the f
 
 ## Generate models from AsyncAPI documents
 
-When providing an AsyncAPI document, the library iterates the entire document and generate models for all defined message payloads. The message payloads are interpreted based on the schema format. 
+When providing an AsyncAPI document, the library iterates the entire document and generate models for all defined message payloads. The message payloads are interpreted based on the schema format.
+
+You can optionally include message headers by providing the `includeMessageHeaders` option and setting to `true`.
 
 For JSON Schema it follows the [JSON Schema input processing](#generate-models-from-json-schema-documents).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@apidevtools/swagger-parser": "^10.1.0",
         "@asyncapi/multi-parser": "^2.3.0",
         "@asyncapi/parser": "^3.4.0",
-        "alterschema": "^1.1.2",
         "change-case": "^4.1.2",
         "fast-xml-parser": "^5.5.10",
         "js-yaml": "^4.1.0",
@@ -962,85 +961,6 @@
       "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true
-    },
-    "node_modules/@hyperjump/json": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@hyperjump/json/-/json-0.1.0.tgz",
-      "integrity": "sha512-jWsAOHjweWhi0UEBCN57YZzyTt76Z6Fm/OJXOfNBJbEZt569AcTRsjv6Dqj5t4gQhW9td72oquiyaVp9oHbhBQ==",
-      "dependencies": {
-        "@hyperjump/json-pointer": "^0.9.2",
-        "moo": "^0.5.1"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/jdesrosiers"
-      }
-    },
-    "node_modules/@hyperjump/json-pointer": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/@hyperjump/json-pointer/-/json-pointer-0.9.8.tgz",
-      "integrity": "sha512-6D6okhpH5VOS3oSYUtxu8nClsOcp59aC+sS06/tCxEta4T5Gk1yaycLiCkG8kE9eh+9AJUHsvQEJJrWBfLOjvA==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "just-curry-it": "^5.3.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/jdesrosiers"
-      }
-    },
-    "node_modules/@hyperjump/json-schema": {
-      "version": "0.23.5",
-      "resolved": "https://registry.npmjs.org/@hyperjump/json-schema/-/json-schema-0.23.5.tgz",
-      "integrity": "sha512-gb1jOT6+BlZBR9Nc/tMGDt757YM7rjS71Dml3+TBYebdGOZlSrTzTfVAUfGzOlsceB3gP4K9b7HzAwEGMWmexQ==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@hyperjump/json-schema-core": "^0.28.0",
-        "fastest-stable-stringify": "^2.0.2",
-        "just-curry-it": "^5.3.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/jdesrosiers"
-      }
-    },
-    "node_modules/@hyperjump/json-schema-core": {
-      "version": "0.28.5",
-      "resolved": "https://registry.npmjs.org/@hyperjump/json-schema-core/-/json-schema-core-0.28.5.tgz",
-      "integrity": "sha512-+f5P3oHYCQru3s+Ha+E10rIyEvyK0Hfa2oj3+cDoGaVMbT4Jg5TgCoIM7B5rl3t3KRA7EOmrLjKFGeLi5yd1pg==",
-      "deprecated": "This package was rolled into @hyperjump/json-schema as of v1.0.0",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@hyperjump/json": "^0.1.0",
-        "@hyperjump/json-pointer": "^0.9.4",
-        "@hyperjump/pact": "^0.2.3",
-        "content-type": "^1.0.4",
-        "node-fetch": "^2.6.5",
-        "pubsub-js": "^1.9.4",
-        "uri-js": "^4.4.1"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/jdesrosiers"
-      }
-    },
-    "node_modules/@hyperjump/pact": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@hyperjump/pact/-/pact-0.2.5.tgz",
-      "integrity": "sha512-93m7gLf40EI8svsKrdPc+KkLsngwX/2ld08xwc0PFioxJSxnfkx1BUHNJVjhG386UUYP6mNe+ZtmIiDXDJ4TQg==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "just-curry-it": "^3.1.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/jdesrosiers"
-      }
-    },
-    "node_modules/@hyperjump/pact/node_modules/just-curry-it": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/just-curry-it/-/just-curry-it-3.2.1.tgz",
-      "integrity": "sha512-Q8206k8pTY7krW32cdmPsP+DqqLgWx/hYPSj9/+7SYqSqz7UuwPbfSe07lQtvuuaVyiSJveXk0E5RydOuWwsEg=="
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -2979,20 +2899,6 @@
         }
       }
     },
-    "node_modules/alterschema": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/alterschema/-/alterschema-1.1.3.tgz",
-      "integrity": "sha512-VqKTk8lX8LHVRvSOgEZDGPeEYOvrSOjlX/1PAi4el7ac8acC6/6a99HuVjfU6N1tNrHV5dU0sQDmuOjRvBf/Sw==",
-      "dependencies": {
-        "@hyperjump/json-schema": "^0.23.5",
-        "json-e": "^4.4.3",
-        "lodash": "^4.17.21",
-        "object-hash": "^3.0.0"
-      },
-      "bin": {
-        "alterschema": "bindings/node/cli.js"
-      }
-    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -3820,14 +3726,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-    },
-    "node_modules/content-type": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
-      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
-      "engines": {
-        "node": ">= 0.6"
-      }
     },
     "node_modules/convert-source-map": {
       "version": "1.9.0",
@@ -5498,11 +5396,6 @@
       "bin": {
         "fxparser": "src/cli/cli.js"
       }
-    },
-    "node_modules/fastest-stable-stringify": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/fastest-stable-stringify/-/fastest-stable-stringify-2.0.2.tgz",
-      "integrity": "sha512-bijHueCGd0LqqNK9b5oCMHc0MluJAx0cwqASgbWMvkO01lCYgIhacVRLcaDz3QnyYIRNJRDwMb41VuT6pHJ91Q=="
     },
     "node_modules/fastq": {
       "version": "1.18.0",
@@ -7918,17 +7811,6 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true
     },
-    "node_modules/json-e": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/json-e/-/json-e-4.8.0.tgz",
-      "integrity": "sha512-YOxEEr9dd9/y5PbXsKx/MCFyAR+UL5zbRBObbuHnjxvC3rY8EIfQMc64iULb97G4NcV5vadIzFdEHAYh0Cqljg==",
-      "dependencies": {
-        "json-stable-stringify-without-jsonify": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -7972,7 +7854,8 @@
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true
     },
     "node_modules/json-to-ast": {
       "version": "2.1.0",
@@ -8044,11 +7927,6 @@
       "engines": {
         "node": ">=4.0"
       }
-    },
-    "node_modules/just-curry-it": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/just-curry-it/-/just-curry-it-5.3.0.tgz",
-      "integrity": "sha512-silMIRiFjUWlfaDhkgSzpuAyQ6EX/o09Eu8ZBfmFwQMbax7+LQzeIU2CBrICT6Ne4l86ITCGvUCBpCubWYy0Yw=="
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -8490,11 +8368,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/moo": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
-      "integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q=="
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -8615,14 +8488,6 @@
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.16.tgz",
       "integrity": "sha512-F1I/bimDpj3ncaNDhfyMWuFqmQDBwDB0Fogc2qpL3BWvkQteFD/8BzWuIRl83rq0DXfm8SGt/HFhLXZyljTXcQ==",
       "dev": true
-    },
-    "node_modules/object-hash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
-      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/object-inspect": {
       "version": "1.13.3",
@@ -9271,11 +9136,6 @@
       "funding": {
         "url": "https://github.com/sponsors/lupomontero"
       }
-    },
-    "node_modules/pubsub-js": {
-      "version": "1.9.5",
-      "resolved": "https://registry.npmjs.org/pubsub-js/-/pubsub-js-1.9.5.tgz",
-      "integrity": "sha512-5MZ0I9i5JWVO7SizvOviKvZU2qaBbl2KQX150FAA+fJBwYpwOUId7aNygURWSdPzlsA/xZ/InUKXqBbzM0czTA=="
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "@apidevtools/swagger-parser": "^10.1.0",
     "@asyncapi/multi-parser": "^2.3.0",
     "@asyncapi/parser": "^3.4.0",
-    "alterschema": "^1.1.2",
     "change-case": "^4.1.2",
     "fast-xml-parser": "^5.5.10",
     "js-yaml": "^4.1.0",

--- a/src/generators/typescript/TypeScriptDependencyManager.ts
+++ b/src/generators/typescript/TypeScriptDependencyManager.ts
@@ -1,6 +1,6 @@
 import { AbstractDependencyManager } from '../AbstractDependencyManager';
 import { renderJavaScriptDependency } from '../../helpers';
-import { ConstrainedMetaModel } from '../../models';
+import { ConstrainedEnumModel, ConstrainedMetaModel } from '../../models';
 import { TypeScriptExportType, TypeScriptOptions } from './TypeScriptGenerator';
 
 export class TypeScriptDependencyManager extends AbstractDependencyManager {
@@ -31,12 +31,29 @@ export class TypeScriptDependencyManager extends AbstractDependencyManager {
   }
 
   /**
+   * Returns true when the model is a type-only construct (interface, type alias)
+   * that requires `export type` / `import type` under `isolatedModules: true`.
+   * Enums are runtime values and must always use the plain export/import form.
+   */
+  private isTypeOnlyModel(model: ConstrainedMetaModel): boolean {
+    return !(model instanceof ConstrainedEnumModel);
+  }
+
+  /**
    * Render the model dependencies based on the option
    */
   renderCompleteModelDependencies(
     model: ConstrainedMetaModel,
     exportType: TypeScriptExportType
   ): string {
+    if (
+      exportType === 'named' &&
+      this.options.moduleSystem === 'ESM' &&
+      this.options.isolatedModules &&
+      this.isTypeOnlyModel(model)
+    ) {
+      return `import type {${model.name}} from './${model.name}';`;
+    }
     const dependencyObject =
       exportType === 'named' ? `{${model.name}}` : model.name;
     return this.renderDependency(dependencyObject, `./${model.name}`);
@@ -53,10 +70,17 @@ export class TypeScriptDependencyManager extends AbstractDependencyManager {
       exportType === 'default'
         ? `module.exports = ${model.name};`
         : `exports.${model.name} = ${model.name};`;
-    const esmExport =
-      exportType === 'default'
-        ? `export default ${model.name};\n`
-        : `export { ${model.name} };`;
-    return this.options.moduleSystem === 'CJS' ? cjsExport : esmExport;
+
+    if (this.options.moduleSystem === 'ESM') {
+      if (exportType === 'default') {
+        return `export default ${model.name};\n`;
+      }
+      if (this.options.isolatedModules && this.isTypeOnlyModel(model)) {
+        return `export type { ${model.name} };`;
+      }
+      return `export { ${model.name} };`;
+    }
+
+    return cjsExport;
   }
 }

--- a/src/generators/typescript/TypeScriptGenerator.ts
+++ b/src/generators/typescript/TypeScriptGenerator.ts
@@ -66,6 +66,14 @@ export interface TypeScriptOptions
    * where you most likely need to access them with obj["propertyName"] instead of obj.propertyName
    */
   rawPropertyNames: boolean;
+  /**
+   * When true, generates `export type { }` for type-only exports (interfaces, type aliases)
+   * and `import type { }` for type-only cross-model imports.
+   * Required when using TypeScript's `isolatedModules: true` compiler option
+   * (e.g. Next.js, SWC, esbuild projects).
+   * Enums are always exported as `export { }` because they are runtime values.
+   */
+  isolatedModules: boolean;
 }
 export type TypeScriptConstantConstraint =
   ConstantConstraint<TypeScriptOptions>;
@@ -117,6 +125,7 @@ export class TypeScriptGenerator extends AbstractGenerator<
     moduleSystem: 'ESM',
     rawPropertyNames: false,
     useJavascriptReservedKeywords: true,
+    isolatedModules: false,
     // Temporarily set
     dependencyManager: () => {
       return {} as TypeScriptDependencyManager;

--- a/src/generators/typescript/presets/JsonBinPackPreset.ts
+++ b/src/generators/typescript/presets/JsonBinPackPreset.ts
@@ -1,6 +1,5 @@
 import { TypeScriptPreset } from '../TypeScriptPreset';
-// eslint-disable-next-line @typescript-eslint/no-var-requires,no-undef
-const alterschema = require('alterschema');
+import { migrateSchemaTo202012 } from '../utils/migrateSchema';
 
 function getInputSchema(originalInput: any): string {
   if (originalInput.$schema !== undefined) {
@@ -25,17 +24,17 @@ function getInputSchema(originalInput: any): string {
  */
 export const TS_JSONBINPACK_PRESET: TypeScriptPreset = {
   class: {
-    async additionalContent({ renderer, content, model }) {
+    additionalContent({ renderer, content, model }) {
       renderer.dependencyManager.addDependency(
         "const jsonbinpack = require('jsonbinpack')"
       );
 
-      const jsonSchema = await alterschema(
-        model.originalInput,
-        getInputSchema(model.originalInput),
-        '2020-12'
+      // Migrate source schema to JSON Schema 2020-12 for jsonbinpack compatibility
+      const fromVersion = getInputSchema(model.originalInput);
+      const jsonSchema = migrateSchemaTo202012(
+        model.originalInput as Record<string, unknown>,
+        fromVersion
       );
-      jsonSchema['$schema'] = 'https://json-schema.org/draft/2020-12/schema';
       const json = JSON.stringify(jsonSchema);
       const packContent = `public async jsonbinSerialize(): Promise<Buffer>{
   const jsonData = JSON.parse(this.marshal());

--- a/src/generators/typescript/utils/migrateSchema.ts
+++ b/src/generators/typescript/utils/migrateSchema.ts
@@ -1,0 +1,166 @@
+/**
+ * Lightweight JSON Schema migration from draft-04/06/07 to 2020-12.
+ *
+ * Replaces the `alterschema` dependency which pulled in broken `@hyperjump/pact`
+ * postinstall scripts causing Yarn build failures (see #2494).
+ *
+ * Covers the most common conversions needed for JsonBinPack schema compatibility:
+ * - `$schema` URI update
+ * - `definitions` → `$defs` + pointer rewrite
+ * - `exclusiveMinimum`/`exclusiveMaximum` boolean → numeric form (draft-04)
+ * - `items` tuple form → `prefixItems` (draft-04/06)
+ * - Nested `$ref` pointer updates in sub-schemas
+ */
+
+const DRAFT_2020_12_SCHEMA = 'https://json-schema.org/draft/2020-12/schema';
+const OBJECT_TYPE = 'object';
+
+// Keys whose values are maps of named sub-schemas (e.g. `properties`).
+const SCHEMA_MAP_KEYS = [
+  'properties',
+  'patternProperties',
+  'additionalProperties',
+  '$defs',
+  'definitions'
+];
+
+// Keys whose values are a single sub-schema or an array of sub-schemas.
+const SCHEMA_OR_LIST_KEYS = [
+  'additionalItems',
+  'prefixItems',
+  'allOf',
+  'anyOf',
+  'oneOf',
+  'not'
+];
+
+type SchemaObject = Record<string, unknown>;
+
+function isSchemaObject(value: unknown): value is SchemaObject {
+  return (
+    typeof value === OBJECT_TYPE && value !== null && !Array.isArray(value)
+  );
+}
+
+// definitions → $defs (draft-04/06)
+function renameDefinitions(obj: SchemaObject): void {
+  if (obj.definitions !== undefined && obj.$defs === undefined) {
+    obj.$defs = obj.definitions;
+    delete obj.definitions;
+  }
+}
+
+// exclusiveMinimum/Maximum as boolean → numeric (draft-04 only)
+function normalizeExclusiveBounds(obj: SchemaObject): void {
+  if (obj.exclusiveMinimum === true && obj.minimum !== undefined) {
+    obj.exclusiveMinimum = obj.minimum;
+    delete obj.minimum;
+  }
+  if (obj.exclusiveMaximum === true && obj.maximum !== undefined) {
+    obj.exclusiveMaximum = obj.maximum;
+    delete obj.maximum;
+  }
+}
+
+// items (tuple) → prefixItems (draft-04/06)
+function tupleItemsToPrefixItems(obj: SchemaObject): void {
+  if (Array.isArray(obj.items)) {
+    obj.prefixItems = obj.items;
+    delete obj.items;
+  }
+}
+
+// Migrate the sub-schemas held under map-valued keys (e.g. `properties`).
+function migrateSchemaMaps(obj: SchemaObject): void {
+  for (const key of SCHEMA_MAP_KEYS) {
+    // Keys come from a fixed constant list, so this access is safe.
+    // eslint-disable-next-line security/detect-object-injection
+    const value = obj[key];
+    if (!isSchemaObject(value)) {
+      continue;
+    }
+    for (const sub of Object.values(value)) {
+      if (isSchemaObject(sub)) {
+        migrateObject(sub);
+      }
+    }
+  }
+}
+
+// Migrate the sub-schemas held under keys that are a single schema or a list.
+function migrateSchemaLists(obj: SchemaObject): void {
+  for (const key of SCHEMA_OR_LIST_KEYS) {
+    // Keys come from a fixed constant list, so this access is safe.
+    // eslint-disable-next-line security/detect-object-injection
+    const value = obj[key];
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        if (isSchemaObject(item)) {
+          migrateObject(item);
+        }
+      }
+    } else if (isSchemaObject(value)) {
+      migrateObject(value);
+    }
+  }
+}
+
+// Recursively migrate the sub-schemas nested under the given object.
+function migrateChildren(obj: SchemaObject): void {
+  migrateSchemaMaps(obj);
+
+  // `items` when it is a single schema rather than a tuple.
+  if (isSchemaObject(obj.items)) {
+    migrateObject(obj.items);
+  }
+
+  migrateSchemaLists(obj);
+}
+
+function migrateObject(obj: SchemaObject): void {
+  renameDefinitions(obj);
+  normalizeExclusiveBounds(obj);
+  tupleItemsToPrefixItems(obj);
+  migrateChildren(obj);
+}
+
+/**
+ * Rewrite JSON string representation of `$ref` pointers from
+ * `#/definitions/...` to `#/$defs/...`.
+ */
+function rewriteRefPointers(json: string): string {
+  return json.replace(/"#\/definitions\//g, '"#/$defs/');
+}
+
+/**
+ * Migrate a JSON Schema from draft-04/06/07 to 2020-12.
+ *
+ * @param schema - The source JSON Schema object
+ * @param fromVersion - The detected source draft (`draft4`, `draft6`, `draft7`)
+ * @returns A new schema object migrated to 2020-12
+ */
+export function migrateSchemaTo202012(
+  schema: SchemaObject,
+  fromVersion: string
+): SchemaObject {
+  // Clone to avoid mutating the input
+  const result = JSON.parse(JSON.stringify(schema)) as SchemaObject;
+  const isLegacyDraft = fromVersion === 'draft4' || fromVersion === 'draft6';
+
+  // Apply structural migrations for draft-04 and draft-06
+  if (isLegacyDraft) {
+    migrateObject(result);
+  }
+
+  // Always set $schema URI to 2020-12 (required by jsonbinpack)
+  result.$schema = DRAFT_2020_12_SCHEMA;
+
+  // Rewrite any remaining $ref pointers (covers nested refs in stringified sub-schemas)
+  if (isLegacyDraft) {
+    return JSON.parse(
+      rewriteRefPointers(JSON.stringify(result))
+    ) as SchemaObject;
+  }
+
+  return result;
+}

--- a/src/generators/typescript/utils/migrateSchema.ts
+++ b/src/generators/typescript/utils/migrateSchema.ts
@@ -129,7 +129,7 @@ function migrateObject(obj: SchemaObject): void {
  * `#/definitions/...` to `#/$defs/...`.
  */
 function rewriteRefPointers(json: string): string {
-  return json.replace(/"#\/definitions\//g, '"#/$defs/');
+  return json.replaceAll('"#/definitions/', '"#/$defs/');
 }
 
 /**

--- a/src/interpreter/Interpreter.ts
+++ b/src/interpreter/Interpreter.ts
@@ -142,6 +142,9 @@ export class Interpreter {
     if (schema.type !== undefined) {
       model.addTypes(schema.type);
     }
+    if ('nullable' in schema && schema.nullable) {
+      model.addTypes('null');
+    }
     if (schema.required !== undefined) {
       model.required = schema.required;
     }

--- a/src/models/ProcessorOptions.ts
+++ b/src/models/ProcessorOptions.ts
@@ -1,12 +1,12 @@
-import { ParseOptions } from '@asyncapi/parser';
 import {
+  AsyncAPIInputProcessorOptions,
   JsonSchemaProcessorOptions,
   OpenAPIInputProcessorOptions,
   TypeScriptInputProcessorOptions
 } from '../processors/index';
 
 export interface ProcessorOptions {
-  asyncapi?: ParseOptions;
+  asyncapi?: AsyncAPIInputProcessorOptions;
   openapi?: OpenAPIInputProcessorOptions;
   typescript?: TypeScriptInputProcessorOptions;
   jsonSchema?: JsonSchemaProcessorOptions;

--- a/src/processors/AsyncAPIInputProcessor.ts
+++ b/src/processors/AsyncAPIInputProcessor.ts
@@ -455,26 +455,6 @@ export class AsyncAPIInputProcessor extends AbstractInputProcessor {
   }
 
   /**
-   * Generate a hash of a schema's JSON representation for duplicate detection
-   */
-  private static hashSchema(schemaJson: any): string {
-    if (!schemaJson || typeof schemaJson !== 'object') {
-      return '';
-    }
-    // Create a stable string representation by sorting keys
-    const sortedJson = JSON.stringify(
-      schemaJson,
-      Object.keys(schemaJson).sort()
-    );
-    // Simple hash function (djb2)
-    let hash = 5381;
-    for (let i = 0; i < sortedJson.length; i++) {
-      hash = (hash << 5) + hash + (sortedJson.codePointAt(i) ?? Number.NaN);
-    }
-    return hash.toString(36);
-  }
-
-  /**
    * Determine the best name for a schema based on available metadata and context.
    *
    * Priority order:

--- a/src/processors/AsyncAPIInputProcessor.ts
+++ b/src/processors/AsyncAPIInputProcessor.ts
@@ -9,7 +9,8 @@ import {
   SchemaV2 as AsyncAPISchema,
   fromFile,
   createAsyncAPIDocument,
-  MessagesInterface
+  MessagesInterface,
+  ParseOptions
 } from '@asyncapi/parser';
 import yaml from 'js-yaml';
 import { AbstractInputProcessor } from './AbstractInputProcessor';
@@ -25,6 +26,13 @@ import {
 } from '@asyncapi/multi-parser';
 import { createDetailedAsyncAPI } from '@asyncapi/parser/cjs/utils';
 import { createMetadataPreservingResolver } from './utils';
+
+export interface AsyncAPIInputProcessorOptions extends ParseOptions {
+  /**
+   * This option will include message headers in the list of models built whilst traversing the AsyncAPI spec.
+   */
+  includeMessageHeaders?: boolean;
+}
 
 /**
  * Context information for schema name inference
@@ -322,61 +330,85 @@ export class AsyncAPIInputProcessor extends AbstractInputProcessor {
             messages: MessagesInterface,
             contextChannelName?: string
           ) => {
+            const includeMessageHeaders =
+              options?.asyncapi?.includeMessageHeaders === true;
+            // Build the schema-naming context for a message
+            const getMessageContext = (
+              message: MessagesInterface[number]
+            ): SchemaContext => {
+              const messageId = message.id();
+              // Use message ID if available, otherwise use channel name
+              const contextId =
+                messageId &&
+                !messageId.includes(
+                  AsyncAPIInputProcessor.ANONYMOUS_MESSAGE_PREFIX
+                )
+                  ? messageId
+                  : contextChannelName;
+              return contextId ? { messageId: contextId } : {};
+            };
             // treat multiple messages as oneOf
             if (messages.length > 1) {
-              const oneOf: any[] = [];
+              const payloadOneOf: any[] = [];
+              const headersOneOf: any[] = [];
 
               for (const message of messages) {
+                const messageContext = getMessageContext(message);
                 const payload = message.payload();
 
-                if (!payload) {
-                  continue;
+                if (payload) {
+                  // Add each individual message payload as a separate model
+                  addToInputModel(payload, messageContext);
+                  payloadOneOf.push(payload.json());
                 }
 
-                // Add each individual message payload as a separate model
-                const messageId = message.id();
-                // Use message ID if available, otherwise use channel name
-                const contextId =
-                  messageId &&
-                  !messageId.includes(
-                    AsyncAPIInputProcessor.ANONYMOUS_MESSAGE_PREFIX
-                  )
-                    ? messageId
-                    : contextChannelName;
-                const messageContext: SchemaContext = contextId
-                  ? { messageId: contextId }
-                  : {};
-                addToInputModel(payload, messageContext);
-                oneOf.push(payload.json());
+                if (includeMessageHeaders) {
+                  const headers = message.headers();
+                  if (headers) {
+                    // Add each individual message header as a separate model
+                    addToInputModel(headers, messageContext);
+                    headersOneOf.push(headers.json());
+                  }
+                }
               }
 
               const payload = new AsyncAPISchema(
                 {
-                  $id: channelId,
-                  oneOf
+                  $id: includeMessageHeaders
+                    ? `${channelId}Payload`
+                    : channelId,
+                  oneOf: payloadOneOf
                 },
                 channel.meta()
               );
 
               addToInputModel(payload);
+
+              if (includeMessageHeaders) {
+                const headers = new AsyncAPISchema(
+                  {
+                    $id: `${channelId}Headers`,
+                    oneOf: headersOneOf
+                  },
+                  channel.meta()
+                );
+
+                addToInputModel(headers);
+              }
             } else if (messages.length === 1) {
               const message = messages[0];
+              const messageContext = getMessageContext(message);
               const payload = message.payload();
               if (payload) {
                 // Use message ID as context for better naming
-                const messageId = message.id();
-                // Use message ID if available, otherwise use channel name
-                const contextId =
-                  messageId &&
-                  !messageId.includes(
-                    AsyncAPIInputProcessor.ANONYMOUS_MESSAGE_PREFIX
-                  )
-                    ? messageId
-                    : contextChannelName;
-                const messageContext: SchemaContext = contextId
-                  ? { messageId: contextId }
-                  : {};
                 addToInputModel(payload, messageContext);
+              }
+
+              if (includeMessageHeaders) {
+                const headers = message.headers();
+                if (headers) {
+                  addToInputModel(headers, messageContext);
+                }
               }
             }
           };

--- a/src/processors/AsyncAPIInputProcessor.ts
+++ b/src/processors/AsyncAPIInputProcessor.ts
@@ -326,90 +326,99 @@ export class AsyncAPIInputProcessor extends AbstractInputProcessor {
           : undefined;
 
         for (const operation of channel.operations()) {
+          const includeMessageHeaders =
+            options?.asyncapi?.includeMessageHeaders === true;
+
+          // Build the schema-naming context for a message
+          const getMessageContext = (
+            message: MessagesInterface[number],
+            contextChannelName?: string
+          ): SchemaContext => {
+            const messageId = message.id();
+            // Use message ID if available, otherwise use channel name
+            const contextId =
+              messageId &&
+              !messageId.includes(
+                AsyncAPIInputProcessor.ANONYMOUS_MESSAGE_PREFIX
+              )
+                ? messageId
+                : contextChannelName;
+            return contextId ? { messageId: contextId } : {};
+          };
+
+          // Add a single message's payload (and optionally headers) as models,
+          // collecting their JSON into the provided oneOf accumulators.
+          const addMessageModels = (
+            message: MessagesInterface[number],
+            contextChannelName?: string,
+            payloadOneOf?: any[],
+            headersOneOf?: any[]
+          ) => {
+            const messageContext = getMessageContext(
+              message,
+              contextChannelName
+            );
+
+            const payload = message.payload();
+            if (payload) {
+              // Add each individual message payload as a separate model
+              addToInputModel(payload, messageContext);
+              payloadOneOf?.push(payload.json());
+            }
+
+            if (includeMessageHeaders) {
+              const headers = message.headers();
+              if (headers) {
+                // Add each individual message header as a separate model
+                addToInputModel(headers, messageContext);
+                headersOneOf?.push(headers.json());
+              }
+            }
+          };
+
           const handleMessages = (
             messages: MessagesInterface,
             contextChannelName?: string
           ) => {
-            const includeMessageHeaders =
-              options?.asyncapi?.includeMessageHeaders === true;
-            // Build the schema-naming context for a message
-            const getMessageContext = (
-              message: MessagesInterface[number]
-            ): SchemaContext => {
-              const messageId = message.id();
-              // Use message ID if available, otherwise use channel name
-              const contextId =
-                messageId &&
-                !messageId.includes(
-                  AsyncAPIInputProcessor.ANONYMOUS_MESSAGE_PREFIX
-                )
-                  ? messageId
-                  : contextChannelName;
-              return contextId ? { messageId: contextId } : {};
-            };
             // treat multiple messages as oneOf
             if (messages.length > 1) {
               const payloadOneOf: any[] = [];
               const headersOneOf: any[] = [];
 
               for (const message of messages) {
-                const messageContext = getMessageContext(message);
-                const payload = message.payload();
-
-                if (payload) {
-                  // Add each individual message payload as a separate model
-                  addToInputModel(payload, messageContext);
-                  payloadOneOf.push(payload.json());
-                }
-
-                if (includeMessageHeaders) {
-                  const headers = message.headers();
-                  if (headers) {
-                    // Add each individual message header as a separate model
-                    addToInputModel(headers, messageContext);
-                    headersOneOf.push(headers.json());
-                  }
-                }
+                addMessageModels(
+                  message,
+                  contextChannelName,
+                  payloadOneOf,
+                  headersOneOf
+                );
               }
 
-              const payload = new AsyncAPISchema(
-                {
-                  $id: includeMessageHeaders
-                    ? `${channelId}Payload`
-                    : channelId,
-                  oneOf: payloadOneOf
-                },
-                channel.meta()
-              );
-
-              addToInputModel(payload);
-
-              if (includeMessageHeaders) {
-                const headers = new AsyncAPISchema(
+              addToInputModel(
+                new AsyncAPISchema(
                   {
-                    $id: `${channelId}Headers`,
-                    oneOf: headersOneOf
+                    $id: includeMessageHeaders
+                      ? `${channelId}Payload`
+                      : channelId,
+                    oneOf: payloadOneOf
                   },
                   channel.meta()
-                );
-
-                addToInputModel(headers);
-              }
-            } else if (messages.length === 1) {
-              const message = messages[0];
-              const messageContext = getMessageContext(message);
-              const payload = message.payload();
-              if (payload) {
-                // Use message ID as context for better naming
-                addToInputModel(payload, messageContext);
-              }
+                )
+              );
 
               if (includeMessageHeaders) {
-                const headers = message.headers();
-                if (headers) {
-                  addToInputModel(headers, messageContext);
-                }
+                addToInputModel(
+                  new AsyncAPISchema(
+                    {
+                      $id: `${channelId}Headers`,
+                      oneOf: headersOneOf
+                    },
+                    channel.meta()
+                  )
+                );
               }
+            } else if (messages.length === 1) {
+              addMessageModels(messages[0], contextChannelName);
             }
           };
           const replyOperation = operation.reply();

--- a/test/generators/typescript/TypeScriptDependencyManager.spec.ts
+++ b/test/generators/typescript/TypeScriptDependencyManager.spec.ts
@@ -1,5 +1,10 @@
 import { TypeScriptGenerator } from '../../../src/generators';
 import { TypeScriptDependencyManager } from '../../../src/generators/typescript/TypeScriptDependencyManager';
+import {
+  ConstrainedEnumModel,
+  ConstrainedObjectModel
+} from '../../../src/models';
+
 describe('TypeScriptDependencyManager', () => {
   describe('renderDependency()', () => {
     test('Should be able to render dependency', () => {
@@ -10,6 +15,140 @@ describe('TypeScriptDependencyManager', () => {
       expect(
         dependencyManager.renderDependency('someComment', 'someComment2')
       ).toEqual(`import someComment from 'someComment2';`);
+    });
+  });
+
+  describe('renderExport()', () => {
+    const makeObjectModel = (name: string) =>
+      new ConstrainedObjectModel(name, undefined, {}, '', {});
+
+    const makeEnumModel = (name: string) =>
+      new ConstrainedEnumModel(name, undefined, {}, '', []);
+
+    test('renders plain named export for ESM without isolatedModules', () => {
+      const dm = new TypeScriptDependencyManager(
+        {
+          ...TypeScriptGenerator.defaultOptions,
+          moduleSystem: 'ESM',
+          isolatedModules: false
+        },
+        []
+      );
+      expect(dm.renderExport(makeObjectModel('MyModel'), 'named')).toEqual(
+        'export { MyModel };'
+      );
+    });
+
+    test('renders export type for ESM with isolatedModules for interface/object model', () => {
+      const dm = new TypeScriptDependencyManager(
+        {
+          ...TypeScriptGenerator.defaultOptions,
+          moduleSystem: 'ESM',
+          isolatedModules: true
+        },
+        []
+      );
+      expect(dm.renderExport(makeObjectModel('MyInterface'), 'named')).toEqual(
+        'export type { MyInterface };'
+      );
+    });
+
+    test('renders plain export for ESM with isolatedModules for enum (runtime value)', () => {
+      const dm = new TypeScriptDependencyManager(
+        {
+          ...TypeScriptGenerator.defaultOptions,
+          moduleSystem: 'ESM',
+          isolatedModules: true
+        },
+        []
+      );
+      expect(dm.renderExport(makeEnumModel('MyEnum'), 'named')).toEqual(
+        'export { MyEnum };'
+      );
+    });
+
+    test('renders default export unchanged when isolatedModules is true', () => {
+      const dm = new TypeScriptDependencyManager(
+        {
+          ...TypeScriptGenerator.defaultOptions,
+          moduleSystem: 'ESM',
+          isolatedModules: true
+        },
+        []
+      );
+      expect(dm.renderExport(makeObjectModel('MyModel'), 'default')).toEqual(
+        'export default MyModel;\n'
+      );
+    });
+
+    test('renders CJS export unchanged when isolatedModules is true', () => {
+      const dm = new TypeScriptDependencyManager(
+        {
+          ...TypeScriptGenerator.defaultOptions,
+          moduleSystem: 'CJS',
+          isolatedModules: true
+        },
+        []
+      );
+      expect(dm.renderExport(makeObjectModel('MyModel'), 'named')).toEqual(
+        'exports.MyModel = MyModel;'
+      );
+    });
+  });
+
+  describe('renderCompleteModelDependencies()', () => {
+    const makeObjectModel = (name: string) =>
+      new ConstrainedObjectModel(name, undefined, {}, '', {});
+
+    const makeEnumModel = (name: string) =>
+      new ConstrainedEnumModel(name, undefined, {}, '', []);
+
+    test('renders import type for ESM named with isolatedModules for object model', () => {
+      const dm = new TypeScriptDependencyManager(
+        {
+          ...TypeScriptGenerator.defaultOptions,
+          moduleSystem: 'ESM',
+          isolatedModules: true
+        },
+        []
+      );
+      expect(
+        dm.renderCompleteModelDependencies(
+          makeObjectModel('OtherModel'),
+          'named'
+        )
+      ).toEqual("import type {OtherModel} from './OtherModel';");
+    });
+
+    test('renders plain import for ESM named without isolatedModules', () => {
+      const dm = new TypeScriptDependencyManager(
+        {
+          ...TypeScriptGenerator.defaultOptions,
+          moduleSystem: 'ESM',
+          isolatedModules: false
+        },
+        []
+      );
+      expect(
+        dm.renderCompleteModelDependencies(
+          makeObjectModel('OtherModel'),
+          'named'
+        )
+      ).toEqual("import {OtherModel} from './OtherModel';");
+    });
+
+    test('renders plain import for enum even with isolatedModules (enum is runtime value)', () => {
+      const dm = new TypeScriptDependencyManager(
+        {
+          ...TypeScriptGenerator.defaultOptions,
+          moduleSystem: 'ESM',
+          isolatedModules: true
+        },
+        []
+      );
+      expect(
+        dm.renderCompleteModelDependencies(makeEnumModel('MyEnum'), 'named')
+      ).toEqual("import {MyEnum} from './MyEnum';");
     });
   });
 });

--- a/test/generators/typescript/TypeScriptGenerator.spec.ts
+++ b/test/generators/typescript/TypeScriptGenerator.spec.ts
@@ -381,6 +381,45 @@ ${content}`;
     expect(models[1].result).toMatchSnapshot();
   });
 
+  test('should render `export type` for ESM named exports with isolatedModules and interface modelType', async () => {
+    generator = new TypeScriptGenerator({
+      moduleSystem: 'ESM',
+      modelType: 'interface',
+      isolatedModules: true
+    });
+    const models = await generator.generateCompleteModels(doc, {
+      exportType: 'named'
+    });
+    expect(models).toHaveLength(2);
+    expect(models[0].result).toMatchSnapshot();
+    expect(models[1].result).toMatchSnapshot();
+    // Verify that type-only exports use `export type`
+    const hasExportType = models.some((m) =>
+      m.result.includes('export type {')
+    );
+    expect(hasExportType).toBe(true);
+    // Verify that plain `export {` is NOT used for interfaces
+    const hasPlainExport = models.some((m) =>
+      m.result.split('\n').some((l) => l.startsWith('export {'))
+    );
+    expect(hasPlainExport).toBe(false);
+  });
+
+  test('should render `import type` for cross-model dependencies with isolatedModules and interface modelType', async () => {
+    generator = new TypeScriptGenerator({
+      moduleSystem: 'ESM',
+      modelType: 'interface',
+      isolatedModules: true
+    });
+    const models = await generator.generateCompleteModels(doc, {
+      exportType: 'named'
+    });
+    // The model that imports OtherModel should use `import type`
+    const modelWithDep = models.find((m) => m.result.includes('import'));
+    expect(modelWithDep).toBeDefined();
+    expect(modelWithDep?.result).toMatch(/import type \{/);
+  });
+
   describe('AsyncAPI with polymorphism', () => {
     const asyncapiDoc = {
       asyncapi: '2.4.0',

--- a/test/generators/typescript/__snapshots__/TypeScriptGenerator.spec.ts.snap
+++ b/test/generators/typescript/__snapshots__/TypeScriptGenerator.spec.ts.snap
@@ -547,6 +547,31 @@ exports[`TypeScriptGenerator should render \`enum\` type 1`] = `
 
 exports[`TypeScriptGenerator should render \`enum\` type as \`union\` if option enumType = \`union\` 1`] = `"type States = \\"Texas\\" | \\"Alabama\\" | \\"California\\";"`;
 
+exports[`TypeScriptGenerator should render \`export type\` for ESM named exports with isolatedModules and interface modelType 1`] = `
+"import type {OtherModel} from './OtherModel';
+interface Address {
+  streetName: string;
+  city: string;
+  state: string;
+  houseNumber: number;
+  marriage?: boolean;
+  members?: string | number | boolean;
+  arrayType: (string | number | any)[];
+  otherModel?: OtherModel;
+  additionalProperties?: Map<string, any | string>;
+}
+export type { Address };"
+`;
+
+exports[`TypeScriptGenerator should render \`export type\` for ESM named exports with isolatedModules and interface modelType 2`] = `
+"
+interface OtherModel {
+  streetName?: string;
+  additionalProperties?: Map<string, any>;
+}
+export type { OtherModel };"
+`;
+
 exports[`TypeScriptGenerator should render \`interface\` type 1`] = `
 "interface Address {
   streetName: string;

--- a/test/generators/typescript/preset/__snapshots__/JsonBinPackPreset.spec.ts.snap
+++ b/test/generators/typescript/preset/__snapshots__/JsonBinPackPreset.spec.ts.snap
@@ -59,12 +59,12 @@ exports[`JsonBinPack preset should work fine with AsyncAPI inputs 1`] = `
   }
   public async jsonbinSerialize(): Promise<Buffer>{
     const jsonData = JSON.parse(this.marshal());
-    const jsonbinpackEncodedSchema = await jsonbinpack.compileSchema({\\"$schema\\":\\"https://json-schema.org/draft/2020-12/schema\\",\\"type\\":\\"object\\",\\"properties\\":{\\"email\\":{\\"format\\":\\"email\\",\\"type\\":\\"string\\",\\"x-parser-schema-id\\":\\"<anonymous-schema-2>\\",\\"x-modelgen-inferred-name\\":\\"UserSignedupPayloadEmail\\"}},\\"x-parser-schema-id\\":\\"<anonymous-schema-1>\\",\\"x-modelgen-inferred-name\\":\\"UserSignedupPayload\\"});
+    const jsonbinpackEncodedSchema = await jsonbinpack.compileSchema({\\"type\\":\\"object\\",\\"properties\\":{\\"email\\":{\\"format\\":\\"email\\",\\"type\\":\\"string\\",\\"x-parser-schema-id\\":\\"<anonymous-schema-2>\\",\\"x-modelgen-inferred-name\\":\\"UserSignedupPayloadEmail\\"}},\\"x-parser-schema-id\\":\\"<anonymous-schema-1>\\",\\"x-modelgen-inferred-name\\":\\"UserSignedupPayload\\",\\"$schema\\":\\"https://json-schema.org/draft/2020-12/schema\\"});
     return jsonbinpack.serialize(jsonbinpackEncodedSchema, jsonData);
   }
 
   public static async jsonbinDeserialize(buffer: Buffer): Promise<UserSignedupPayload> {
-    const jsonbinpackEncodedSchema = await jsonbinpack.compileSchema({\\"$schema\\":\\"https://json-schema.org/draft/2020-12/schema\\",\\"type\\":\\"object\\",\\"properties\\":{\\"email\\":{\\"format\\":\\"email\\",\\"type\\":\\"string\\",\\"x-parser-schema-id\\":\\"<anonymous-schema-2>\\",\\"x-modelgen-inferred-name\\":\\"UserSignedupPayloadEmail\\"}},\\"x-parser-schema-id\\":\\"<anonymous-schema-1>\\",\\"x-modelgen-inferred-name\\":\\"UserSignedupPayload\\"});
+    const jsonbinpackEncodedSchema = await jsonbinpack.compileSchema({\\"type\\":\\"object\\",\\"properties\\":{\\"email\\":{\\"format\\":\\"email\\",\\"type\\":\\"string\\",\\"x-parser-schema-id\\":\\"<anonymous-schema-2>\\",\\"x-modelgen-inferred-name\\":\\"UserSignedupPayloadEmail\\"}},\\"x-parser-schema-id\\":\\"<anonymous-schema-1>\\",\\"x-modelgen-inferred-name\\":\\"UserSignedupPayload\\",\\"$schema\\":\\"https://json-schema.org/draft/2020-12/schema\\"});
     const json = jsonbinpack.deserialize(jsonbinpackEncodedSchema, buffer);
     return UserSignedupPayload.unmarshal(json);
   }

--- a/test/processors/AsyncAPIInputProcessor.spec.ts
+++ b/test/processors/AsyncAPIInputProcessor.spec.ts
@@ -252,7 +252,7 @@ describe('AsyncAPIInputProcessor', () => {
         }
       });
       expect(commonInputModel instanceof InputMetaModel).toBeTruthy();
-      expect(Object.keys(commonInputModel.models).length).toBe(2);
+      expect(Object.keys(commonInputModel.models)).toHaveLength(2);
       expect(commonInputModel.models['userSignUpMessageHeaders']).toBeDefined();
       expect(commonInputModel.models['userSignUpMessagePayload']).toBeDefined();
     });
@@ -268,7 +268,7 @@ describe('AsyncAPIInputProcessor', () => {
         }
       );
       expect(commonInputModel instanceof InputMetaModel).toBeTruthy();
-      expect(Object.keys(commonInputModel.models).length).toBe(6);
+      expect(Object.keys(commonInputModel.models)).toHaveLength(6);
       expect(commonInputModel.models['userSignedUpPayload']).toBeDefined();
       expect(commonInputModel.models['userSignedUpHeaders']).toBeDefined();
       expect(

--- a/test/processors/AsyncAPIInputProcessor.spec.ts
+++ b/test/processors/AsyncAPIInputProcessor.spec.ts
@@ -36,6 +36,17 @@ const multipleMessagesInOperation = fs.readFileSync(
   ),
   'utf8'
 );
+const messageWithHeaders = fs.readFileSync(
+  path.resolve(__dirname, './AsyncAPIInputProcessor/message_with_headers.json'),
+  'utf8'
+);
+const oneofMessageWithHeaders = fs.readFileSync(
+  path.resolve(
+    __dirname,
+    './AsyncAPIInputProcessor/oneof_message_with_headers.json'
+  ),
+  'utf8'
+);
 const ymlFileURI = `file://${path.resolve(
   __dirname,
   './AsyncAPIInputProcessor/testasyncapi.yml'
@@ -231,6 +242,47 @@ describe('AsyncAPIInputProcessor', () => {
       expect(commonInputModel.models['workers']).toBeDefined();
       // Snapshot the model names
       expect(Object.keys(commonInputModel.models).sort()).toMatchSnapshot();
+    });
+
+    test('should be able to process operation with message headers when includeMessageHeaders is true', async () => {
+      const processor = new AsyncAPIInputProcessor();
+      const commonInputModel = await processor.process(messageWithHeaders, {
+        asyncapi: {
+          includeMessageHeaders: true
+        }
+      });
+      expect(commonInputModel instanceof InputMetaModel).toBeTruthy();
+      expect(Object.keys(commonInputModel.models).length).toBe(2);
+      expect(commonInputModel.models['userSignUpMessageHeaders']).toBeDefined();
+      expect(commonInputModel.models['userSignUpMessagePayload']).toBeDefined();
+    });
+
+    test('should be able to process operation with multiple messages with headers when includeMessageHeaders is true', async () => {
+      const processor = new AsyncAPIInputProcessor();
+      const commonInputModel = await processor.process(
+        oneofMessageWithHeaders,
+        {
+          asyncapi: {
+            includeMessageHeaders: true
+          }
+        }
+      );
+      expect(commonInputModel instanceof InputMetaModel).toBeTruthy();
+      expect(Object.keys(commonInputModel.models).length).toBe(6);
+      expect(commonInputModel.models['userSignedUpPayload']).toBeDefined();
+      expect(commonInputModel.models['userSignedUpHeaders']).toBeDefined();
+      expect(
+        commonInputModel.models['userSignUpMessageV1Headers']
+      ).toBeDefined();
+      expect(
+        commonInputModel.models['userSignUpMessageV1Payload']
+      ).toBeDefined();
+      expect(
+        commonInputModel.models['userSignUpMessageV2Headers']
+      ).toBeDefined();
+      expect(
+        commonInputModel.models['userSignUpMessageV2Payload']
+      ).toBeDefined();
     });
 
     test('should derive meaningful names from channel paths for inline payloads (v2)', async () => {

--- a/test/processors/AsyncAPIInputProcessor.spec.ts
+++ b/test/processors/AsyncAPIInputProcessor.spec.ts
@@ -1536,18 +1536,6 @@ describe('AsyncAPIInputProcessor', () => {
       expect(Object.keys(commonInputModel.models).length).toBeGreaterThan(0);
     });
 
-    test('should handle null or undefined schema json in hashSchema', () => {
-      // Test edge cases in hashSchema
-      const hash1 = (AsyncAPIInputProcessor as any).hashSchema(null);
-      expect(hash1).toBe('');
-
-      const hash2 = (AsyncAPIInputProcessor as any).hashSchema(undefined);
-      expect(hash2).toBe('');
-
-      const hash3 = (AsyncAPIInputProcessor as any).hashSchema('not an object');
-      expect(hash3).toBe('');
-    });
-
     test('should handle schema with anonymous title', async () => {
       const doc = {
         asyncapi: '2.0.0',

--- a/test/processors/AsyncAPIInputProcessor/message_with_headers.json
+++ b/test/processors/AsyncAPIInputProcessor/message_with_headers.json
@@ -1,0 +1,47 @@
+{
+  "asyncapi": "3.0.0",
+  "defaultContentType": "application/json",
+  "info": {
+    "title": "Signup service example (internal)",
+    "version": "0.1.0"
+  },
+  "channels": {
+    "userSignedUp": {
+      "address": "/user/signedup",
+      "messages": {
+        "userSignUpMessage": {
+          "headers": {
+            "title": "userSignUpMessageHeaders",
+            "type": "object",
+            "properties": {
+              "x-correlation-id": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "x-correlation-id"
+            ]
+          },
+          "payload": {
+            "title": "userSignUpMessagePayload",
+            "type": "object",
+            "properties": {
+              "email": {
+                "type": "string",
+                "format": "email"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "operations": {
+    "userSignup": {
+      "action": "send",
+      "channel": {
+        "$ref": "#/channels/userSignedUp"
+      }
+    }
+  }
+}

--- a/test/processors/AsyncAPIInputProcessor/oneof_message_with_headers.json
+++ b/test/processors/AsyncAPIInputProcessor/oneof_message_with_headers.json
@@ -1,0 +1,71 @@
+{
+  "asyncapi": "3.0.0",
+  "defaultContentType": "application/json",
+  "info": {
+    "title": "Signup service example (internal)",
+    "version": "0.1.0"
+  },
+  "channels": {
+    "userSignedUp": {
+      "address": "/user/signedup",
+      "messages": {
+        "userSignUpMessageV1": {
+          "headers": {
+            "title": "userSignUpMessageV1Headers",
+            "type": "object",
+            "properties": {
+              "x-correlation-id": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "x-correlation-id"
+            ]
+          },
+          "payload": {
+            "title": "userSignUpMessageV1Payload",
+            "type": "object",
+            "properties": {
+              "email": {
+                "type": "string",
+                "format": "email"
+              }
+            }
+          }
+        },
+        "userSignUpMessageV2": {
+          "headers": {
+            "title": "userSignUpMessageV2Headers",
+            "type": "object",
+            "properties": {
+              "x-correlation-id": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "x-correlation-id"
+            ]
+          },
+          "payload": {
+            "title": "userSignUpMessageV2Payload",
+            "type": "object",
+            "properties": {
+              "email": {
+                "type": "string",
+                "format": "email"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "operations": {
+    "userSignup": {
+      "action": "send",
+      "channel": {
+        "$ref": "#/channels/userSignedUp"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Bundles several community contributions together into `next` for simplicity and faster review. Each change is a separate commit crediting the original author via `Co-authored-by`.

## Included

- **fix: replace alterschema with inline schema migration (#2494)** — from #2528 by @armorbreak001. Drops the `alterschema` dependency (broken `@hyperjump/pact` postinstall scripts caused Yarn build failures) in favour of a lightweight inline JSON Schema draft-04/06/07 → 2020-12 migration used by the JsonBinPack preset. The migration helper was also cleaned up to satisfy SonarCloud (reduced cognitive complexity, removed unused constants).
- **fix(interpreter): apply nullable schema property to model isNullable** — from #2527 by @armorbreak001. Adds the `null` type when a source schema (e.g. OpenAPI 3.0) declares `nullable: true`. Uses an `in` type guard to keep the schema union type-safe.
- **feat(typescript): add isolatedModules option** — from #2543 by @chengyixu. Adds an `isolatedModules` TS generator option that emits `export type { }` / `import type { }` for type-only constructs under ESM (required by `isolatedModules: true` — Next.js, SWC, esbuild). Enums stay plain `export { }` as runtime values.
- **feat: add support for AsyncAPI headers** — from #2484 by @matthew-inamdar. Adds an `includeMessageHeaders` AsyncAPI processor option that emits models for message headers alongside payloads, including combined oneOf `<channel>Payload` / `<channel>Headers` schemas for multi-message channels.
- **chore(processor): remove unused hashSchema helper** — removes dead code flagged as declared-but-never-read, plus the test that only exercised it.

## Not included (already present on `next`)

- #2532 — the `convertToInternalSchema` tuple-items recursion guard is already applied (and improved with context).
- #2529 — the `runtime-go-testing.yml` YAML is already correct on `next`.

## Verification

- `tsc` build clean, `eslint` clean on all changed source + test files.
- Tests green: TypeScript generators, interpreter, and processors suites (including the new header / isolatedModules / nullable paths).

Closes #2528
Closes #2527
Closes #2543
Closes #2484

🤖 Generated with [Claude Code](https://claude.com/claude-code)