### PR TITLE
fix(python): await defaultSelf in dataclass and attrs presets

### DIFF
--- a/src/generators/python/presets/PythonAttrsPreset.ts
+++ b/src/generators/python/presets/PythonAttrsPreset.ts
@@ -2,8 +2,8 @@ import { PythonPreset } from '../PythonPreset';
 
 export const PYTHON_ATTRS_PRESET: PythonPreset = {
   class: {
-    self({ renderer }) {
-      return `import attr\n\n@attr.s(auto_attribs=True)\n${renderer.defaultSelf()}`;
+    async self({ renderer }) {
+      return `import attr\n\n@attr.s(auto_attribs=True)\n${await renderer.defaultSelf()}`;
     }
   }
 };

--- a/src/generators/python/presets/PythonDataClassPreset.ts
+++ b/src/generators/python/presets/PythonDataClassPreset.ts
@@ -2,8 +2,8 @@ import { PythonPreset } from '../PythonPreset';
 
 export const PYTHON_DATACLASS_PRESET: PythonPreset = {
   class: {
-    self({ renderer }) {
-      return `from dataclasses import dataclass\n\n@dataclass\n${renderer.defaultSelf()}`;
+    async self({ renderer }) {
+      return `from dataclasses import dataclass\n\n@dataclass\n${await renderer.defaultSelf()}`;
     }
   }
 };

--- a/test/generators/python/presets/PythonAttrsPreset.test.ts
+++ b/test/generators/python/presets/PythonAttrsPreset.test.ts
@@ -5,10 +5,14 @@ describe('PythonAttrsPreset', () => {
   test('should generate a class with @attr.s decorator', async () => {
     const generator = new PythonGenerator({ presets: [PYTHON_ATTRS_PRESET] });
     const inputModel = {
-      name: 'User',
+      $id: 'User',
+      type: 'object',
       properties: { name: { type: 'string' }, age: { type: 'integer' } }
     };
     const output = await generator.generate(inputModel);
     expect(output[0].result).toContain('@attr.s(auto_attribs=True)');
+    // Regression: the class body must be rendered, not an unawaited `[object Promise]`
+    expect(output[0].result).not.toContain('[object Promise]');
+    expect(output[0].result).toContain('class User');
   });
 });

--- a/test/generators/python/presets/PythonDataclassPreset.test.ts
+++ b/test/generators/python/presets/PythonDataclassPreset.test.ts
@@ -7,10 +7,14 @@ describe('PythonDataclassPreset', () => {
       presets: [PYTHON_DATACLASS_PRESET]
     });
     const inputModel = {
-      name: 'User',
+      $id: 'User',
+      type: 'object',
       properties: { name: { type: 'string' }, age: { type: 'integer' } }
     };
     const output = await generator.generate(inputModel);
     expect(output[0].result).toContain('@dataclass');
+    // Regression: the class body must be rendered, not an unawaited `[object Promise]`
+    expect(output[0].result).not.toContain('[object Promise]');
+    expect(output[0].result).toContain('class User');
   });
 });


### PR DESCRIPTION
## Description
The `PYTHON_DATACLASS_PRESET` and `PYTHON_ATTRS_PRESET` `self` hooks interpolated the async `renderer.defaultSelf()` into a template literal without awaiting it, so every generated class body was the literal string `[object Promise]`. This makes both hooks `async` and awaits `defaultSelf()`, matching the Pydantic preset.

## Related Issue
Closes #2641

## Checklist
- [x] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [x] Tests have been added or updated to cover the changes.
- [ ] Documentation has been updated to reflect the changes.
- [x] All tests pass successfully locally (`npm run test`).

## Additional Notes
The existing preset tests only asserted the decorator line (which comes from the preset's own string prefix), so the broken body slipped through. I strengthened them to assert the class body renders and is not `[object Promise]`.
