### PR TITLE
ci: run runtime tests when shared code changes

### DIFF
--- a/.github/workflows/runtime-cplusplus-testing.yml
+++ b/.github/workflows/runtime-cplusplus-testing.yml
@@ -7,6 +7,18 @@ on:
       - 'src/generators/cplusplus/**'
       - 'test/runtime/runtime-cplusplus/**'
       - 'test/runtime/**cplusplus**'
+      # Shared code — a change to any of these feeds every language generator,
+      # so it can break this language's generated code too.
+      - 'src/generators/*.ts'
+      - 'src/helpers/**'
+      - 'src/interpreter/**'
+      - 'src/models/**'
+      - 'src/processors/**'
+      - 'src/utils/**'
+      - 'src/index.ts'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/runtime-cplusplus-testing.yml'
 
 jobs:
   test:

--- a/.github/workflows/runtime-csharp-testing.yml
+++ b/.github/workflows/runtime-csharp-testing.yml
@@ -7,6 +7,18 @@ on:
       - 'src/generators/csharp/**'
       - 'test/runtime/runtime-csharp/**'
       - 'test/runtime/**csharp**'
+      # Shared code — a change to any of these feeds every language generator,
+      # so it can break this language's generated code too.
+      - 'src/generators/*.ts'
+      - 'src/helpers/**'
+      - 'src/interpreter/**'
+      - 'src/models/**'
+      - 'src/processors/**'
+      - 'src/utils/**'
+      - 'src/index.ts'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/runtime-csharp-testing.yml'
 
 jobs:
   test:

--- a/.github/workflows/runtime-go-testing.yml
+++ b/.github/workflows/runtime-go-testing.yml
@@ -7,6 +7,18 @@ on:
       - 'src/generators/go/**'
       - 'test/runtime/runtime-go/**'
       - 'test/runtime/**go**'
+      # Shared code — a change to any of these feeds every language generator,
+      # so it can break this language's generated code too.
+      - 'src/generators/*.ts'
+      - 'src/helpers/**'
+      - 'src/interpreter/**'
+      - 'src/models/**'
+      - 'src/processors/**'
+      - 'src/utils/**'
+      - 'src/index.ts'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/runtime-go-testing.yml'
 
 jobs:
   test:

--- a/.github/workflows/runtime-java-testing.yml
+++ b/.github/workflows/runtime-java-testing.yml
@@ -7,6 +7,18 @@ on:
       - 'src/generators/java/**'
       - 'test/runtime/runtime-java/**'
       - 'test/runtime/**java**'
+      # Shared code — a change to any of these feeds every language generator,
+      # so it can break this language's generated code too.
+      - 'src/generators/*.ts'
+      - 'src/helpers/**'
+      - 'src/interpreter/**'
+      - 'src/models/**'
+      - 'src/processors/**'
+      - 'src/utils/**'
+      - 'src/index.ts'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/runtime-java-testing.yml'
 
 jobs:
   test:

--- a/.github/workflows/runtime-kotlin-testing.yml
+++ b/.github/workflows/runtime-kotlin-testing.yml
@@ -8,6 +8,18 @@ on:
       - 'src/generators/kotlin/**'
       - 'test/runtime/runtime-kotlin/**'
       - 'test/runtime/**kotlin**'
+      # Shared code — a change to any of these feeds every language generator,
+      # so it can break this language's generated code too.
+      - 'src/generators/*.ts'
+      - 'src/helpers/**'
+      - 'src/interpreter/**'
+      - 'src/models/**'
+      - 'src/processors/**'
+      - 'src/utils/**'
+      - 'src/index.ts'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/runtime-kotlin-testing.yml'
 
 jobs:
   test:

--- a/.github/workflows/runtime-php-testing.yml
+++ b/.github/workflows/runtime-php-testing.yml
@@ -7,6 +7,18 @@ on:
       - 'src/generators/php/**'
       - 'test/runtime/runtime-php/**'
       - 'test/runtime/**php**'
+      # Shared code — a change to any of these feeds every language generator,
+      # so it can break this language's generated code too.
+      - 'src/generators/*.ts'
+      - 'src/helpers/**'
+      - 'src/interpreter/**'
+      - 'src/models/**'
+      - 'src/processors/**'
+      - 'src/utils/**'
+      - 'src/index.ts'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/runtime-php-testing.yml'
 
 jobs:
   runtime-php-test:

--- a/.github/workflows/runtime-python-testing.yml
+++ b/.github/workflows/runtime-python-testing.yml
@@ -7,6 +7,18 @@ on:
     paths:
       - 'src/generators/python/**'
       - 'test/runtime/runtime-python/**'
+      # Shared code — a change to any of these feeds every language generator,
+      # so it can break this language's generated code too.
+      - 'src/generators/*.ts'
+      - 'src/helpers/**'
+      - 'src/interpreter/**'
+      - 'src/models/**'
+      - 'src/processors/**'
+      - 'src/utils/**'
+      - 'src/index.ts'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/runtime-python-testing.yml'
 jobs:
   test:
     name: Runtime testing Python Models

