### PR TITLE
fix: do not serialize input during processor detection

### DIFF
--- a/src/processors/AvroSchemaInputProcessor.ts
+++ b/src/processors/AvroSchemaInputProcessor.ts
@@ -21,6 +21,21 @@ const avroType = [
   'map'
 ];
 
+/**
+ * Detect an empty object or array without serializing the input.
+ *
+ * `shouldProcess` runs during processor detection on raw, caller-supplied
+ * input, which may be a circular object graph (for example a document that has
+ * already been dereferenced with circular references resolved). `JSON.stringify`
+ * throws on such input, so the emptiness check has to be structural.
+ */
+function isEmptyObjectOrArray(input: any): boolean {
+  if (typeof input !== 'object' || input === null) {
+    return false;
+  }
+  return Object.keys(input).length === 0;
+}
+
 export class AvroSchemaInputProcessor extends AbstractInputProcessor {
   /**
    * Function processing an Avro Schema input
@@ -28,11 +43,10 @@ export class AvroSchemaInputProcessor extends AbstractInputProcessor {
    * @param input
    */
   shouldProcess(input?: any): boolean {
-    if (
-      input === '' ||
-      JSON.stringify(input) === '{}' ||
-      JSON.stringify(input) === '[]'
-    ) {
+    if (input === '' || input === null || input === undefined) {
+      return false;
+    }
+    if (isEmptyObjectOrArray(input)) {
       return false;
     }
     if (!avroType.includes(input.type) || !input.name) {

--- a/test/processors/AvroSchemaInputProcessor.spec.ts
+++ b/test/processors/AvroSchemaInputProcessor.spec.ts
@@ -23,6 +23,23 @@ describe('AvroSchemaInputProcessor', () => {
       expect(processor.shouldProcess([])).toBeFalsy();
     });
 
+    test('should fail correctly for undefined input', () => {
+      expect(processor.shouldProcess(undefined)).toBeFalsy();
+    });
+
+    test('should fail correctly for null input', () => {
+      expect(processor.shouldProcess(null)).toBeFalsy();
+    });
+
+    test('should not throw for circular input', () => {
+      const circular: any = {
+        type: 'object',
+        properties: { children: { type: 'array', items: null } }
+      };
+      circular.properties.children.items = circular;
+      expect(processor.shouldProcess(circular)).toBeFalsy();
+    });
+
     test('should fail if input has no name property', () => {
       expect(
         processor.shouldProcess({ prop: 'hello', type: 'string' })

--- a/test/processors/InputProcessor.spec.ts
+++ b/test/processors/InputProcessor.spec.ts
@@ -204,6 +204,42 @@ describe('InputProcessor', () => {
       expect(defaultInputProcessor.process).not.toHaveBeenCalled();
       expect(defaultInputProcessor.shouldProcess).not.toHaveBeenCalled();
     });
+    test('should be able to route circular input without serializing it', async () => {
+      const {
+        processor,
+        avroSchemaInputProcessor,
+        defaultInputProcessor,
+        openAPIInputProcessor
+      } = getProcessors();
+      // Mirrors an input that has already been dereferenced by the caller, where
+      // a self-referencing $ref has become a real JavaScript object cycle.
+      const inputSchema: any = {
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        type: 'object',
+        properties: {
+          label: { type: 'string' },
+          children: { type: 'array', items: null }
+        }
+      };
+      inputSchema.properties.children.items = inputSchema;
+
+      await processor.process(inputSchema);
+
+      expect(openAPIInputProcessor.shouldProcess).toHaveNthReturnedWith(
+        1,
+        false
+      );
+      expect(avroSchemaInputProcessor.shouldProcess).toHaveNthReturnedWith(
+        1,
+        false
+      );
+      expect(avroSchemaInputProcessor.process).not.toHaveBeenCalled();
+      expect(defaultInputProcessor.process).toHaveBeenNthCalledWith(
+        1,
+        inputSchema,
+        undefined
+      );
+    });
     test('should be able to process AsyncAPI schema input with options', async () => {
       const { processor, asyncInputProcessor, defaultInputProcessor } =
         getProcessors();


### PR DESCRIPTION
## Description

Passing an already-dereferenced recursive schema to any Modelina entry point (`generateCompleteModels`, `generateToFiles`, `InputProcessor.process`) crashes with:

```
TypeError: Converting circular structure to JSON
    at JSON.stringify (<anonymous>)
    at AvroSchemaInputProcessor.shouldProcess (src/processors/AvroSchemaInputProcessor.ts:33:12)
    at InputProcessor.process (src/processors/InputProcessor.ts:57:21)
```

`AvroSchemaInputProcessor.shouldProcess` used `JSON.stringify(input) === '{}'` to test for an empty object/array. Detection runs during `InputProcessor` routing on raw, caller-supplied input, so the crash happens before a processor is even selected. It was the only `shouldProcess` that serialized the whole input rather than reading a discriminator field (`input.openapi`, `input.asyncapi`, …).

Circular inputs are ordinary here: dereferencing a recursive `$ref` with `circular: true` — the `json-schema-ref-parser` default, and what `OpenAPIInputProcessor` itself passes at `OpenAPIInputProcessor.ts:35` — produces real JavaScript object cycles. Every stage after routing is already cycle-safe by design (identity-keyed caches in `Interpreter`, `CommonModelToMetaModel`, `MetaModelToConstrained`, `ConstrainedTypes`, and hand-rolled deep copies in `OpenapiV3Schema`/`AsyncapiV2Schema` specifically instead of JSON round-trips). Routing was the one gap.

## Changes

- Replace the serialization-based emptiness check with a structural `isEmptyObjectOrArray` helper.
- Guard `null`/`undefined`, which would otherwise `TypeError` on the following `input.type` access.

Behaviour is unchanged for every non-circular input: `{}`/`[]` still return false, and objects whose values are all `undefined` still fall through to the `avroType`/`name` check and return false there.

## Tests

- `test/processors/AvroSchemaInputProcessor.spec.ts` — `undefined`, `null`, and circular input return falsy without throwing.
- `test/processors/InputProcessor.spec.ts` — a circular schema routes past `openapi`/`avro` detection to the default JSON Schema processor.

Full library suite passes (161 suites / 1656 tests / 317 snapshots); `tsc --noEmit` and `eslint` clean.

## Related issue(s)

Fixes the **OpenAPI** half of https://github.com/the-codegen-project/cli/issues/447.

That issue reports recursive `$ref` breaking generation for both OpenAPI and AsyncAPI input. Modelina's own `OpenAPIInputProcessor` and `AsyncAPIInputProcessor` handle those documents; the failures occur on the path where a caller dereferences the document itself and hands Modelina a single extracted payload sub-schema.

Verified end-to-end against the reporter's OpenAPI document with the real CLI. Before this change: `Converting circular structure to JSON`. After: generation succeeds with the expected self-referencing model.

```ts
interface GetNodeResponse_200Interface {
  label: string
  children?: Node[]
}
```

**The AsyncAPI half of that issue is a separate defect and is *not* fixed here.** Instrumenting the CLI shows the payload it hands Modelina there retains an unresolved pointer out of its own fragment:

```json
"children": { "type": "array", "items": { "$ref": "#/components/schemas/Node" } }
```

`processDraft7` → `dereferenceInputs` then fails with `Missing $ref pointer "#/components/schemas/Node". Token "components" does not exist.`, since the extracted root has no `components`. That is unresolvable from inside Modelina — the pointer's target was left behind with the document — so it needs handling on the caller side.