### PR TITLE
feat(cli): add --javaJakarta flag for constraint namespace

### DIFF
--- a/modelina-cli/README.md
+++ b/modelina-cli/README.md
@@ -407,7 +407,7 @@ USAGE
     [--tsExportType default|named] [--tsJsonBinPack] [--tsMarshalling] [--tsExampleInstance] [--tsRawPropertyNames]
     [--csharpAutoImplement] [--csharpNewtonsoft] [--csharpArrayType Array|List] [--csharpHashcode] [--csharpEqual]
     [--csharpSystemJson] [--goIncludeComments] [--goIncludeTags] [--javaIncludeComments] [--javaJackson]
-    [--javaConstraints] [--javaArrayType Array|List] [--pyDantic]
+    [--javaConstraints] [--javaJakarta] [--javaArrayType Array|List] [--pyDantic]
 
 ARGUMENTS
   LANGUAGE  (typescript|csharp|golang|java|javascript|dart|python|rust|kotlin|php|cplusplus|scala) The language you want
@@ -432,6 +432,8 @@ FLAGS
       --javaConstraints           Java specific, generate the models with constraints
       --javaIncludeComments       Java specific, if enabled add comments while generating models.
       --javaJackson               Java specific, generate the models with Jackson serialization support
+      --javaJakarta               Java specific, use the jakarta.validation namespace instead of javax.validation for
+                                  constraints. Only has an effect together with --javaConstraints.
       --namespace=<value>         C#, C++ and PHP specific, define the namespace to use for the generated models. This
                                   is required when language is `csharp`,`c++` or `php`.
       --packageName=<value>       Go, Java and Kotlin specific, define the package to use for the generated models. This

--- a/modelina-cli/src/helpers/java.ts
+++ b/modelina-cli/src/helpers/java.ts
@@ -18,6 +18,11 @@ export const JavaOclifFlags = {
     required: false,
     default: false
   }),
+  javaJakarta: Flags.boolean({
+    description: 'Java specific, use the jakarta.validation namespace instead of javax.validation for constraints. Only has an effect together with --javaConstraints.',
+    required: false,
+    default: false
+  }),
   javaArrayType: Flags.string({
     type: 'option',
     description: 'Java specific, define which type of array needs to be generated.',
@@ -34,7 +39,7 @@ export const JavaOclifFlags = {
  * @returns 
  */
 export function buildJavaGenerator(flags: any): BuilderReturnType {
-  const { packageName, javaIncludeComments, javaJackson, javaConstraints, javaArrayType } = flags;
+  const { packageName, javaIncludeComments, javaJackson, javaConstraints, javaArrayType, javaJakarta } = flags;
   const presets = []
   
   if (packageName === undefined) {
@@ -46,7 +51,13 @@ export function buildJavaGenerator(flags: any): BuilderReturnType {
   });
   if (javaIncludeComments) {presets.push(JAVA_DESCRIPTION_PRESET);}
   if (javaJackson) {presets.push(JAVA_JACKSON_PRESET);}
-  if (javaConstraints) {presets.push(JAVA_CONSTRAINTS_PRESET);}
+  if (javaConstraints) {
+    presets.push({
+      preset: JAVA_CONSTRAINTS_PRESET,
+      options: { useJakarta: javaJakarta }
+    });
+  }
+
   const fileGenerator = new JavaFileGenerator({
     presets,
     collectionType: javaArrayType as 'Array' | 'List'

--- a/modelina-cli/test/helpers/generate.test.ts
+++ b/modelina-cli/test/helpers/generate.test.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { expect } from '@oclif/test';
 import {buildPythonGenerator} from '../../src/helpers/python'
+import {buildJavaGenerator} from '../../src/helpers/java'
 
 const AsyncapiV3Yaml = fs.readFileSync(
   path.resolve(__dirname, '../fixtures/asyncapi_v3.yml'),
@@ -51,6 +52,34 @@ describe('generate models', () => {
       const {fileOptions, fileGenerator} = buildPythonGenerator({packageName: 'test', pyDantic: true});
       expect(fileOptions).to.have.property('packageName','test');
       expect(fileGenerator.options.presets.length).equal(1);
+    });
+  });
+
+  describe('for Java', () => {
+    it('should default to the javax namespace', async () => {
+      const { fileGenerator } = buildJavaGenerator({
+        packageName: 'test',
+        javaArrayType: 'Array',
+        javaConstraints: true
+      });
+      const models = await fileGenerator.generateCompleteModels(AsyncapiV3Yaml, {
+        packageName: 'test'
+      });
+      expect(models[0].result).to.include('javax.validation');
+    });
+
+    it('should properly parse --javaJakarta flag', async () => {
+      const { fileGenerator } = buildJavaGenerator({
+        packageName: 'test',
+        javaArrayType: 'Array',
+        javaConstraints: true,
+        javaJakarta: true
+      });
+      const models = await fileGenerator.generateCompleteModels(AsyncapiV3Yaml, {
+        packageName: 'test'
+      });
+      expect(models[0].result).to.include('jakarta.validation');
+      expect(models[0].result).to.not.include('javax.validation');
     });
   });
 });


### PR DESCRIPTION
## Description
This PR adds a `--javaJakarta` flag to the CLI parameters, which translates to the `useJakarta` property which was added to Modelina with #1807.

## Related Issue
- None

## Checklist
- [x] The code follows the project's coding standards and is properly linted (`npm run lint`).
- [x] Tests have been added or updated to cover the changes.
- [x] Documentation has been updated to reflect the changes.
- [x] All tests pass successfully locally.(`npm run test`).

## Additional Notes
We are using the asyncapi CLI in a Java project to generate Java classes in the build lifecycle. We realized that modelina supported generating validation annotations for both the legacy javax.* namespace and the newer jakarta.* namespace, but we were not able to pass the `useJakarta` flag to the library via the CLI.

One test is failing for me, locally. It seems like raml-dt-schema-parser is no longer defined in `package.json`, but still present in `package-lock.json`. Upon runnint `npm i` on my machine, it is no longer available in the updated package-lock.json and the test fails. I don't think this has something to do with my changes. I don't expect this error to be present in the CI, but heads up that I could not verify this locally. 

```
FAIL examples/asyncapi-raml-schema/index.spec.ts
  ● Should be able to process an AsyncAPI object with RAML schema type › and should log expected output to console

    Input is not an correct AsyncAPI document so it cannot be processed.

      90 |         doc = document as unknown as AsyncAPIDocumentInterface;
      91 |       } else {
    > 92 |         const err = new Error(
         |                     ^
      93 |           'Input is not an correct AsyncAPI document so it cannot be processed.'
      94 |         );
      95 |         (err as any).diagnostics = diagnostics;

      at AsyncAPIInputProcessor.process (src/processors/AsyncAPIInputProcessor.ts:92:21)
      at TypeScriptGenerator.processInput (src/generators/AbstractGenerator.ts:302:49)
      at TypeScriptGenerator.generate (src/generators/AbstractGenerator.ts:268:24)
      at generate (examples/asyncapi-raml-schema/index.ts:34:18)
      at Object.<anonymous> (examples/asyncapi-raml-schema/index.spec.ts:10:5)
      ```