--- a/.github/workflows/runtime-rust-testing.yml
+++ b/.github/workflows/runtime-rust-testing.yml
@@ -7,6 +7,18 @@ on:
       - 'src/generators/rust/**'
       - 'test/runtime/runtime-rust/**'
       - 'test/runtime/**rust**'
+      # Shared code — a change to any of these feeds every language generator,
+      # so it can break this language's generated code too.
+      - 'src/generators/*.ts'
+      - 'src/helpers/**'
+      - 'src/interpreter/**'
+      - 'src/models/**'
+      - 'src/processors/**'
+      - 'src/utils/**'
+      - 'src/index.ts'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/runtime-rust-testing.yml'
 
 jobs:
   test:

--- a/.github/workflows/runtime-scala-testing.yml
+++ b/.github/workflows/runtime-scala-testing.yml
@@ -8,6 +8,18 @@ on:
       - 'src/generators/scala/**'
       - 'test/runtime/runtime-scala/**'
       - 'test/runtime/**scala**'
+      # Shared code — a change to any of these feeds every language generator,
+      # so it can break this language's generated code too.
+      - 'src/generators/*.ts'
+      - 'src/helpers/**'
+      - 'src/interpreter/**'
+      - 'src/models/**'
+      - 'src/processors/**'
+      - 'src/utils/**'
+      - 'src/index.ts'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/runtime-scala-testing.yml'
 
 jobs:
   test:

--- a/.github/workflows/runtime-typescript-testing.yml
+++ b/.github/workflows/runtime-typescript-testing.yml
@@ -5,12 +5,36 @@ on:
       - 'src/generators/typescript/**'
       - 'test/runtime/runtime-typescript/**'
       - 'test/runtime/**typescript**'
+      # Shared code — a change to any of these feeds every language generator,
+      # so it can break this language's generated code too.
+      - 'src/generators/*.ts'
+      - 'src/helpers/**'
+      - 'src/interpreter/**'
+      - 'src/models/**'
+      - 'src/processors/**'
+      - 'src/utils/**'
+      - 'src/index.ts'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/runtime-typescript-testing.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths: 
       - 'src/generators/typescript/**'
       - 'test/runtime/runtime-typescript/**'
       - 'test/runtime/**typescript**'
+      # Shared code — a change to any of these feeds every language generator,
+      # so it can break this language's generated code too.
+      - 'src/generators/*.ts'
+      - 'src/helpers/**'
+      - 'src/interpreter/**'
+      - 'src/models/**'
+      - 'src/processors/**'
+      - 'src/utils/**'
+      - 'src/index.ts'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/runtime-typescript-testing.yml'
 
 jobs:
   test:


### PR DESCRIPTION
## Description

Every `runtime-*-testing.yml` only triggers on:

```yaml
paths:
  - 'src/generators/<lang>/**'
  - 'test/runtime/runtime-<lang>/**'
  - 'test/runtime/**<lang>**'
```

Everything *upstream* of the language generators — `src/processors/`, `src/interpreter/`, `src/models/`, `src/helpers/`, `src/utils/`, the abstract generator/renderer classes — matches no filter. A change to the shared core therefore runs **no runtime tests at all, for any language**.

That core is precisely the code most likely to change generated output across every language at once, so it is the worst possible blind spot. Two recent examples: #2624 and #2626 both changed input processing, and neither triggered a single runtime workflow. `Test NodeJS PR`, `Build` and SonarCloud were the only checks that ran.

## Changes

Add the shared paths to each runtime workflow's `paths` filter (both `push` and `pull_request` where present):

```yaml
- 'src/generators/*.ts'   # AbstractGenerator, AbstractRenderer, …
- 'src/helpers/**'
- 'src/interpreter/**'
- 'src/models/**'
- 'src/processors/**'
- 'src/utils/**'
- 'src/index.ts'
- 'package.json'
- 'package-lock.json'
- '.github/workflows/runtime-<lang>-testing.yml'
```

`src/generators/*.ts` deliberately uses a single `*` so it matches only the top-level abstract classes, not the per-language directories — those stay language-scoped as before. The workflow file itself is included so edits to it are exercised by the job they configure.

All ten workflows were verified to still parse, and each `pull_request.paths` list was checked to contain the new entries.

## Trade-off

This means a PR touching the shared core now triggers all ten runtime workflows (C++, C#, Go, Java, Kotlin, PHP, Python, Rust, Scala, TypeScript) instead of none. Each builds the library and runs that language's toolchain, with a 30-minute timeout.

That is a real increase in CI minutes for core PRs, and it is the maintainers' call whether the coverage is worth it. If it is too much, a narrower variant would be to add only `src/processors/**`, `src/interpreter/**` and `src/models/**` — the parts whose output every generator consumes directly — and leave `helpers`/`utils` out.

Language-scoped PRs are unaffected: a change to only `src/generators/rust/**` still triggers just the Rust workflow.

## Related issue(s)

Follow-up to #2624 and #2626, neither of which ran any runtime tests despite changing code that every generator depends on.