### PR TITLE
fix: keep self-referencing schemas as a single model

### DIFF
--- a/src/processors/JsonSchemaInputProcessor.ts
+++ b/src/processors/JsonSchemaInputProcessor.ts
@@ -105,7 +105,7 @@ export class JsonSchemaInputProcessor extends AbstractInputProcessor {
     input = JsonSchemaInputProcessor.reflectSchemaNames(
       input,
       {},
-      new Set(),
+      new Map(),
       'root',
       true
     );
@@ -135,7 +135,7 @@ export class JsonSchemaInputProcessor extends AbstractInputProcessor {
     input = JsonSchemaInputProcessor.reflectSchemaNames(
       input,
       {},
-      new Set(),
+      new Map(),
       'root',
       true
     );
@@ -165,7 +165,7 @@ export class JsonSchemaInputProcessor extends AbstractInputProcessor {
     input = JsonSchemaInputProcessor.reflectSchemaNames(
       input,
       {},
-      new Set(),
+      new Map(),
       'root',
       true
     );
@@ -263,7 +263,7 @@ export class JsonSchemaInputProcessor extends AbstractInputProcessor {
    *
    * @param schema to process
    * @param namesStack is a aggregator of previous used names
-   * @param seenSchemas is a set of schema already seen and named
+   * @param seenSchemas maps each already seen schema to the named copy made for it
    * @param name to infer
    * @param isRoot indicates if performed schema is a root schema
    */
@@ -277,12 +277,13 @@ export class JsonSchemaInputProcessor extends AbstractInputProcessor {
       | OpenapiV3Schema
       | boolean,
     namesStack: Record<string, number>,
-    seenSchemas: Set<
+    seenSchemas: Map<
       | Draft4Schema
       | Draft6Schema
       | Draft7Schema
       | SwaggerV2Schema
-      | OpenapiV3Schema
+      | OpenapiV3Schema,
+      any
     >,
     name?: string,
     isRoot?: boolean
@@ -291,13 +292,21 @@ export class JsonSchemaInputProcessor extends AbstractInputProcessor {
       return schema;
     }
 
-    // short-circuit circular references
-    if (seenSchemas.has(schema)) {
-      return schema;
+    // Short-circuit circular references by handing back the copy already made
+    // for this schema. Returning the original instead would leave the cycle
+    // pointing at an unnamed object with a different identity, which every
+    // downstream identity cache (Interpreter, OpenapiV3Schema.internalToSchema,
+    // CommonModelToMetaModel) would then treat as a second, distinct schema.
+    const seenSchema = seenSchemas.get(schema);
+    if (seenSchema !== undefined) {
+      return seenSchema;
     }
-    seenSchemas.add(schema);
 
+    const originalSchema = schema;
     schema = { ...schema };
+    // Cache before recursing, so a self-reference reached while naming the
+    // children resolves to this same copy.
+    seenSchemas.set(originalSchema, schema);
 
     if (isRoot) {
       namesStack[String(name)] = 0;

--- a/src/processors/OpenAPIInputProcessor.ts
+++ b/src/processors/OpenAPIInputProcessor.ts
@@ -287,7 +287,7 @@ export class OpenAPIInputProcessor extends AbstractInputProcessor {
     const namedSchema = JsonSchemaInputProcessor.reflectSchemaNames(
       schema,
       {},
-      new Set(),
+      new Map(),
       name,
       true
     );

--- a/src/processors/SwaggerInputProcessor.ts
+++ b/src/processors/SwaggerInputProcessor.ts
@@ -172,7 +172,7 @@ export class SwaggerInputProcessor extends AbstractInputProcessor {
     schema = JsonSchemaInputProcessor.reflectSchemaNames(
       schema,
       {},
-      new Set(),
+      new Map(),
       name,
       true
     );

--- a/test/processors/JsonSchemaInputProcessor.spec.ts
+++ b/test/processors/JsonSchemaInputProcessor.spec.ts
@@ -388,7 +388,7 @@ describe('JsonSchemaInputProcessor', () => {
       const expected = JsonSchemaInputProcessor.reflectSchemaNames(
         schema,
         {},
-        new Set(),
+        new Map(),
         'root',
         true
       ) as any;

--- a/test/processors/OpenAPIInputProcessor.spec.ts
+++ b/test/processors/OpenAPIInputProcessor.spec.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { AnyModel, CommonModel } from '../../src/models';
+import { AnyModel, CommonModel, OpenapiV3Schema } from '../../src/models';
 import { OpenAPIInputProcessor } from '../../src/processors/OpenAPIInputProcessor';
 const basicDoc = JSON.parse(
   fs.readFileSync(
@@ -17,6 +17,15 @@ const noPathsDoc = JSON.parse(
 const circularDoc = JSON.parse(
   fs.readFileSync(
     path.resolve(__dirname, './OpenAPIInputProcessor/references_circular.json'),
+    'utf8'
+  )
+);
+const recursiveDoc = JSON.parse(
+  fs.readFileSync(
+    path.resolve(
+      __dirname,
+      './OpenAPIInputProcessor/references_recursive.json'
+    ),
     'utf8'
   )
 );
@@ -159,6 +168,19 @@ describe('OpenAPIInputProcessor', () => {
       const commonInputModel = await processor.process(circularDoc);
       expect(commonInputModel).toMatchSnapshot();
       expect(processorSpy.mock.calls).toMatchSnapshot();
+    });
+    test('should keep a self-referencing schema as a single schema', async () => {
+      const processor = new OpenAPIInputProcessor();
+      await processor.process(recursiveDoc);
+
+      const rootSchema = processorSpy.mock.results[0].value as OpenapiV3Schema;
+      const children = rootSchema.properties!['children'] as OpenapiV3Schema;
+
+      // The cycle has to close back onto the root schema itself. Naming the
+      // schemas must not introduce a second identity for it, because every
+      // downstream cache (Interpreter, CommonModelToMetaModel) is keyed on
+      // object identity and would emit a duplicate model for it.
+      expect(children.items).toBe(rootSchema);
     });
   });
 });

--- a/test/processors/OpenAPIInputProcessor/references_recursive.json
+++ b/test/processors/OpenAPIInputProcessor/references_recursive.json
@@ -1,0 +1,45 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Recursive",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/nodes": {
+      "get": {
+        "operationId": "getNode",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Node"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Node": {
+        "type": "object",
+        "required": ["label"],
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "children": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Node"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

A recursive `$ref` in an OpenAPI or Swagger document generates **two** structurally identical models instead of one self-referencing model.

For the recursive document from https://github.com/the-codegen-project/cli/issues/447, `TypeScriptFileGenerator` currently emits:

```ts
class NodesGet_200ApplicationJson {
  private _children?: AnonymSchema3[];   // <-- points at a duplicate
}
class AnonymSchema3 {
  private _children?: AnonymSchema3[];
}
```

where AsyncAPI and JSON Schema input each produce a single self-referencing model.

### Cause

`reflectSchemaNames` shallow-copies each schema on first visit (`schema = { ...schema }`) and annotates the copy with `x-modelgen-inferred-name`. Its circular-reference short-circuit, however, returned the *original* object rather than that copy:

```ts
if (seenSchemas.has(schema)) {
  return schema;      // <-- the original, not the named copy
}
seenSchemas.add(schema);
schema = { ...schema };
```

One logical schema therefore ends up with two JavaScript identities: the named copy at the top of the subtree, and the unnamed original wherever the cycle closes. Every downstream cache keys on object identity — `OpenapiV3Schema.internalToSchema`'s `seenSchemas`, `Interpreter.seenSchemas`, `convertToMetaModel`'s `alreadySeenModels` — so the second identity is treated as a distinct schema and gets its own model.

### Why only OpenAPI/Swagger

Ordering. `processDraft4/6/7` run `reflectSchemaNames` **before** `dereferenceInputs`, so the input still holds `$ref` strings, no cycles exist yet, and the short-circuit never fires. `OpenAPIInputProcessor` (`:35`) and `SwaggerInputProcessor` dereference **first** and name afterwards, so they walk an already-circular graph and hit it every time.

## Changes

- `reflectSchemaNames` caches the copy before recursing into children and returns it on revisit — the same "cache before recursing" pattern already used in `OpenapiV3Schema.internalToSchema`, `CommonModelToMetaModel`, and `MetaModelToConstrained`.
- `seenSchemas` changes from `Set<schema>` to `Map<schema, copy>`; all in-repo call sites updated (`JsonSchemaInputProcessor` ×3, `OpenAPIInputProcessor`, `SwaggerInputProcessor`).

Note this is a signature change on the public static `JsonSchemaInputProcessor.reflectSchemaNames`. External callers passing `new Set()` would need `new Map()`.

After the change, the same document produces one model:

```ts
class NodesGet_200ApplicationJson {
  private _children?: NodesGet_200ApplicationJson[];
}
```

## Tests

Added to `test/processors/OpenAPIInputProcessor.spec.ts` (`should keep a self-referencing schema as a single schema`). That spec mocks the `Interpreter` and `convertToMetaModel`, so the assertion is made one level up, on the real output of `convertToInternalSchema`: the `children` array's `items` must **be** the root schema object, not merely equal to it. Fixture: `test/processors/OpenAPIInputProcessor/references_recursive.json`.

Verified the test fails without the fix (`expect(received).toBe(expected)`) and passes with it.

Full library suite: 163 suites / 1679 tests / **318 snapshots, none changed**. `tsc --noEmit` and `eslint` clean.

## Related issue(s)

Follow-up to #2624. That PR fixed the crash from https://github.com/the-codegen-project/cli/issues/447; this addresses the duplicate-model behaviour on Modelina's own OpenAPI/Swagger path, which the issue's "Expected" section describes (`children?: Node[]`, one model — matching openapi-generator, Kiota and @hey-api/openapi-ts).
