### PR TITLE
fix: respect mapType in marshal/unmarshal serialization

### DIFF
--- a/src/generators/typescript/presets/utils/MarshalFunction.ts
+++ b/src/generators/typescript/presets/utils/MarshalFunction.ts
@@ -1,4 +1,5 @@
 import { ClassRenderer } from '../../renderers/ClassRenderer';
+import { TypeScriptOptions } from '../../TypeScriptGenerator';
 import {
   getDictionary,
   getNormalProperties,
@@ -15,6 +16,19 @@ import {
   ConstrainedTupleModel,
   ConstrainedUnionModel
 } from '../../../../models';
+
+type MapType = TypeScriptOptions['mapType'];
+
+/**
+ * Build the expression that iterates a dictionary's entries. Only `mapType: 'map'`
+ * produces a runtime `Map` (with `.entries()`); `record`/`indexedObject` produce a
+ * plain object, which must be iterated with `Object.entries()`.
+ */
+function dictionaryEntries(accessor: string, mapType: MapType): string {
+  return mapType === 'map'
+    ? `${accessor}.entries()`
+    : `Object.entries(${accessor})`;
+}
 
 /**
  * Build the guard expression that wraps a property's serialization.
@@ -184,7 +198,8 @@ function renderToJsonUnion(
  * Render toJson logic for dictionary types (additionalProperties)
  */
 function renderToJsonDictionary(
-  properties: Record<string, ConstrainedObjectPropertyModel>
+  properties: Record<string, ConstrainedObjectPropertyModel>,
+  mapType: MapType
 ): string[] {
   const unwrapDictionaryProperties = getDictionary(properties);
   const originalPropertyNames = getOriginalPropertyList(properties);
@@ -193,14 +208,14 @@ function renderToJsonDictionary(
     const dictValue = (propModel.property as ConstrainedDictionaryModel).value;
     const valueConversion = dictionaryValueToJson(dictValue);
     // A nullable dictionary (e.g. a root `type: ['null', 'object']`) is a
-    // `Map | null`; `.entries()` is dereferenced inside the guard so `null`
-    // must be narrowed away too.
+    // `Map | null` (or `object | null`); the value is dereferenced inside the
+    // guard so `null` must be narrowed away too.
     const dictionaryGuard = definedGuard(
       `this.${prop}`,
       propModel.property.options?.isNullable === true
     );
     return `if(${dictionaryGuard}) {
-  for (const [key, value] of this.${prop}.entries()) {
+  for (const [key, value] of ${dictionaryEntries(`this.${prop}`, mapType)}) {
     //Only unwrap those that are not already a property in the JSON object
     if([${originalPropertyNames.map((v) => `"${v}"`).join(',')}].includes(String(key))) continue;
     json[key] = ${valueConversion};
@@ -217,11 +232,12 @@ function renderToJsonDictionary(
 function renderToJsonDictionaryProperty(
   modelInstanceVariable: string,
   unconstrainedProperty: string,
-  dictionaryModel: ConstrainedDictionaryModel
+  dictionaryModel: ConstrainedDictionaryModel,
+  mapType: MapType
 ): string {
   const valueConversion = dictionaryValueToJson(dictionaryModel.value);
   return `const serializedMap: Record<string, unknown> = {};
-  for (const [key, value] of ${modelInstanceVariable}.entries()) {
+  for (const [key, value] of ${dictionaryEntries(modelInstanceVariable, mapType)}) {
     serializedMap[key] = ${valueConversion};
   }
   json["${unconstrainedProperty}"] = serializedMap;`;
@@ -231,7 +247,8 @@ function renderToJsonDictionaryProperty(
  * Render toJson code for all normal properties (not dictionaries with unwrap)
  */
 function renderToJsonNormalProperties(
-  properties: Record<string, ConstrainedObjectPropertyModel>
+  properties: Record<string, ConstrainedObjectPropertyModel>,
+  mapType: MapType
 ): string[] {
   const normalProperties = getNormalProperties(properties);
 
@@ -270,7 +287,8 @@ function renderToJsonNormalProperties(
       toJsonCode = renderToJsonDictionaryProperty(
         modelInstanceVariable,
         propModel.unconstrainedPropertyName,
-        propModel.property
+        propModel.property,
+        mapType
       );
     } else {
       const propToJsonCode = renderToJsonProperty(
@@ -300,8 +318,15 @@ export function renderToJson({
   model: ConstrainedObjectModel;
 }): string {
   const properties = model.properties || {};
-  const toJsonNormalProperties = renderToJsonNormalProperties(properties);
-  const toJsonDictionaryProperties = renderToJsonDictionary(properties);
+  const mapType = renderer.generator.options.mapType;
+  const toJsonNormalProperties = renderToJsonNormalProperties(
+    properties,
+    mapType
+  );
+  const toJsonDictionaryProperties = renderToJsonDictionary(
+    properties,
+    mapType
+  );
 
   return `public toJson(): Record<string, unknown> {
   const json: Record<string, unknown> = {};

--- a/src/generators/typescript/presets/utils/UnmarshalFunction.ts
+++ b/src/generators/typescript/presets/utils/UnmarshalFunction.ts
@@ -1,4 +1,5 @@
 import { ClassRenderer } from '../../renderers/ClassRenderer';
+import { TypeScriptOptions } from '../../TypeScriptGenerator';
 import { getDictionary, getNormalProperties } from '../../../../helpers';
 import {
   ConstrainedArrayModel,
@@ -11,6 +12,8 @@ import {
   ConstrainedStringModel,
   ConstrainedUnionModel
 } from '../../../../models';
+
+type MapType = TypeScriptOptions['mapType'];
 
 /**
  * The `== null` fallback value is only emitted when the declared type can hold
@@ -67,13 +70,22 @@ function withNullFallback(
  */
 function renderDictionaryFromJson(
   modelInstanceVariable: string,
-  dictionaryModel: ConstrainedDictionaryModel
+  dictionaryModel: ConstrainedDictionaryModel,
+  mapType: MapType
 ): string {
   const valueModel = dictionaryModel.value;
-  if (isModelReference(valueModel)) {
-    return `new Map(Object.entries(${modelInstanceVariable} as Record<string, unknown>).map(([key, value]): [string, ${valueModel.type}] => [key, ${valueModel.type}.fromJson(value as Record<string, unknown>)]))`;
+  if (mapType === 'map') {
+    if (isModelReference(valueModel)) {
+      return `new Map(Object.entries(${modelInstanceVariable} as Record<string, unknown>).map(([key, value]): [string, ${valueModel.type}] => [key, ${valueModel.type}.fromJson(value as Record<string, unknown>)]))`;
+    }
+    return `new Map(Object.entries(${modelInstanceVariable} as Record<string, ${valueModel.type}>))`;
   }
-  return `new Map(Object.entries(${modelInstanceVariable} as Record<string, ${valueModel.type}>))`;
+  // record / indexedObject: the property is a plain object at runtime, matching
+  // the JSON shape. Only nested model references need recursing into.
+  if (isModelReference(valueModel)) {
+    return `Object.fromEntries(Object.entries(${modelInstanceVariable} as Record<string, unknown>).map(([key, value]): [string, ${valueModel.type}] => [key, ${valueModel.type}.fromJson(value as Record<string, unknown>)])) as ${dictionaryModel.type}`;
+  }
+  return `${modelInstanceVariable} as ${dictionaryModel.type}`;
 }
 
 /**
@@ -82,6 +94,7 @@ function renderDictionaryFromJson(
 function renderFromJsonProperty(
   modelInstanceVariable: string,
   model: ConstrainedMetaModel,
+  mapType: MapType,
   isOptional: boolean = false
 ): string {
   const nullFallback = nullFallbackFor(isOptional, model);
@@ -101,7 +114,8 @@ function renderFromJsonProperty(
   if (model instanceof ConstrainedDictionaryModel) {
     const mapExpression = renderDictionaryFromJson(
       modelInstanceVariable,
-      model
+      model,
+      mapType
     );
     return withNullFallback(modelInstanceVariable, nullFallback, mapExpression);
   }
@@ -129,7 +143,8 @@ function renderFromJsonProperty(
  * Render the code for fromJson of regular properties
  */
 function fromJsonRegularProperty(
-  propModel: ConstrainedObjectPropertyModel
+  propModel: ConstrainedObjectPropertyModel,
+  mapType: MapType
 ): string | undefined {
   if (propModel.property.options.const) {
     return undefined;
@@ -140,6 +155,7 @@ function fromJsonRegularProperty(
   const fromJsonCode = renderFromJsonProperty(
     modelInstanceVariable,
     propModel.property,
+    mapType,
     isOptional
   );
   return `if (${modelInstanceVariable} !== undefined) {
@@ -150,7 +166,10 @@ function fromJsonRegularProperty(
 /**
  * Render the code for fromJson of unwrappable dictionary models
  */
-function fromJsonDictionary(model: ConstrainedObjectModel): string {
+function fromJsonDictionary(
+  model: ConstrainedObjectModel,
+  mapType: MapType
+): string {
   const setDictionaryProperties: string[] = [];
   const fromJsonDictionaryProperties: string[] = [];
   const properties = model.properties || {};
@@ -164,12 +183,21 @@ function fromJsonDictionary(model: ConstrainedObjectModel): string {
     const modelInstanceVariable = 'value';
     const fromJsonCode = renderFromJsonProperty(
       modelInstanceVariable,
-      (propModel.property as ConstrainedDictionaryModel).value
+      (propModel.property as ConstrainedDictionaryModel).value,
+      mapType
     );
-    setDictionaryProperties.push(`instance.${prop} = new Map();`);
-    fromJsonDictionaryProperties.push(
-      `instance.${prop}.set(key, ${fromJsonCode});`
-    );
+    if (mapType === 'map') {
+      setDictionaryProperties.push(`instance.${prop} = new Map();`);
+      fromJsonDictionaryProperties.push(
+        `instance.${prop}.set(key, ${fromJsonCode});`
+      );
+    } else {
+      // record / indexedObject: the dictionary is a plain object at runtime.
+      setDictionaryProperties.push(`instance.${prop} = {};`);
+      fromJsonDictionaryProperties.push(
+        `instance.${prop}[key] = ${fromJsonCode};`
+      );
+    }
   }
 
   const corePropertyKeys = originalPropertyNames
@@ -196,11 +224,12 @@ export function renderFromJson({
   model: ConstrainedObjectModel;
 }): string {
   const properties = model.properties || {};
+  const mapType = renderer.generator.options.mapType;
   const normalProperties = getNormalProperties(properties);
   const fromJsonNormalProperties = normalProperties.map(([, propModel]) =>
-    fromJsonRegularProperty(propModel)
+    fromJsonRegularProperty(propModel, mapType)
   );
-  const fromJsonDictionaryCode = fromJsonDictionary(model);
+  const fromJsonDictionaryCode = fromJsonDictionary(model, mapType);
 
   return `public static fromJson(obj: Record<string, unknown>): ${model.type} {
   const instance = new ${model.type}({} as any);

--- a/test/generators/typescript/preset/MarshallingPreset.spec.ts
+++ b/test/generators/typescript/preset/MarshallingPreset.spec.ts
@@ -595,4 +595,75 @@ describe('Marshalling preset', () => {
       expect(result).not.toContain('this.nullableScalar !== null');
     });
   });
+
+  describe('mapType serialization', () => {
+    // A normal (non-unwrap) dictionary property `tags` plus a top-level
+    // `additionalProperties` unwrap dictionary. Both must serialize according
+    // to the configured `mapType`, not always as a `Map`.
+    const mapDoc = {
+      $id: 'MapTypeTest',
+      type: 'object',
+      properties: {
+        tags: { type: 'object', additionalProperties: { type: 'string' } }
+      },
+      additionalProperties: { type: 'number' }
+    };
+
+    async function generateMap(
+      mapType: 'map' | 'record' | 'indexedObject'
+    ): Promise<string> {
+      const generator = new TypeScriptGenerator({
+        mapType,
+        presets: [{ preset: TS_COMMON_PRESET, options: { marshalling: true } }]
+      });
+      const models = await generator.generate(mapDoc);
+      return models[0].result;
+    }
+
+    test('mapType "map" iterates with .entries() and rebuilds with new Map()', async () => {
+      const result = await generateMap('map');
+
+      // Normal dictionary property
+      expect(result).toContain('for (const [key, value] of this.tags.entries())');
+      expect(result).toContain('new Map(Object.entries(obj["tags"]');
+      // Unwrap additionalProperties
+      expect(result).toContain(
+        'for (const [key, value] of this.additionalProperties.entries())'
+      );
+      expect(result).toContain('instance.additionalProperties = new Map();');
+      expect(result).toContain('instance.additionalProperties.set(key,');
+    });
+
+    test('mapType "record" iterates with Object.entries() and rebuilds as a plain object', async () => {
+      const result = await generateMap('record');
+
+      // No Map usage anywhere in the serializer.
+      expect(result).not.toContain('.entries()');
+      expect(result).not.toContain('new Map(');
+
+      // Normal dictionary property
+      expect(result).toContain(
+        'for (const [key, value] of Object.entries(this.tags))'
+      );
+      expect(result).toContain('obj["tags"] as Record<string, string>');
+      // Unwrap additionalProperties
+      expect(result).toContain(
+        'for (const [key, value] of Object.entries(this.additionalProperties))'
+      );
+      expect(result).toContain('instance.additionalProperties = {};');
+      expect(result).toContain('instance.additionalProperties[key] =');
+    });
+
+    test('mapType "indexedObject" behaves like a plain object', async () => {
+      const result = await generateMap('indexedObject');
+
+      expect(result).not.toContain('.entries()');
+      expect(result).not.toContain('new Map(');
+      expect(result).toContain(
+        'for (const [key, value] of Object.entries(this.additionalProperties))'
+      );
+      expect(result).toContain('instance.additionalProperties = {};');
+      expect(result).toContain('obj["tags"] as { [name: string]: string }');
+    });
+  });
 });

--- a/test/runtime/runtime-typescript.ts
+++ b/test/runtime/runtime-typescript.ts
@@ -55,6 +55,32 @@ async function generateMarshalling() {
   );
 }
 
+async function generateMarshallingMapType(
+  mapType: 'record' | 'indexedObject',
+  outDir: string
+) {
+  const generator = new TypeScriptFileGenerator({
+    mapType,
+    presets: [
+      {
+        preset: TS_COMMON_PRESET,
+        options: {
+          marshalling: true
+        }
+      }
+    ]
+  });
+  await generator.generateToFiles(
+    input,
+    path.resolve(
+      // eslint-disable-next-line no-undef
+      __dirname,
+      outDir
+    ),
+    { exportType: 'named' }
+  );
+}
+
 async function generateJsonBinPack() {
   const generator = new TypeScriptFileGenerator({
     presets: [
@@ -84,6 +110,8 @@ Promise.all(
     generateNamedExport(),
     generateDefaultExport(),
     generateMarshalling(),
+    generateMarshallingMapType('record', './runtime-typescript/src/marshalling-record'),
+    generateMarshallingMapType('indexedObject', './runtime-typescript/src/marshalling-indexed'),
     generateJsonBinPack()
   ]
 )

--- a/test/runtime/runtime-typescript/test/MarshallingIndexed.spec.ts
+++ b/test/runtime/runtime-typescript/test/MarshallingIndexed.spec.ts
@@ -1,0 +1,68 @@
+import {TestObject} from '../src/marshalling-indexed/TestObject';
+import {ObjectType} from '../src/marshalling-indexed/ObjectType';
+import {ArrayItem} from '../src/marshalling-indexed/ArrayItem';
+
+// With `mapType: 'indexedObject'` dictionaries are plain objects at runtime
+// (declared as `{ [name: string]: T }`), not `Map`s. The serializer must
+// iterate with `Object.entries()` and rebuild as plain objects instead of
+// `Map`/`.entries()`/`new Map()` — otherwise marshal throws ("... is not a
+// function") and unmarshal produces the wrong runtime type.
+describe('Marshalling with mapType: indexedObject', () => {
+  const testObject = new TestObject({
+    stringType: 'test',
+    numberType: 1,
+    booleanType: true,
+    requiredDate: new Date('2024-03-10T08:00:00Z'),
+    requiredNullableDate: new Date('2023-06-15T12:00:00Z'),
+    requiredRefArray: [new ArrayItem({itemName: 'item1'})],
+    objectType: new ObjectType({test: 'test'}),
+    // A normal (non-unwrap) dictionary property: a plain object, not a Map.
+    dictionaryType: {a: 'one', b: 'two'},
+    // Unwrapped additionalProperties: also a plain object.
+    additionalProperties: {extra1: 'x', extra2: 'y'},
+  });
+
+  test('constructor accepts plain objects for dictionary + additionalProperties', () => {
+    expect(testObject.dictionaryType).not.toBeInstanceOf(Map);
+    expect(testObject.additionalProperties).not.toBeInstanceOf(Map);
+  });
+
+  test('marshal does not throw on plain-object dictionaries', () => {
+    // The pre-fix code called `.entries()` on a plain object here.
+    expect(() => testObject.marshal()).not.toThrow();
+  });
+
+  test('toJson emits the normal dictionary as a plain object under its key', () => {
+    const json = testObject.toJson();
+    expect(json['dictionary_type']).toEqual({a: 'one', b: 'two'});
+  });
+
+  test('toJson unwraps additionalProperties onto the top-level object', () => {
+    const json = testObject.toJson();
+    expect(json['extra1']).toBe('x');
+    expect(json['extra2']).toBe('y');
+    // Unwrapped keys must not leak an `additionalProperties` wrapper key.
+    expect(json['additionalProperties']).toBeUndefined();
+  });
+
+  test('fromJson rebuilds the normal dictionary as a plain object, not a Map', () => {
+    const instance = TestObject.fromJson(testObject.toJson());
+    expect(instance.dictionaryType).not.toBeInstanceOf(Map);
+    expect(instance.dictionaryType).toEqual({a: 'one', b: 'two'});
+  });
+
+  test('fromJson collects additionalProperties into a plain object, not a Map', () => {
+    const instance = TestObject.fromJson(testObject.toJson());
+    expect(instance.additionalProperties).not.toBeInstanceOf(Map);
+    expect(instance.additionalProperties?.['extra1']).toBe('x');
+    expect(instance.additionalProperties?.['extra2']).toBe('y');
+  });
+
+  test('round-trip: unmarshal(marshal()) preserves values', () => {
+    const serialized = testObject.marshal();
+    const roundTripped = TestObject.unmarshal(serialized);
+    expect(roundTripped.marshal()).toEqual(serialized);
+    expect(roundTripped.dictionaryType).toEqual({a: 'one', b: 'two'});
+    expect(roundTripped.additionalProperties?.['extra1']).toBe('x');
+  });
+});

--- a/test/runtime/runtime-typescript/test/MarshallingRecord.spec.ts
+++ b/test/runtime/runtime-typescript/test/MarshallingRecord.spec.ts
@@ -1,0 +1,68 @@
+import {TestObject} from '../src/marshalling-record/TestObject';
+import {ObjectType} from '../src/marshalling-record/ObjectType';
+import {ArrayItem} from '../src/marshalling-record/ArrayItem';
+
+// With `mapType: 'record'` (and `indexedObject`) dictionaries are plain objects
+// at runtime, not `Map`s. The serializer must therefore iterate with
+// `Object.entries()` and rebuild as plain objects instead of `Map`/`.entries()`/
+// `new Map()` — otherwise marshal throws ("... is not a function") and unmarshal
+// produces the wrong runtime type.
+describe('Marshalling with mapType: record', () => {
+  const testObject = new TestObject({
+    stringType: 'test',
+    numberType: 1,
+    booleanType: true,
+    requiredDate: new Date('2024-03-10T08:00:00Z'),
+    requiredNullableDate: new Date('2023-06-15T12:00:00Z'),
+    requiredRefArray: [new ArrayItem({itemName: 'item1'})],
+    objectType: new ObjectType({test: 'test'}),
+    // A normal (non-unwrap) dictionary property: a plain object, not a Map.
+    dictionaryType: {a: 'one', b: 'two'},
+    // Unwrapped additionalProperties: also a plain object.
+    additionalProperties: {extra1: 'x', extra2: 'y'},
+  });
+
+  test('constructor accepts plain objects for dictionary + additionalProperties', () => {
+    expect(testObject.dictionaryType).not.toBeInstanceOf(Map);
+    expect(testObject.additionalProperties).not.toBeInstanceOf(Map);
+  });
+
+  test('marshal does not throw on plain-object dictionaries', () => {
+    // The pre-fix code called `.entries()` on a plain object here.
+    expect(() => testObject.marshal()).not.toThrow();
+  });
+
+  test('toJson emits the normal dictionary as a plain object under its key', () => {
+    const json = testObject.toJson();
+    expect(json['dictionary_type']).toEqual({a: 'one', b: 'two'});
+  });
+
+  test('toJson unwraps additionalProperties onto the top-level object', () => {
+    const json = testObject.toJson();
+    expect(json['extra1']).toBe('x');
+    expect(json['extra2']).toBe('y');
+    // Unwrapped keys must not leak an `additionalProperties` wrapper key.
+    expect(json['additionalProperties']).toBeUndefined();
+  });
+
+  test('fromJson rebuilds the normal dictionary as a plain object, not a Map', () => {
+    const instance = TestObject.fromJson(testObject.toJson());
+    expect(instance.dictionaryType).not.toBeInstanceOf(Map);
+    expect(instance.dictionaryType).toEqual({a: 'one', b: 'two'});
+  });
+
+  test('fromJson collects additionalProperties into a plain object, not a Map', () => {
+    const instance = TestObject.fromJson(testObject.toJson());
+    expect(instance.additionalProperties).not.toBeInstanceOf(Map);
+    expect(instance.additionalProperties?.['extra1']).toBe('x');
+    expect(instance.additionalProperties?.['extra2']).toBe('y');
+  });
+
+  test('round-trip: unmarshal(marshal()) preserves values', () => {
+    const serialized = testObject.marshal();
+    const roundTripped = TestObject.unmarshal(serialized);
+    expect(roundTripped.marshal()).toEqual(serialized);
+    expect(roundTripped.dictionaryType).toEqual({a: 'one', b: 'two'});
+    expect(roundTripped.additionalProperties?.['extra1']).toBe('x');
+  });
+});


### PR DESCRIPTION
## Description

The TypeScript marshalling preset (`toJson`/`fromJson`) always treated dictionaries — both normal map-typed properties and unwrapped `additionalProperties` — as runtime `Map` instances. It iterated with `.entries()` and rebuilt with `new Map()`/`.set()`, regardless of the configured `mapType`.

When `mapType` is `record` or `indexedObject`, the property is a **plain object**, so the generated code:
- **threw at runtime** — `this.prop.entries()` is not a function on a plain object
- **failed strict type-checking** — `new Map(...)` is not assignable to a `Record<...>` / `{ [name: string]: T }` field

`toJson`/`fromJson` now branch on the configured `mapType`:

| | `map` (unchanged) | `record` / `indexedObject` |
|---|---|---|
| marshal iterate | `x.entries()` | `Object.entries(x)` |
| unmarshal normal dict | `new Map(Object.entries(...))` | plain-object cast, or `Object.fromEntries(...)` for reference values |
| unmarshal additionalProperties | `new Map()` + `.set(k, v)` | `{}` + `x[k] = v` |

The `mapType` is read type-safely via `renderer.generator.options.mapType`, so the preset signatures are unchanged.

## Changes

- `src/generators/typescript/presets/utils/MarshalFunction.ts` — `toJson` respects `mapType`
- `src/generators/typescript/presets/utils/UnmarshalFunction.ts` — `fromJson` respects `mapType`
- `test/generators/typescript/preset/MarshallingPreset.spec.ts` — 3 new tests covering all three map types
- `test/runtime/runtime-typescript.ts` + `test/runtime/runtime-typescript/test/MarshallingRecord.spec.ts` — runtime models generated for `record` and `indexedObject` (strict-typechecked by the harness), plus a round-trip spec proving plain-object dictionaries marshal/unmarshal correctly

## How it's tested

- Library suite: full TypeScript generator tests pass (**147 passed, 48 snapshots unchanged** — default `map` output is byte-for-byte identical)
- Runtime harness: `tsc --noEmit --strict` clean for both new variants; jest round-trip suite passes (**30 passed, 1 skipped**), including the previously-throwing `.entries()` case
- Manual round-trip verified for `record` and `indexedObject`, including reference-valued maps

🤖 Generated with [Claude Code](https://claude.com/claude-code)