### PR TITLE
fix: correct isolatedModules type-only detection and schema migration gaps

### DIFF
--- a/src/generators/typescript/TypeScriptDependencyManager.ts
+++ b/src/generators/typescript/TypeScriptDependencyManager.ts
@@ -1,6 +1,11 @@
 import { AbstractDependencyManager } from '../AbstractDependencyManager';
 import { renderJavaScriptDependency } from '../../helpers';
-import { ConstrainedEnumModel, ConstrainedMetaModel } from '../../models';
+import {
+  ConstrainedEnumModel,
+  ConstrainedMetaModel,
+  ConstrainedObjectModel,
+  ConstrainedReferenceModel
+} from '../../models';
 import { TypeScriptExportType, TypeScriptOptions } from './TypeScriptGenerator';
 
 export class TypeScriptDependencyManager extends AbstractDependencyManager {
@@ -33,10 +38,29 @@ export class TypeScriptDependencyManager extends AbstractDependencyManager {
   /**
    * Returns true when the model is a type-only construct (interface, type alias)
    * that requires `export type` / `import type` under `isolatedModules: true`.
-   * Enums are runtime values and must always use the plain export/import form.
+   *
+   * Runtime values must always use the plain export/import form:
+   * - Enums are runtime values.
+   * - Object models rendered as classes (`modelType: 'class'`) are runtime values
+   *   (they are instantiated with `new` and expose static helpers like `unmarshal`).
+   *
+   * Cross-model dependencies arrive wrapped in a `ConstrainedReferenceModel`
+   * (see `getNearestDependencies`), so the reference must be unwrapped before the
+   * underlying model kind can be inspected.
    */
   private isTypeOnlyModel(model: ConstrainedMetaModel): boolean {
-    return !(model instanceof ConstrainedEnumModel);
+    const actualModel =
+      model instanceof ConstrainedReferenceModel ? model.ref : model;
+    if (actualModel instanceof ConstrainedEnumModel) {
+      return false;
+    }
+    if (
+      actualModel instanceof ConstrainedObjectModel &&
+      this.options.modelType === 'class'
+    ) {
+      return false;
+    }
+    return true;
   }
 
   /**

--- a/src/generators/typescript/utils/migrateSchema.ts
+++ b/src/generators/typescript/utils/migrateSchema.ts
@@ -8,7 +8,7 @@
  * - `$schema` URI update
  * - `definitions` → `$defs` + pointer rewrite
  * - `exclusiveMinimum`/`exclusiveMaximum` boolean → numeric form (draft-04)
- * - `items` tuple form → `prefixItems` (draft-04/06)
+ * - `items` tuple form → `prefixItems`, `additionalItems` → `items` (draft-04/06)
  * - Nested `$ref` pointer updates in sub-schemas
  */
 
@@ -16,10 +16,12 @@ const DRAFT_2020_12_SCHEMA = 'https://json-schema.org/draft/2020-12/schema';
 const OBJECT_TYPE = 'object';
 
 // Keys whose values are maps of named sub-schemas (e.g. `properties`).
+// NOTE: `additionalProperties` is intentionally NOT here — it is a single
+// sub-schema (or boolean), not a map of named sub-schemas, and is handled in
+// `migrateChildren`.
 const SCHEMA_MAP_KEYS = [
   'properties',
   'patternProperties',
-  'additionalProperties',
   '$defs',
   'definitions'
 ];
@@ -50,23 +52,43 @@ function renameDefinitions(obj: SchemaObject): void {
   }
 }
 
-// exclusiveMinimum/Maximum as boolean → numeric (draft-04 only)
+// exclusiveMinimum/Maximum as boolean → numeric (draft-04 only).
+// `true` becomes the numeric bound; `false` (the default) is simply dropped, as
+// a boolean value is invalid for these keywords in 2020-12.
 function normalizeExclusiveBounds(obj: SchemaObject): void {
-  if (obj.exclusiveMinimum === true && obj.minimum !== undefined) {
-    obj.exclusiveMinimum = obj.minimum;
-    delete obj.minimum;
+  if (obj.exclusiveMinimum === true) {
+    if (obj.minimum !== undefined) {
+      obj.exclusiveMinimum = obj.minimum;
+      delete obj.minimum;
+    } else {
+      delete obj.exclusiveMinimum;
+    }
+  } else if (obj.exclusiveMinimum === false) {
+    delete obj.exclusiveMinimum;
   }
-  if (obj.exclusiveMaximum === true && obj.maximum !== undefined) {
-    obj.exclusiveMaximum = obj.maximum;
-    delete obj.maximum;
+  if (obj.exclusiveMaximum === true) {
+    if (obj.maximum !== undefined) {
+      obj.exclusiveMaximum = obj.maximum;
+      delete obj.maximum;
+    } else {
+      delete obj.exclusiveMaximum;
+    }
+  } else if (obj.exclusiveMaximum === false) {
+    delete obj.exclusiveMaximum;
   }
 }
 
-// items (tuple) → prefixItems (draft-04/06)
+// items (tuple) → prefixItems, and the companion additionalItems → items
+// (draft-04/06). In 2020-12 `additionalItems` is not a keyword; the schema for
+// extra tuple elements is expressed via `items` alongside `prefixItems`.
 function tupleItemsToPrefixItems(obj: SchemaObject): void {
   if (Array.isArray(obj.items)) {
     obj.prefixItems = obj.items;
     delete obj.items;
+    if (obj.additionalItems !== undefined) {
+      obj.items = obj.additionalItems;
+      delete obj.additionalItems;
+    }
   }
 }
 
@@ -114,6 +136,11 @@ function migrateChildren(obj: SchemaObject): void {
     migrateObject(obj.items);
   }
 
+  // `additionalProperties` is a single sub-schema (or boolean), not a map.
+  if (isSchemaObject(obj.additionalProperties)) {
+    migrateObject(obj.additionalProperties);
+  }
+
   migrateSchemaLists(obj);
 }
 
@@ -145,10 +172,15 @@ export function migrateSchemaTo202012(
 ): SchemaObject {
   // Clone to avoid mutating the input
   const result = JSON.parse(JSON.stringify(schema)) as SchemaObject;
-  const isLegacyDraft = fromVersion === 'draft4' || fromVersion === 'draft6';
+  // draft-04/06/07 all use `definitions` and tuple-form `items`, none of which
+  // are valid 2020-12; the structural migration is a safe no-op for an
+  // already-2020-12 schema, so run it for every recognised legacy draft.
+  const needsMigration =
+    fromVersion === 'draft4' ||
+    fromVersion === 'draft6' ||
+    fromVersion === 'draft7';
 
-  // Apply structural migrations for draft-04 and draft-06
-  if (isLegacyDraft) {
+  if (needsMigration) {
     migrateObject(result);
   }
 
@@ -156,7 +188,7 @@ export function migrateSchemaTo202012(
   result.$schema = DRAFT_2020_12_SCHEMA;
 
   // Rewrite any remaining $ref pointers (covers nested refs in stringified sub-schemas)
-  if (isLegacyDraft) {
+  if (needsMigration) {
     return JSON.parse(
       rewriteRefPointers(JSON.stringify(result))
     ) as SchemaObject;

--- a/src/processors/AsyncAPIInputProcessor.ts
+++ b/src/processors/AsyncAPIInputProcessor.ts
@@ -406,7 +406,10 @@ export class AsyncAPIInputProcessor extends AbstractInputProcessor {
                 )
               );
 
-              if (includeMessageHeaders) {
+              // Only emit a combined headers model when at least one message
+              // actually declared headers; an empty `oneOf` would otherwise
+              // produce a spurious, typeless header model.
+              if (includeMessageHeaders && headersOneOf.length > 0) {
                 addToInputModel(
                   new AsyncAPISchema(
                     {

--- a/test/generators/typescript/TypeScriptDependencyManager.spec.ts
+++ b/test/generators/typescript/TypeScriptDependencyManager.spec.ts
@@ -2,7 +2,9 @@ import { TypeScriptGenerator } from '../../../src/generators';
 import { TypeScriptDependencyManager } from '../../../src/generators/typescript/TypeScriptDependencyManager';
 import {
   ConstrainedEnumModel,
-  ConstrainedObjectModel
+  ConstrainedMetaModel,
+  ConstrainedObjectModel,
+  ConstrainedReferenceModel
 } from '../../../src/models';
 
 describe('TypeScriptDependencyManager', () => {
@@ -39,11 +41,12 @@ describe('TypeScriptDependencyManager', () => {
       );
     });
 
-    test('renders export type for ESM with isolatedModules for interface/object model', () => {
+    test('renders export type for ESM with isolatedModules when modelType is interface', () => {
       const dm = new TypeScriptDependencyManager(
         {
           ...TypeScriptGenerator.defaultOptions,
           moduleSystem: 'ESM',
+          modelType: 'interface',
           isolatedModules: true
         },
         []
@@ -53,11 +56,27 @@ describe('TypeScriptDependencyManager', () => {
       );
     });
 
+    test('renders plain export for object model rendered as class (modelType class) with isolatedModules', () => {
+      const dm = new TypeScriptDependencyManager(
+        {
+          ...TypeScriptGenerator.defaultOptions,
+          moduleSystem: 'ESM',
+          modelType: 'class',
+          isolatedModules: true
+        },
+        []
+      );
+      expect(dm.renderExport(makeObjectModel('MyClass'), 'named')).toEqual(
+        'export { MyClass };'
+      );
+    });
+
     test('renders plain export for ESM with isolatedModules for enum (runtime value)', () => {
       const dm = new TypeScriptDependencyManager(
         {
           ...TypeScriptGenerator.defaultOptions,
           moduleSystem: 'ESM',
+          modelType: 'interface',
           isolatedModules: true
         },
         []
@@ -97,27 +116,67 @@ describe('TypeScriptDependencyManager', () => {
   });
 
   describe('renderCompleteModelDependencies()', () => {
-    const makeObjectModel = (name: string) =>
-      new ConstrainedObjectModel(name, undefined, {}, '', {});
+    // Cross-model dependencies are always wrapped in a ConstrainedReferenceModel
+    // by getNearestDependencies(), so tests exercise the reference-wrapped form
+    // to reflect real generation.
+    const makeObjectRef = (name: string) =>
+      new ConstrainedReferenceModel(
+        name,
+        undefined,
+        {},
+        '',
+        new ConstrainedObjectModel(
+          name,
+          undefined,
+          {},
+          '',
+          {}
+        ) as ConstrainedMetaModel
+      );
 
-    const makeEnumModel = (name: string) =>
-      new ConstrainedEnumModel(name, undefined, {}, '', []);
+    const makeEnumRef = (name: string) =>
+      new ConstrainedReferenceModel(
+        name,
+        undefined,
+        {},
+        '',
+        new ConstrainedEnumModel(
+          name,
+          undefined,
+          {},
+          '',
+          []
+        ) as ConstrainedMetaModel
+      );
 
-    test('renders import type for ESM named with isolatedModules for object model', () => {
+    test('renders import type for ESM named with isolatedModules for interface dependency', () => {
       const dm = new TypeScriptDependencyManager(
         {
           ...TypeScriptGenerator.defaultOptions,
           moduleSystem: 'ESM',
+          modelType: 'interface',
           isolatedModules: true
         },
         []
       );
       expect(
-        dm.renderCompleteModelDependencies(
-          makeObjectModel('OtherModel'),
-          'named'
-        )
+        dm.renderCompleteModelDependencies(makeObjectRef('OtherModel'), 'named')
       ).toEqual("import type {OtherModel} from './OtherModel';");
+    });
+
+    test('renders plain import for object dependency rendered as class (modelType class) with isolatedModules', () => {
+      const dm = new TypeScriptDependencyManager(
+        {
+          ...TypeScriptGenerator.defaultOptions,
+          moduleSystem: 'ESM',
+          modelType: 'class',
+          isolatedModules: true
+        },
+        []
+      );
+      expect(
+        dm.renderCompleteModelDependencies(makeObjectRef('OtherModel'), 'named')
+      ).toEqual("import {OtherModel} from './OtherModel';");
     });
 
     test('renders plain import for ESM named without isolatedModules', () => {
@@ -130,24 +189,22 @@ describe('TypeScriptDependencyManager', () => {
         []
       );
       expect(
-        dm.renderCompleteModelDependencies(
-          makeObjectModel('OtherModel'),
-          'named'
-        )
+        dm.renderCompleteModelDependencies(makeObjectRef('OtherModel'), 'named')
       ).toEqual("import {OtherModel} from './OtherModel';");
     });
 
-    test('renders plain import for enum even with isolatedModules (enum is runtime value)', () => {
+    test('renders plain import for enum dependency even with isolatedModules (enum is runtime value)', () => {
       const dm = new TypeScriptDependencyManager(
         {
           ...TypeScriptGenerator.defaultOptions,
           moduleSystem: 'ESM',
+          modelType: 'interface',
           isolatedModules: true
         },
         []
       );
       expect(
-        dm.renderCompleteModelDependencies(makeEnumModel('MyEnum'), 'named')
+        dm.renderCompleteModelDependencies(makeEnumRef('MyEnum'), 'named')
       ).toEqual("import {MyEnum} from './MyEnum';");
     });
   });

--- a/test/generators/typescript/utils/migrateSchema.spec.ts
+++ b/test/generators/typescript/utils/migrateSchema.spec.ts
@@ -1,0 +1,148 @@
+import { migrateSchemaTo202012 } from '../../../../src/generators/typescript/utils/migrateSchema';
+
+describe('migrateSchemaTo202012', () => {
+  const DRAFT_2020_12 = 'https://json-schema.org/draft/2020-12/schema';
+
+  test('always sets the $schema URI to 2020-12', () => {
+    const result = migrateSchemaTo202012({ type: 'object' }, 'draft7');
+    expect(result.$schema).toEqual(DRAFT_2020_12);
+  });
+
+  test('does not mutate the input schema', () => {
+    const input = { definitions: { Foo: { type: 'string' } } };
+    const clone = JSON.parse(JSON.stringify(input));
+    migrateSchemaTo202012(input, 'draft4');
+    expect(input).toEqual(clone);
+  });
+
+  describe('definitions → $defs', () => {
+    test('renames definitions and rewrites $ref pointers for draft-04', () => {
+      const result = migrateSchemaTo202012(
+        {
+          definitions: { Foo: { type: 'string' } },
+          properties: { foo: { $ref: '#/definitions/Foo' } }
+        },
+        'draft4'
+      );
+      expect(result.$defs).toEqual({ Foo: { type: 'string' } });
+      expect(result.definitions).toBeUndefined();
+      expect((result.properties as any).foo.$ref).toEqual('#/$defs/Foo');
+    });
+
+    test('renames definitions for draft-07 (previously skipped)', () => {
+      const result = migrateSchemaTo202012(
+        {
+          definitions: { Foo: { type: 'string' } },
+          properties: { foo: { $ref: '#/definitions/Foo' } }
+        },
+        'draft7'
+      );
+      expect(result.$defs).toEqual({ Foo: { type: 'string' } });
+      expect(result.definitions).toBeUndefined();
+      expect((result.properties as any).foo.$ref).toEqual('#/$defs/Foo');
+    });
+  });
+
+  describe('exclusiveMinimum / exclusiveMaximum (draft-04 boolean form)', () => {
+    test('converts boolean true to the numeric bound', () => {
+      const result = migrateSchemaTo202012(
+        { type: 'integer', minimum: 5, exclusiveMinimum: true },
+        'draft4'
+      );
+      expect(result.exclusiveMinimum).toEqual(5);
+      expect(result.minimum).toBeUndefined();
+    });
+
+    test('drops boolean false rather than leaving an invalid boolean', () => {
+      const result = migrateSchemaTo202012(
+        {
+          type: 'integer',
+          minimum: 5,
+          exclusiveMinimum: false,
+          maximum: 10,
+          exclusiveMaximum: false
+        },
+        'draft4'
+      );
+      expect(result.exclusiveMinimum).toBeUndefined();
+      expect(result.exclusiveMaximum).toBeUndefined();
+      expect(result.minimum).toEqual(5);
+      expect(result.maximum).toEqual(10);
+    });
+  });
+
+  describe('tuple items', () => {
+    test('converts tuple items to prefixItems for draft-06', () => {
+      const result = migrateSchemaTo202012(
+        {
+          type: 'array',
+          items: [{ type: 'string' }, { type: 'number' }]
+        },
+        'draft6'
+      );
+      expect(result.prefixItems).toEqual([
+        { type: 'string' },
+        { type: 'number' }
+      ]);
+      expect(result.items).toBeUndefined();
+    });
+
+    test('converts companion additionalItems to items', () => {
+      const result = migrateSchemaTo202012(
+        {
+          type: 'array',
+          items: [{ type: 'string' }],
+          additionalItems: false
+        },
+        'draft6'
+      );
+      expect(result.prefixItems).toEqual([{ type: 'string' }]);
+      expect(result.items).toEqual(false);
+      expect(result.additionalItems).toBeUndefined();
+    });
+
+    test('migrates tuple items nested inside additionalProperties', () => {
+      const result = migrateSchemaTo202012(
+        {
+          type: 'object',
+          additionalProperties: {
+            type: 'array',
+            items: [{ type: 'string' }, { type: 'number' }]
+          }
+        },
+        'draft4'
+      );
+      const additional = result.additionalProperties as any;
+      expect(additional.prefixItems).toEqual([
+        { type: 'string' },
+        { type: 'number' }
+      ]);
+      expect(additional.items).toBeUndefined();
+    });
+  });
+
+  test('recurses through oneOf/allOf/anyOf and property sub-schemas', () => {
+    const result = migrateSchemaTo202012(
+      {
+        oneOf: [
+          {
+            type: 'array',
+            items: [{ type: 'string' }]
+          }
+        ],
+        properties: {
+          nested: {
+            definitions: { Bar: { type: 'number' } }
+          }
+        }
+      },
+      'draft4'
+    );
+    expect((result.oneOf as any)[0].prefixItems).toEqual([{ type: 'string' }]);
+    expect((result.oneOf as any)[0].items).toBeUndefined();
+    expect((result.properties as any).nested.$defs).toEqual({
+      Bar: { type: 'number' }
+    });
+    expect((result.properties as any).nested.definitions).toBeUndefined();
+  });
+});

--- a/test/processors/AsyncAPIInputProcessor.spec.ts
+++ b/test/processors/AsyncAPIInputProcessor.spec.ts
@@ -47,6 +47,13 @@ const oneofMessageWithHeaders = fs.readFileSync(
   ),
   'utf8'
 );
+const multipleMessagesNoHeaders = fs.readFileSync(
+  path.resolve(
+    __dirname,
+    './AsyncAPIInputProcessor/multiple_messages_no_headers.json'
+  ),
+  'utf8'
+);
 const ymlFileURI = `file://${path.resolve(
   __dirname,
   './AsyncAPIInputProcessor/testasyncapi.yml'
@@ -279,6 +286,28 @@ describe('AsyncAPIInputProcessor', () => {
       ).toBeDefined();
       expect(
         commonInputModel.models['userSignUpMessageV2Headers']
+      ).toBeDefined();
+      expect(
+        commonInputModel.models['userSignUpMessageV2Payload']
+      ).toBeDefined();
+    });
+
+    test('should not create a combined headers model when no message declares headers and includeMessageHeaders is true', async () => {
+      const processor = new AsyncAPIInputProcessor();
+      const commonInputModel = await processor.process(
+        multipleMessagesNoHeaders,
+        {
+          asyncapi: {
+            includeMessageHeaders: true
+          }
+        }
+      );
+      expect(commonInputModel instanceof InputMetaModel).toBeTruthy();
+      const modelNames = Object.keys(commonInputModel.models);
+      // No spurious `...Headers` model should be produced from an empty oneOf.
+      expect(modelNames.some((name) => name.endsWith('Headers'))).toBe(false);
+      expect(
+        commonInputModel.models['userSignUpMessageV1Payload']
       ).toBeDefined();
       expect(
         commonInputModel.models['userSignUpMessageV2Payload']

--- a/test/processors/AsyncAPIInputProcessor/multiple_messages_no_headers.json
+++ b/test/processors/AsyncAPIInputProcessor/multiple_messages_no_headers.json
@@ -1,0 +1,47 @@
+{
+  "asyncapi": "3.0.0",
+  "defaultContentType": "application/json",
+  "info": {
+    "title": "Signup service example (internal)",
+    "version": "0.1.0"
+  },
+  "channels": {
+    "userSignedUp": {
+      "address": "/user/signedup",
+      "messages": {
+        "userSignUpMessageV1": {
+          "payload": {
+            "title": "userSignUpMessageV1Payload",
+            "type": "object",
+            "properties": {
+              "email": {
+                "type": "string",
+                "format": "email"
+              }
+            }
+          }
+        },
+        "userSignUpMessageV2": {
+          "payload": {
+            "title": "userSignUpMessageV2Payload",
+            "type": "object",
+            "properties": {
+              "email": {
+                "type": "string",
+                "format": "email"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "operations": {
+    "userSignup": {
+      "action": "send",
+      "channel": {
+        "$ref": "#/channels/userSignedUp"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Follow-up correctness fixes on top of the community bundle (#2598: `isolatedModules`, AsyncAPI headers, jsonbinpack inline schema migration) now merged into `next`. Each area below was found to misbehave under real generation / default configuration and is covered by tests.

## `isolatedModules` (`TypeScriptDependencyManager`)

- **Unwrap `ConstrainedReferenceModel` before inspecting the model kind.** Cross-model dependencies always arrive wrapped in a reference (via `getNearestDependencies`), so the enum special-case was dead on the import path — enum dependencies were emitted as `import type { X }`, which breaks runtime enum usage (`X.Member`) *even in the intended `interface` mode*.
- **Treat object models as runtime values when `modelType: 'class'` (the default).** Classes are instantiated with `new` and expose static `unmarshal`/`fromJson`, so they must use plain `export {}` / `import {}`. The previous logic emitted `export type`/`import type` for classes, erasing the binding (TS1361) — i.e. `isolatedModules: true` produced broken output under the default `modelType`.

## AsyncAPI headers (`AsyncAPIInputProcessor`)

- Only emit the combined `${channelId}Headers` model when at least one message actually declares headers. With `includeMessageHeaders: true` on a multi-message channel where no message had headers, an empty `oneOf` produced a spurious, typeless header model.

## Inline schema migration (`migrateSchema`)

- **Run structural migration for draft-07** — previously skipped despite the docstring, and it's the default branch of `getInputSchema` for schema-less inputs, so `definitions`/tuple-`items`/`$ref`s were left un-migrated and handed to `jsonbinpack` as invalid 2020-12.
- **Reclassify `additionalProperties`** as a single sub-schema instead of a named-schema map, so schemas nested under it are migrated.
- **Drop boolean `exclusiveMinimum/Maximum: false`** (invalid in 2020-12) and **rename companion `additionalItems` → `items`** alongside `prefixItems`.

## Tests

Written/updated first:
- `TypeScriptDependencyManager.spec.ts` now exercises **reference-wrapped** models (as real generation produces) and both `class` vs `interface` modes — the prior tests passed raw models, which masked the import-path bug.
- New `test/generators/typescript/utils/migrateSchema.spec.ts` unit suite (draft-07, `additionalProperties`, exclusive bounds, `additionalItems`, nested recursion).
- New `multiple_messages_no_headers.json` fixture + test asserting no spurious `…Headers` model.

`tsc --noEmit` clean, eslint clean on all touched files; TypeScript generator, processor, and interpreter suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)