### PR TITLE
fix(csharp): exclude declared properties from Newtonsoft additionalProperties dictionary

### DIFF
--- a/src/generators/csharp/presets/NewtonsoftSerializerPreset.ts
+++ b/src/generators/csharp/presets/NewtonsoftSerializerPreset.ts
@@ -136,7 +136,7 @@ value.${propertyAccessor} = ${toValue};
   const additionalPropertiesCode =
     unwrapDictionaryProps.length !== 0
       ? `var additionalProperties = jo.Properties().Where((prop) => ${nonDictionaryPropCheck.join(
-          ' || '
+          ' && '
         )});
   ${dictionaryInitializers}
 

--- a/test/generators/csharp/presets/NewtonsoftSerializerPreset.spec.ts
+++ b/test/generators/csharp/presets/NewtonsoftSerializerPreset.spec.ts
@@ -43,6 +43,16 @@ describe('Newtonsoft JSON serializer preset', () => {
 
     const outputModels = await generator.generate(doc);
     expect(outputModels).toHaveLength(3);
+    // Regression: the additional-properties filter must exclude ALL declared
+    // properties, so the checks are joined with `&&`. Joining with `||` is
+    // always true for 2+ properties and duplicates declared props into the dictionary.
+    const allResults = outputModels.map((model) => model.result).join('\n');
+    expect(allResults).toContain(
+      'prop.Name != "string prop" && prop.Name != "const string prop"'
+    );
+    expect(allResults).not.toContain(
+      'prop.Name != "string prop" || prop.Name != "const string prop"'
+    );
     expect(outputModels[0].result).toMatchSnapshot();
     expect(outputModels[1].result).toMatchSnapshot();
     expect(outputModels[2].result).toMatchSnapshot();

--- a/test/generators/csharp/presets/__snapshots__/NewtonsoftSerializerPreset.spec.ts.snap
+++ b/test/generators/csharp/presets/__snapshots__/NewtonsoftSerializerPreset.spec.ts.snap
@@ -91,7 +91,7 @@ if(jo[\\"objectProp\\"] != null) {
   value.ObjectProp = jo[\\"objectProp\\"].ToObject<NestedTest?>(serializer);
 }
 
-  var additionalProperties = jo.Properties().Where((prop) => prop.Name != \\"string prop\\" || prop.Name != \\"const string prop\\" || prop.Name != \\"notRequiredStringProp\\" || prop.Name != \\"numberProp\\" || prop.Name != \\"enumProp\\" || prop.Name != \\"objectProp\\");
+  var additionalProperties = jo.Properties().Where((prop) => prop.Name != \\"string prop\\" && prop.Name != \\"const string prop\\" && prop.Name != \\"notRequiredStringProp\\" && prop.Name != \\"numberProp\\" && prop.Name != \\"enumProp\\" && prop.Name != \\"objectProp\\");
   value.AdditionalProperties = new Dictionary<string, dynamic>();
 
   foreach (var additionalProperty in additionalProperties)


### PR DESCRIPTION
## Description
When a model has `additionalProperties`, the generated Newtonsoft `ReadJson` joined its per-declared-property "extra keys" checks with `||`, which is always true for 2+ properties. As a result every declared property was also copied into the `additionalProperties` dictionary on deserialization. This joins with `&&` instead, matching the `WriteJson` side, so a property is treated as additional only when it matches none of the declared names.

## Related Issue
Closes #2643

## Checklist
- [x] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [x] Tests have been added or updated to cover the changes.
- [ ] Documentation has been updated to reflect the changes.
- [x] All tests pass successfully locally (`npm run test`).

## Additional Notes
Updated the Newtonsoft snapshot (the multi-property filter flips from `||` to `&&`) and added an explicit assertion so the regression is covered independently of the snapshot.
