### PR TITLE
feat(kotlin): render required properties first

### DIFF
--- a/examples/kotlin-generate-jackson/__snapshots__/index.spec.ts.snap
+++ b/examples/kotlin-generate-jackson/__snapshots__/index.spec.ts.snap
@@ -18,7 +18,7 @@ enum class OrderStatus(@get:JsonValue val value: String) {
         @JsonCreator
         fun forValue(value: String): OrderStatus {
             return values().firstOrNull { it.value == value }
-                ?: throw IllegalArgumentException(\\"Unexpected value '$value'\\")
+                ?: throw IllegalArgumentException(\\"Unexpected value '$value' for enum 'OrderStatus'\\")
         }
     }
 }",

--- a/src/generators/kotlin/KotlinConstrainer.ts
+++ b/src/generators/kotlin/KotlinConstrainer.ts
@@ -1,4 +1,9 @@
-import { ConstrainedEnumValueModel } from '../../models';
+import {
+  ConstrainedEnumValueModel,
+  ConstrainedObjectModel,
+  ConstrainedReferenceModel,
+  ConstrainedUnionModel
+} from '../../models';
 import {
   defaultEnumKeyConstraints,
   defaultEnumValueConstraints
@@ -72,11 +77,28 @@ function interpretUnionValueType(types: string[]): string {
   return 'Any';
 }
 
+export function kotlinUnionIncludesBuiltInTypes(
+  model: ConstrainedUnionModel
+): boolean {
+  return !model.union.every(
+    (union) =>
+      union instanceof ConstrainedObjectModel ||
+      (union instanceof ConstrainedReferenceModel &&
+        union.ref instanceof ConstrainedObjectModel)
+  );
+}
+
 export const KotlinDefaultTypeMapping: KotlinTypeMapping = {
   Object({ constrainedModel }): string {
     return constrainedModel.name;
   },
   Reference({ constrainedModel }): string {
+    if (
+      constrainedModel.ref instanceof ConstrainedUnionModel &&
+      kotlinUnionIncludesBuiltInTypes(constrainedModel.ref)
+    ) {
+      return 'Any';
+    }
     return constrainedModel.name;
   },
   Any(): string {
@@ -137,9 +159,10 @@ export const KotlinDefaultTypeMapping: KotlinTypeMapping = {
       ? interpretUnionValueType(uniqueTypes)
       : uniqueTypes[0];
   },
-  Union(): string {
-    // No Unions in Kotlin, use Any for now.
-    return 'Any';
+  Union({ constrainedModel }): string {
+    return kotlinUnionIncludesBuiltInTypes(constrainedModel)
+      ? 'Any'
+      : constrainedModel.name;
   },
   Dictionary({ constrainedModel }): string {
     return `Map<${constrainedModel.key.type}, ${constrainedModel.value.type}>`;

--- a/src/generators/kotlin/KotlinGenerator.ts
+++ b/src/generators/kotlin/KotlinGenerator.ts
@@ -52,6 +52,7 @@ export interface KotlinOptions extends CommonGeneratorOptions<KotlinPreset> {
   typeMapping: TypeMapping<KotlinOptions, KotlinDependencyManager>;
   constraints: Constraints<KotlinOptions>;
   collectionType: 'List' | 'Array';
+  requiredPropertiesFirst: boolean;
 }
 export type KotlinConstantConstraint = ConstantConstraint<KotlinOptions>;
 export type KotlinEnumKeyConstraint = EnumKeyConstraint<KotlinOptions>;
@@ -94,6 +95,7 @@ export class KotlinGenerator extends AbstractGenerator<
     },
     defaultPreset: KOTLIN_DEFAULT_PRESET,
     collectionType: 'List',
+    requiredPropertiesFirst: false,
     typeMapping: KotlinDefaultTypeMapping,
     constraints: KotlinDefaultConstraints
   };

--- a/src/generators/kotlin/KotlinGenerator.ts
+++ b/src/generators/kotlin/KotlinGenerator.ts
@@ -19,12 +19,16 @@ import {
   ConstrainedUnionModel,
   InputMetaModel,
   MetaModel,
-  RenderOutput
+  ObjectModel,
+  ReferenceModel,
+  RenderOutput,
+  UnionModel
 } from '../../models';
 import { IndentationTypes, split, TypeMapping } from '../../helpers';
 import { KotlinPreset, KOTLIN_DEFAULT_PRESET } from './KotlinPreset';
 import { ClassRenderer } from './renderers/ClassRenderer';
 import { EnumRenderer } from './renderers/EnumRenderer';
+import { UnionRenderer } from './renderers/UnionRenderer';
 import { isReservedKotlinKeyword } from './Constants';
 import { Logger } from '../..';
 import {
@@ -38,7 +42,8 @@ import {
 } from '../../helpers/ConstrainHelpers';
 import {
   KotlinDefaultConstraints,
-  KotlinDefaultTypeMapping
+  KotlinDefaultTypeMapping,
+  kotlinUnionIncludesBuiltInTypes
 } from './KotlinConstrainer';
 import { DeepPartial, mergePartialAndDefault } from '../../utils/Partials';
 import { KotlinDependencyManager } from './KotlinDependencyManager';
@@ -130,9 +135,19 @@ export class KotlinGenerator extends AbstractGenerator<
   splitMetaModel(model: MetaModel): MetaModel[] {
     const metaModelsToSplit = {
       splitEnum: true,
-      splitObject: true
+      splitObject: true,
+      splitUnion: true
     };
-    return split(model, metaModelsToSplit);
+    return split(model, metaModelsToSplit).filter(
+      (splitModel) =>
+        !(splitModel instanceof UnionModel) ||
+        splitModel.union.every(
+          (unionModel) =>
+            unionModel instanceof ObjectModel ||
+            (unionModel instanceof ReferenceModel &&
+              unionModel.ref instanceof ObjectModel)
+        )
+    );
   }
 
   constrainToMetaModel(
@@ -178,6 +193,15 @@ export class KotlinGenerator extends AbstractGenerator<
       );
     } else if (args.constrainedModel instanceof ConstrainedEnumModel) {
       return this.renderEnum(
+        args.constrainedModel,
+        args.inputModel,
+        optionsToUse
+      );
+    } else if (
+      args.constrainedModel instanceof ConstrainedUnionModel &&
+      !kotlinUnionIncludesBuiltInTypes(args.constrainedModel)
+    ) {
+      return this.renderUnion(
         args.constrainedModel,
         args.inputModel,
         optionsToUse
@@ -255,6 +279,33 @@ ${outputModel.result}`;
     const dependencyManagerToUse = this.getDependencyManager(optionsToUse);
     const presets = this.getPresets('class');
     const renderer = new ClassRenderer(
+      this.options,
+      this,
+      presets,
+      model,
+      inputModel,
+      dependencyManagerToUse
+    );
+    const result = await renderer.runSelfPreset();
+    return RenderOutput.toRenderOutput({
+      result,
+      renderedName: model.name,
+      dependencies: dependencyManagerToUse.dependencies
+    });
+  }
+
+  async renderUnion(
+    model: ConstrainedUnionModel,
+    inputModel: InputMetaModel,
+    options?: DeepPartial<KotlinOptions>
+  ): Promise<RenderOutput> {
+    const optionsToUse = KotlinGenerator.getKotlinOptions({
+      ...this.options,
+      ...options
+    });
+    const dependencyManagerToUse = this.getDependencyManager(optionsToUse);
+    const presets = this.getPresets('union');
+    const renderer = new UnionRenderer(
       this.options,
       this,
       presets,

--- a/src/generators/kotlin/KotlinPreset.ts
+++ b/src/generators/kotlin/KotlinPreset.ts
@@ -4,7 +4,9 @@ import {
   ClassPreset,
   EnumPreset,
   PresetArgs,
-  ConstrainedEnumModel
+  ConstrainedEnumModel,
+  ConstrainedUnionModel,
+  CommonPreset
 } from '../../models';
 import { KotlinOptions } from './KotlinGenerator';
 import {
@@ -15,6 +17,10 @@ import {
   EnumRenderer,
   KOTLIN_DEFAULT_ENUM_PRESET
 } from './renderers/EnumRenderer';
+import {
+  UnionRenderer,
+  KOTLIN_DEFAULT_UNION_PRESET
+} from './renderers/UnionRenderer';
 
 export type ClassPresetType<O> = ClassPreset<ClassRenderer, O>;
 export interface EnumPresetType<O> extends EnumPreset<EnumRenderer, O> {
@@ -26,12 +32,20 @@ export interface EnumPresetType<O> extends EnumPreset<EnumRenderer, O> {
   ) => Promise<string> | string;
 }
 
+export type UnionPresetType<O> = CommonPreset<
+  UnionRenderer,
+  O,
+  ConstrainedUnionModel
+>;
+
 export type KotlinPreset<O = any> = Preset<{
   class: ClassPresetType<O>;
   enum: EnumPresetType<O>;
+  union: UnionPresetType<O>;
 }>;
 
 export const KOTLIN_DEFAULT_PRESET: KotlinPreset<KotlinOptions> = {
   class: KOTLIN_DEFAULT_CLASS_PRESET,
-  enum: KOTLIN_DEFAULT_ENUM_PRESET
+  enum: KOTLIN_DEFAULT_ENUM_PRESET,
+  union: KOTLIN_DEFAULT_UNION_PRESET
 };

--- a/src/generators/kotlin/constrainer/EnumConstrainer.ts
+++ b/src/generators/kotlin/constrainer/EnumConstrainer.ts
@@ -7,11 +7,36 @@ import {
   NO_RESERVED_KEYWORDS,
   FormatHelpers
 } from '../../../helpers';
+import { Logger } from '../../../utils';
 import { isInvalidKotlinEnumKey } from '../Constants';
 import {
   KotlinEnumKeyConstraint,
   KotlinEnumValueConstraint
 } from '../KotlinGenerator';
+
+/**
+ * Reads the `x-enum-varnames` extension from an enum schema.
+ *
+ * The extension is only honored when it provides exactly one string name for
+ * every enum value, otherwise the generated names are derived from the values.
+ */
+function getEnumVarNames(enumModel: EnumModel): string[] | undefined {
+  const enumVarNames = enumModel.originalInput?.['x-enum-varnames'];
+  if (enumVarNames === undefined) {
+    return undefined;
+  }
+  const isValid =
+    Array.isArray(enumVarNames) &&
+    enumVarNames.length === enumModel.values.length &&
+    enumVarNames.every((enumVarName) => typeof enumVarName === 'string');
+  if (!isValid) {
+    Logger.warn(
+      `Ignoring invalid x-enum-varnames for ${enumModel.name}; expected one string name for every enum value.`
+    );
+    return undefined;
+  }
+  return enumVarNames;
+}
 
 export type ModelEnumKeyConstraints = {
   NO_SPECIAL_CHAR: (value: string) => string;
@@ -50,13 +75,21 @@ export function defaultEnumKeyConstraints(
   const constraints = { ...DefaultEnumKeyConstraints, ...customConstraints };
 
   return ({ enumKey, enumModel, constrainedEnumModel }) => {
-    let constrainedEnumKey = enumKey;
+    const enumValueIndex = enumModel.values.findIndex(
+      (enumValue) => String(enumValue.key) === enumKey
+    );
+    const enumVarName = getEnumVarNames(enumModel)?.at(enumValueIndex);
+    const originalEnumKey =
+      enumValueIndex !== -1 && enumVarName !== undefined
+        ? enumVarName
+        : enumKey;
+    let constrainedEnumKey = originalEnumKey;
     constrainedEnumKey = constraints.NO_SPECIAL_CHAR(constrainedEnumKey);
     constrainedEnumKey = constraints.NO_NUMBER_START_CHAR(constrainedEnumKey);
     constrainedEnumKey = constraints.NO_EMPTY_VALUE(constrainedEnumKey);
     constrainedEnumKey = constraints.NO_RESERVED_KEYWORDS(constrainedEnumKey);
     //If the enum key has been manipulated, lets make sure it don't clash with existing keys
-    if (constrainedEnumKey !== enumKey) {
+    if (constrainedEnumKey !== originalEnumKey) {
       constrainedEnumKey = constraints.NO_DUPLICATE_KEYS(
         constrainedEnumModel,
         enumModel,

--- a/src/generators/kotlin/presets/JacksonPreset.ts
+++ b/src/generators/kotlin/presets/JacksonPreset.ts
@@ -1,33 +1,104 @@
-import { ConstrainedDictionaryModel } from '../../../models';
+import {
+  ConstrainedDictionaryModel,
+  ConstrainedMetaModel,
+  ConstrainedObjectModel,
+  ConstrainedReferenceModel,
+  ConstrainedUnionModel
+} from '../../../models';
+import { shouldRenderInterface } from '../renderers/ClassRenderer';
+import { KotlinRenderer } from '../KotlinRenderer';
 import { KotlinPreset } from '../KotlinPreset';
 
-const JACKSON_ANNOTATION_DEPENDENCY = 'com.fasterxml.jackson.annotation.*';
+const JACKSON_ANNOTATION_PACKAGE = 'com.fasterxml.jackson.annotation';
 
 /**
  * Preset which adds Jackson annotations for JSON serialization and deserialization.
  */
 export const KOTLIN_JACKSON_PRESET: KotlinPreset = {
   class: {
-    self({ renderer, content }) {
-      renderer.dependencyManager.addDependency(JACKSON_ANNOTATION_DEPENDENCY);
+    self({ renderer, model, content }) {
+      const discriminator = discriminatorName(model);
+      if (
+        shouldRenderInterface(model) &&
+        discriminator &&
+        model.options.implementedBy?.length
+      ) {
+        return renderer.renderBlock([
+          renderTypeInfo(renderer, discriminator),
+          renderSubTypes(
+            renderer,
+            model.options.implementedBy,
+            discriminator,
+            discriminatorMapping(model)
+          ),
+          content
+        ]);
+      }
+
+      const typeName = concreteDiscriminatorName(model);
+      if (typeName) {
+        addJacksonDependency(renderer, 'JsonTypeName');
+        return renderer.renderBlock([
+          renderer.renderAnnotation('JsonTypeName', `"${typeName}"`),
+          content
+        ]);
+      }
       return content;
     },
-    property({ renderer, property, content }) {
+    property({ renderer, model, property, content }) {
+      const discriminator = inheritedDiscriminatorName(model);
+      const usesGeneratedTypeId = Boolean(
+        concreteDiscriminatorName(model) ||
+          (shouldRenderInterface(model) && model.options.implementedBy?.length)
+      );
+      if (
+        usesGeneratedTypeId &&
+        property.unconstrainedPropertyName === discriminator
+      ) {
+        addJacksonDependency(renderer, 'JsonProperty');
+        return renderer.renderBlock([
+          renderer.renderAnnotation(
+            'JsonProperty',
+            {
+              value: `"${property.unconstrainedPropertyName}"`,
+              access: 'JsonProperty.Access.WRITE_ONLY'
+            },
+            'get:'
+          ),
+          content
+        ]);
+      }
       const isUnwrappedDictionary =
         property.property instanceof ConstrainedDictionaryModel &&
         property.property.serializationType === 'unwrap';
       if (isUnwrappedDictionary) {
+        addJacksonDependency(renderer, 'JsonAnyGetter');
+        if (shouldRenderInterface(model)) {
+          return renderer.renderBlock([
+            renderer.renderAnnotation('JsonAnyGetter', undefined, 'get:'),
+            content
+          ]);
+        }
+        addJacksonDependency(renderer, 'JsonAnySetter');
         const mutableMapType = property.property.type.replace(
           /^Map</,
           'MutableMap<'
         );
+        const nullableMapType = `${property.property.type}?`;
+        const renderedMapType = content.includes(nullableMapType)
+          ? nullableMapType
+          : property.property.type;
+        const mutableContent = content
+          .replace(renderedMapType, mutableMapType)
+          .replace(' = null', ' = mutableMapOf()');
         return renderer.renderBlock([
           renderer.renderAnnotation('JsonAnyGetter', undefined, 'get:'),
           renderer.renderAnnotation('JsonAnySetter', undefined, 'field:'),
-          `val ${property.propertyName}: ${mutableMapType} = mutableMapOf(),`
+          mutableContent
         ]);
       }
 
+      addJacksonDependency(renderer, 'JsonProperty');
       const annotations = [
         renderer.renderAnnotation(
           'JsonProperty',
@@ -36,6 +107,7 @@ export const KOTLIN_JACKSON_PRESET: KotlinPreset = {
         )
       ];
       if (!property.required) {
+        addJacksonDependency(renderer, 'JsonInclude');
         annotations.push(
           renderer.renderAnnotation(
             'JsonInclude',
@@ -48,28 +120,177 @@ export const KOTLIN_JACKSON_PRESET: KotlinPreset = {
     }
   },
   enum: {
-    self({ renderer, content }) {
-      renderer.dependencyManager.addDependency(JACKSON_ANNOTATION_DEPENDENCY);
+    item({ renderer, content, model, item }) {
+      const defaultEnumValue = model.originalInput?.default;
+      if (item.originalInput === defaultEnumValue) {
+        addJacksonDependency(renderer, 'JsonEnumDefaultValue');
+        return `@JsonEnumDefaultValue ${content}`;
+      }
       return content;
     },
-    item({ content, model, item }) {
-      const defaultEnumValue = model.originalInput?.default;
-      return item.originalInput === defaultEnumValue
-        ? `@JsonEnumDefaultValue ${content}`
-        : content;
-    },
-    value({ content }) {
+    value({ renderer, content }) {
+      addJacksonDependency(renderer, 'JsonValue');
       return `@get:JsonValue ${content}`;
     },
-    fromValue({ model }) {
+    fromValue({ renderer, model }) {
+      addJacksonDependency(renderer, 'JsonCreator');
       return `companion object {
     @JvmStatic
     @JsonCreator
     fun forValue(value: ${model.type}): ${model.name} {
         return values().firstOrNull { it.value == value }
-            ?: throw IllegalArgumentException("Unexpected value '$value'")
+            ?: throw IllegalArgumentException("Unexpected value '$value' for enum '${model.name}'")
     }
 }`;
     }
   }
 };
+
+function addJacksonDependency<ModelType extends ConstrainedMetaModel>(
+  renderer: KotlinRenderer<ModelType>,
+  annotation: string
+): void {
+  renderer.dependencyManager.addDependency(
+    `${JACKSON_ANNOTATION_PACKAGE}.${annotation}`
+  );
+}
+
+function renderTypeInfo<ModelType extends ConstrainedMetaModel>(
+  renderer: KotlinRenderer<ModelType>,
+  discriminator: string
+): string {
+  addJacksonDependency(renderer, 'JsonTypeInfo');
+  return renderer.renderAnnotation('JsonTypeInfo', {
+    use: 'JsonTypeInfo.Id.NAME',
+    include: 'JsonTypeInfo.As.PROPERTY',
+    property: `"${discriminator}"`,
+    visible: 'true'
+  });
+}
+
+function renderSubTypes<ModelType extends ConstrainedMetaModel>(
+  renderer: KotlinRenderer<ModelType>,
+  subTypes: ConstrainedMetaModel[],
+  discriminator: string,
+  mapping: Map<string, string> = new Map()
+): string {
+  addJacksonDependency(renderer, 'JsonSubTypes');
+  const renderedTypes = subTypes
+    .map((subType) => {
+      const model =
+        subType instanceof ConstrainedReferenceModel ? subType.ref : subType;
+      if (!(model instanceof ConstrainedObjectModel)) {
+        return undefined;
+      }
+      const discriminatorValue =
+        mapping.get(model.name) ||
+        discriminatorConst(model, discriminator) ||
+        model.name;
+      return `JsonSubTypes.Type(value = ${model.name}::class, name = "${discriminatorValue}")`;
+    })
+    .filter(Boolean)
+    .join(',\n');
+  return renderer.renderAnnotation('JsonSubTypes', `\n${renderedTypes}\n`);
+}
+
+function discriminatorConst(
+  model: ConstrainedObjectModel,
+  discriminator: string
+): string | undefined {
+  const property = Object.values(model.properties).find(
+    (candidate) => candidate.unconstrainedPropertyName === discriminator
+  );
+  const value = property?.property.options.const?.originalInput;
+  return typeof value === 'string' ? value : undefined;
+}
+
+function inheritedDiscriminatorName(
+  model: ConstrainedObjectModel
+): string | undefined {
+  const ownDiscriminator = discriminatorName(model);
+  if (ownDiscriminator) {
+    return ownDiscriminator;
+  }
+  for (const extended of model.options.extend || []) {
+    const parent =
+      extended instanceof ConstrainedReferenceModel ? extended.ref : extended;
+    if (parent instanceof ConstrainedObjectModel) {
+      const parentDiscriminator = discriminatorName(parent);
+      if (parentDiscriminator) {
+        return parentDiscriminator;
+      }
+    }
+  }
+  return undefined;
+}
+
+function concreteDiscriminatorName(
+  model: ConstrainedObjectModel
+): string | undefined {
+  return extendedDiscriminatorName(model) || unionDiscriminatorName(model);
+}
+
+function extendedDiscriminatorName(
+  model: ConstrainedObjectModel
+): string | undefined {
+  for (const extended of model.options.extend || []) {
+    const parent =
+      extended instanceof ConstrainedReferenceModel ? extended.ref : extended;
+    if (!(parent instanceof ConstrainedObjectModel)) {
+      continue;
+    }
+    const mapping = discriminatorMapping(parent);
+    const discriminator = discriminatorName(parent);
+    const typeName =
+      mapping.get(model.name) ||
+      (discriminator ? discriminatorConst(model, discriminator) : undefined);
+    if (typeName) {
+      return typeName;
+    }
+  }
+  return undefined;
+}
+
+function unionDiscriminatorName(
+  model: ConstrainedObjectModel
+): string | undefined {
+  for (const parent of model.options.parents || []) {
+    if (
+      parent instanceof ConstrainedUnionModel &&
+      parent.options.discriminator
+    ) {
+      return (
+        discriminatorConst(model, parent.options.discriminator.discriminator) ||
+        model.name
+      );
+    }
+  }
+  return undefined;
+}
+
+function discriminatorName(model: ConstrainedObjectModel): string | undefined {
+  const discriminator =
+    model.options.discriminator?.discriminator ||
+    model.originalInput?.discriminator;
+  return typeof discriminator === 'string' ? discriminator : undefined;
+}
+
+function discriminatorMapping(
+  model: ConstrainedObjectModel
+): Map<string, string> {
+  const mapping = model.originalInput?.['x-discriminator-mapping'];
+  if (!mapping || typeof mapping !== 'object' || Array.isArray(mapping)) {
+    return new Map();
+  }
+
+  const result = new Map<string, string>();
+  for (const [wireValue, schemaReference] of Object.entries(mapping)) {
+    if (typeof schemaReference === 'string') {
+      result.set(
+        schemaReference.split('/').pop() || schemaReference,
+        wireValue
+      );
+    }
+  }
+  return result;
+}

--- a/src/generators/kotlin/renderers/ClassRenderer.ts
+++ b/src/generators/kotlin/renderers/ClassRenderer.ts
@@ -44,10 +44,15 @@ ${this.indent(this.renderBlock(content, 2))}
   }
 
   async renderProperties(): Promise<string> {
-    const properties = this.model.properties || {};
+    const properties = Object.values(this.model.properties || {});
+    if (this.options.requiredPropertiesFirst) {
+      properties.sort(
+        (first, second) => Number(second.required) - Number(first.required)
+      );
+    }
     const content: string[] = [];
 
-    for (const property of Object.values(properties)) {
+    for (const property of properties) {
       const rendererProperty = await this.runPropertyPreset(property);
       content.push(rendererProperty);
     }

--- a/src/generators/kotlin/renderers/ClassRenderer.ts
+++ b/src/generators/kotlin/renderers/ClassRenderer.ts
@@ -1,32 +1,46 @@
 import { KotlinRenderer } from '../KotlinRenderer';
 import {
+  ConstrainedMetaModel,
   ConstrainedObjectModel,
-  ConstrainedObjectPropertyModel
+  ConstrainedObjectPropertyModel,
+  ConstrainedReferenceModel,
+  ConstrainedUnionModel
 } from '../../../models';
 import { KotlinOptions } from '../KotlinGenerator';
 import { ClassPresetType } from '../KotlinPreset';
+import { kotlinUnionIncludesBuiltInTypes } from '../KotlinConstrainer';
+import { getSharedPolymorphicBase } from './UnionRenderer';
 
-/**
- * Renderer for Kotlin's `class` type
- *
- * @extends KotlinRenderer
- */
+/** Renderer for Kotlin classes and interfaces. */
 export class ClassRenderer extends KotlinRenderer<ConstrainedObjectModel> {
-  async defaultSelf(hasProperties: boolean): Promise<string> {
-    return hasProperties
-      ? await this.defaultWithProperties()
-      : `class ${this.model.name} {}`;
-  }
+  async defaultSelf(): Promise<string> {
+    const hasProperties = Object.keys(this.model.properties).length > 0;
+    const parents = getParentModels(this.model);
+    const inheritance = parents.length
+      ? ` : ${parents.map((parent) => parent.name).join(', ')}`
+      : '';
 
-  private async defaultWithProperties(): Promise<string> {
+    if (shouldRenderInterface(this.model)) {
+      if (!hasProperties) {
+        return `interface ${this.model.name}${inheritance}`;
+      }
+      const properties = await this.renderProperties();
+      return `interface ${this.model.name}${inheritance} {
+${this.indent(properties)}
+}`;
+    }
+
+    if (!hasProperties) {
+      return `class ${this.model.name}${inheritance}`;
+    }
+
     const content = [
       await this.renderProperties(),
       await this.runAdditionalContentPreset()
     ];
-
     return `data class ${this.model.name}(
 ${this.indent(this.renderBlock(content, 2))}
-)`;
+)${inheritance}`;
   }
 
   async renderProperties(): Promise<string> {
@@ -46,15 +60,110 @@ ${this.indent(this.renderBlock(content, 2))}
   }
 }
 
-export const KOTLIN_DEFAULT_CLASS_PRESET: ClassPresetType<KotlinOptions> = {
-  self({ renderer, model }) {
-    const hasProperties = Object.keys(model.properties).length > 0;
+export function shouldRenderInterface(model: ConstrainedObjectModel): boolean {
+  return Boolean(
+    model.options.isExtended || model.options.implementedBy?.length
+  );
+}
 
-    return renderer.defaultSelf(hasProperties);
+function getParentModels(
+  model: ConstrainedObjectModel
+): ConstrainedMetaModel[] {
+  const parents: ConstrainedMetaModel[] = [];
+
+  for (const parent of model.options.parents || []) {
+    if (
+      parent instanceof ConstrainedUnionModel &&
+      !kotlinUnionIncludesBuiltInTypes(parent)
+    ) {
+      parents.push(parent);
+    }
+  }
+
+  const basesInheritedThroughUnions = new Set(
+    parents
+      .filter(
+        (parent): parent is ConstrainedUnionModel =>
+          parent instanceof ConstrainedUnionModel
+      )
+      .map(getSharedPolymorphicBase)
+      .filter((base): base is ConstrainedObjectModel => base !== undefined)
+      .map((base) => base.name)
+  );
+
+  for (const extended of model.options.extend || []) {
+    const extendedModel =
+      extended instanceof ConstrainedReferenceModel ? extended.ref : extended;
+    if (
+      extendedModel instanceof ConstrainedObjectModel &&
+      shouldRenderInterface(extendedModel) &&
+      !basesInheritedThroughUnions.has(extendedModel.name)
+    ) {
+      parents.push(extended);
+    }
+  }
+
+  return parents.filter(
+    (parent, index) =>
+      parents.findIndex((candidate) => candidate.name === parent.name) === index
+  );
+}
+
+function overridesParentProperty(
+  model: ConstrainedObjectModel,
+  property: ConstrainedObjectPropertyModel
+): boolean {
+  for (const parent of getParentModels(model)) {
+    if (parent instanceof ConstrainedUnionModel) {
+      if (
+        parent.options.discriminator?.discriminator ===
+        property.unconstrainedPropertyName
+      ) {
+        return true;
+      }
+      const sharedBase = getSharedPolymorphicBase(parent);
+      if (
+        sharedBase &&
+        Object.values(sharedBase.properties).some(
+          (parentProperty) =>
+            parentProperty.unconstrainedPropertyName ===
+            property.unconstrainedPropertyName
+        )
+      ) {
+        return true;
+      }
+    }
+
+    const parentModel =
+      parent instanceof ConstrainedReferenceModel ? parent.ref : parent;
+    if (
+      parentModel instanceof ConstrainedObjectModel &&
+      Object.values(parentModel.properties).some(
+        (parentProperty) =>
+          parentProperty.unconstrainedPropertyName ===
+          property.unconstrainedPropertyName
+      )
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export const KOTLIN_DEFAULT_CLASS_PRESET: ClassPresetType<KotlinOptions> = {
+  self({ renderer }) {
+    return renderer.defaultSelf();
   },
-  property({ property }) {
-    return `val ${property.propertyName}: ${property.property.type}${
-      property.required ? '' : '? = null'
-    },`;
+  property({ property, model }) {
+    const optionalType = property.required ? '' : '?';
+    if (shouldRenderInterface(model)) {
+      return `val ${property.propertyName}: ${property.property.type}${optionalType}`;
+    }
+
+    const override = overridesParentProperty(model, property)
+      ? 'override '
+      : '';
+    const defaultValue = property.required ? '' : ' = null';
+    return `${override}val ${property.propertyName}: ${property.property.type}${optionalType}${defaultValue},`;
   }
 };

--- a/src/generators/kotlin/renderers/UnionRenderer.ts
+++ b/src/generators/kotlin/renderers/UnionRenderer.ts
@@ -1,0 +1,102 @@
+import { FormatHelpers } from '../../../helpers';
+import {
+  ConstrainedMetaModel,
+  ConstrainedObjectModel,
+  ConstrainedReferenceModel,
+  ConstrainedUnionModel
+} from '../../../models';
+import { KotlinOptions } from '../KotlinGenerator';
+import { UnionPresetType } from '../KotlinPreset';
+import { KotlinRenderer } from '../KotlinRenderer';
+
+/** Renderer for Kotlin sealed interfaces that represent object unions. */
+export class UnionRenderer extends KotlinRenderer<ConstrainedUnionModel> {
+  async defaultSelf(): Promise<string> {
+    const content: string[] = [];
+    const discriminator = this.model.options.discriminator;
+    if (discriminator?.type) {
+      const propertyName = FormatHelpers.toCamelCase(
+        FormatHelpers.replaceSpecialCharacters(discriminator.discriminator, {
+          exclude: ['_'],
+          separator: '_'
+        })
+      );
+      const overridesSharedBase = getSharedPolymorphicBase(this.model)
+        ? 'override '
+        : '';
+      content.push(
+        `${overridesSharedBase}val ${propertyName}: ${discriminator.type}`
+      );
+    }
+    content.push(await this.runAdditionalContentPreset());
+
+    const sharedBase = getSharedPolymorphicBase(this.model);
+    const inheritance = sharedBase ? ` : ${sharedBase.name}` : '';
+    const body = this.renderBlock(content);
+    if (!body) {
+      return `sealed interface ${this.model.name}${inheritance}`;
+    }
+    return `sealed interface ${this.model.name}${inheritance} {
+${this.indent(body)}
+}`;
+  }
+}
+
+export function getSharedPolymorphicBase(
+  model: ConstrainedUnionModel
+): ConstrainedObjectModel | undefined {
+  const discriminator = model.options.discriminator?.discriminator;
+  const members = model.union
+    .map(resolveModel)
+    .filter(
+      (member): member is ConstrainedObjectModel =>
+        member instanceof ConstrainedObjectModel
+    );
+  if (
+    !discriminator ||
+    members.length !== model.union.length ||
+    !members.length
+  ) {
+    return undefined;
+  }
+
+  const candidates = extendedObjectModels(members[0]).filter(
+    (candidate) => discriminatorName(candidate) === discriminator
+  );
+  const sharedCandidates = candidates.filter((candidate) =>
+    members.every((member) =>
+      extendedObjectModels(member).some(
+        (extended) => extended.name === candidate.name
+      )
+    )
+  );
+  return sharedCandidates.length === 1 ? sharedCandidates[0] : undefined;
+}
+
+function extendedObjectModels(
+  model: ConstrainedObjectModel
+): ConstrainedObjectModel[] {
+  return (model.options.extend || [])
+    .map(resolveModel)
+    .filter(
+      (extended): extended is ConstrainedObjectModel =>
+        extended instanceof ConstrainedObjectModel
+    );
+}
+
+function resolveModel(model: ConstrainedMetaModel): ConstrainedMetaModel {
+  return model instanceof ConstrainedReferenceModel ? model.ref : model;
+}
+
+function discriminatorName(model: ConstrainedObjectModel): string | undefined {
+  const discriminator =
+    model.options.discriminator?.discriminator ||
+    model.originalInput?.discriminator;
+  return typeof discriminator === 'string' ? discriminator : undefined;
+}
+
+export const KOTLIN_DEFAULT_UNION_PRESET: UnionPresetType<KotlinOptions> = {
+  self({ renderer }) {
+    return renderer.defaultSelf();
+  }
+};

--- a/src/interpreter/InterpretAllOf.ts
+++ b/src/interpreter/InterpretAllOf.ts
@@ -51,6 +51,9 @@ export default function interpretAllOf(
 
   // Interpret each sub-schema in allOf
   for (const subSchema of schema.allOf) {
+    if (isEmptyInlineObjectSchema(subSchema)) {
+      continue;
+    }
     const subModel = interpreter.interpret(subSchema, interpreterOptions);
     if (!subModel) {
       continue;
@@ -84,4 +87,29 @@ export default function interpretAllOf(
       interpreterOptions
     );
   }
+}
+
+function isEmptyInlineObjectSchema(schema: InterpreterSchemaType): boolean {
+  if (typeof schema === 'boolean' || schema.type !== 'object') {
+    return false;
+  }
+  return !(
+    hasMeaningfulSchemaId(schema) ||
+    schema.properties ||
+    schema.patternProperties ||
+    schema.additionalProperties !== undefined ||
+    schema.required?.length ||
+    schema.allOf?.length ||
+    schema.oneOf?.length ||
+    schema.anyOf?.length ||
+    schema.$ref
+  );
+}
+
+function hasMeaningfulSchemaId(
+  schema: Exclude<InterpreterSchemaType, boolean>
+): boolean {
+  const schemaId = Reflect.get(schema, '$id');
+  const syntheticAllOfPattern = /(?:AllOfOption|allOf)[_-]?\d+$/i;
+  return typeof schemaId === 'string' && !syntheticAllOfPattern.test(schemaId);
 }

--- a/src/processors/AsyncAPIInputProcessor.ts
+++ b/src/processors/AsyncAPIInputProcessor.ts
@@ -32,6 +32,10 @@ export interface AsyncAPIInputProcessorOptions extends ParseOptions {
    * This option will include message headers in the list of models built whilst traversing the AsyncAPI spec.
    */
   includeMessageHeaders?: boolean;
+  /**
+   * This option will include every schema from components/schemas, even when it is not referenced by a message payload.
+   */
+  includeComponentSchemas?: boolean;
 }
 
 /**
@@ -163,7 +167,7 @@ export class AsyncAPIInputProcessor extends AbstractInputProcessor {
     // Build a mapping of schema IDs to component keys for better naming
     const componentSchemaKeys = new Map<string, string>();
     try {
-      const allSchemas = doc.schemas();
+      const allSchemas = doc.components().schemas();
       for (const schema of allSchemas) {
         const schemaId = schema.id();
         // Extract the component key from the schema ID
@@ -450,6 +454,12 @@ export class AsyncAPIInputProcessor extends AbstractInputProcessor {
             : undefined;
           addToInputModel(payload, messageName);
         }
+      }
+    }
+
+    if (options?.asyncapi?.includeComponentSchemas) {
+      for (const schema of doc.components().schemas()) {
+        addToInputModel(schema);
       }
     }
 

--- a/test/generators/kotlin/KotlinGenerator.spec.ts
+++ b/test/generators/kotlin/KotlinGenerator.spec.ts
@@ -203,6 +203,36 @@ describe('KotlinGenerator', () => {
     expect(models[0].result).toMatchSnapshot();
     expect(models[1].result).toMatchSnapshot();
   });
+  test('should generate unreferenced AsyncAPI component schemas when enabled', async () => {
+    const doc = {
+      asyncapi: '3.0.0',
+      info: {
+        title: 'Shared models',
+        version: '1.0.0'
+      },
+      channels: {},
+      components: {
+        schemas: {
+          SharedStatus: {
+            type: 'string',
+            enum: ['active', 'inactive']
+          }
+        }
+      }
+    };
+    generator = new KotlinGenerator({
+      processorOptions: {
+        asyncapi: {
+          includeComponentSchemas: true
+        }
+      }
+    });
+
+    const models = await generator.generate(doc);
+
+    expect(models.map((model) => model.modelName)).toContain('SharedStatus');
+  });
+
   test('should escape reserved keywords in package name', async () => {
     const doc = {
       $id: 'Address',

--- a/test/generators/kotlin/KotlinGenerator.spec.ts
+++ b/test/generators/kotlin/KotlinGenerator.spec.ts
@@ -79,6 +79,35 @@ describe('KotlinGenerator', () => {
     expect(models[0].dependencies).toEqual(expectedDependencies);
   });
 
+  test('should honor x-enum-varnames', async () => {
+    const doc = {
+      $id: 'States',
+      type: 'string',
+      enum: ['New York', 'California'],
+      'x-enum-varnames': ['NY', 'GOLDEN_STATE']
+    };
+
+    const models = await generator.generate(doc);
+
+    expect(models).toHaveLength(1);
+    expect(models[0].result).toContain('NY("New York")');
+    expect(models[0].result).toContain('GOLDEN_STATE("California")');
+  });
+
+  test('should ignore invalid x-enum-varnames', async () => {
+    const doc = {
+      $id: 'States',
+      type: 'string',
+      enum: ['New York', 'California'],
+      'x-enum-varnames': ['NY']
+    };
+
+    const models = await generator.generate(doc);
+
+    expect(models[0].result).toContain('NEW_YORK("New York")');
+    expect(models[0].result).toContain('CALIFORNIA("California")');
+  });
+
   test('should render `enum` type (integer type)', async () => {
     const doc = {
       $id: 'Numbers',

--- a/test/generators/kotlin/KotlinGenerator.spec.ts
+++ b/test/generators/kotlin/KotlinGenerator.spec.ts
@@ -143,6 +143,31 @@ describe('KotlinGenerator', () => {
     expect(models[0].result).toMatchSnapshot();
   });
 
+  test('should render required properties before optional properties when configured', async () => {
+    const doc = {
+      $id: 'OrderedProperties',
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        optionalFirst: { type: 'string' },
+        requiredSecond: { type: 'string' },
+        optionalThird: { type: 'string' }
+      },
+      required: ['requiredSecond']
+    };
+    generator = new KotlinGenerator({ requiredPropertiesFirst: true });
+
+    const models = await generator.generate(doc);
+    const result = models[0].result;
+
+    expect(result.indexOf('requiredSecond')).toBeLessThan(
+      result.indexOf('optionalFirst')
+    );
+    expect(result.indexOf('optionalFirst')).toBeLessThan(
+      result.indexOf('optionalThird')
+    );
+  });
+
   test('should render List type for collections', async () => {
     const doc = {
       $id: 'CustomClass',

--- a/test/generators/kotlin/KotlinInheritance.spec.ts
+++ b/test/generators/kotlin/KotlinInheritance.spec.ts
@@ -1,0 +1,97 @@
+import { KotlinGenerator, KOTLIN_JACKSON_PRESET } from '../../../src';
+
+describe('Kotlin inheritance and discriminators', () => {
+  test('should render inherited object unions with Jackson subtype metadata', async () => {
+    const document = {
+      asyncapi: '3.0.0',
+      info: {
+        title: 'Animals',
+        version: '1.0.0'
+      },
+      channels: {
+        animals: {
+          address: 'animals',
+          messages: {
+            Dog: { $ref: '#/components/messages/Dog' },
+            Cat: { $ref: '#/components/messages/Cat' }
+          }
+        }
+      },
+      operations: {
+        receiveAnimals: {
+          action: 'receive',
+          channel: { $ref: '#/channels/animals' },
+          messages: [
+            { $ref: '#/channels/animals/messages/Dog' },
+            { $ref: '#/channels/animals/messages/Cat' }
+          ]
+        }
+      },
+      components: {
+        messages: {
+          Dog: {
+            payload: { $ref: '#/components/schemas/Dog' }
+          },
+          Cat: {
+            payload: { $ref: '#/components/schemas/Cat' }
+          }
+        },
+        schemas: {
+          Pet: {
+            type: 'object',
+            discriminator: 'kind',
+            'x-discriminator-mapping': {
+              dog: '#/components/schemas/Dog',
+              cat: '#/components/schemas/Cat'
+            },
+            required: ['kind'],
+            properties: {
+              kind: { type: 'string' }
+            }
+          },
+          Dog: {
+            allOf: [{ $ref: '#/components/schemas/Pet' }, { type: 'object' }],
+            required: ['bark'],
+            properties: {
+              bark: { type: 'boolean' }
+            }
+          },
+          Cat: {
+            allOf: [{ $ref: '#/components/schemas/Pet' }, { type: 'object' }],
+            required: ['lives'],
+            properties: {
+              lives: { type: 'integer' }
+            }
+          }
+        }
+      }
+    };
+    const generator = new KotlinGenerator({
+      presets: [KOTLIN_JACKSON_PRESET],
+      processorOptions: {
+        asyncapi: {
+          includeComponentSchemas: true
+        },
+        jsonSchema: {
+          allowInheritance: true
+        }
+      }
+    });
+
+    const models = await generator.generate(document);
+    const renderedModels = models
+      .filter((model) => model.result)
+      .map((model) => model.result.replace(/[ \t]+$/gm, ''));
+
+    expect(renderedModels).toMatchSnapshot();
+    expect(renderedModels).toContainEqual(
+      expect.stringContaining('sealed interface Animals : Pet')
+    );
+    expect(renderedModels).toContainEqual(
+      expect.stringMatching(/data class Dog[\s\S]*\) : Animals$/)
+    );
+    expect(renderedModels).not.toContainEqual(
+      expect.stringMatching(/sealed interface Animals[\s\S]*@JsonTypeInfo/)
+    );
+  });
+});

--- a/test/generators/kotlin/__snapshots__/KotlinInheritance.spec.ts.snap
+++ b/test/generators/kotlin/__snapshots__/KotlinInheritance.spec.ts.snap
@@ -1,0 +1,40 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Kotlin inheritance and discriminators should render inherited object unions with Jackson subtype metadata 1`] = `
+Array [
+  "sealed interface Animals : Pet {
+    override val kind: String
+}",
+  "@JsonTypeName(\\"dog\\")
+data class Dog(
+    @get:JsonProperty(\\"bark\\")
+    val bark: Boolean,
+    @get:JsonProperty(value=\\"kind\\", access=JsonProperty.Access.WRITE_ONLY)
+    override val kind: String,
+    @get:JsonAnyGetter
+    @field:JsonAnySetter
+    override val additionalProperties: MutableMap<String, Any> = mutableMapOf(),
+) : Animals",
+  "@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.PROPERTY, property=\\"kind\\", visible=true)
+@JsonSubTypes(
+JsonSubTypes.Type(value = Dog::class, name = \\"dog\\"),
+JsonSubTypes.Type(value = Cat::class, name = \\"cat\\")
+)
+interface Pet {
+    @get:JsonProperty(value=\\"kind\\", access=JsonProperty.Access.WRITE_ONLY)
+    val kind: String
+    @get:JsonAnyGetter
+    val additionalProperties: Map<String, Any>?
+}",
+  "@JsonTypeName(\\"cat\\")
+data class Cat(
+    @get:JsonProperty(\\"lives\\")
+    val lives: Int,
+    @get:JsonProperty(value=\\"kind\\", access=JsonProperty.Access.WRITE_ONLY)
+    override val kind: String,
+    @get:JsonAnyGetter
+    @field:JsonAnySetter
+    override val additionalProperties: MutableMap<String, Any> = mutableMapOf(),
+) : Animals",
+]
+`;

--- a/test/generators/kotlin/presets/JacksonPreset.spec.ts
+++ b/test/generators/kotlin/presets/JacksonPreset.spec.ts
@@ -18,7 +18,8 @@ describe('KOTLIN_JACKSON_PRESET', () => {
         order_id: { type: 'string' },
         description: { type: 'string' }
       },
-      required: ['order_id']
+      required: ['order_id'],
+      additionalProperties: false
     };
 
     const models = await generator.generate(doc);
@@ -26,8 +27,48 @@ describe('KOTLIN_JACKSON_PRESET', () => {
     expect(models).toHaveLength(1);
     expect(models[0].result.replace(/[ \t]+$/gm, '')).toMatchSnapshot();
     expect(models[0].dependencies).toEqual([
-      'import com.fasterxml.jackson.annotation.*'
+      'import com.fasterxml.jackson.annotation.JsonProperty',
+      'import com.fasterxml.jackson.annotation.JsonInclude'
     ]);
+  });
+
+  test('should omit null values for optional nullable and non-nullable properties', async () => {
+    const doc = {
+      $id: 'Nullability',
+      type: 'object',
+      properties: {
+        optionalNonNullable: { type: 'string' },
+        optionalNullable: { type: ['string', 'null'] }
+      },
+      additionalProperties: false
+    };
+
+    const models = await generator.generate(doc);
+    const result = models[0].result;
+
+    expect(result).toMatch(
+      /@get:JsonProperty\("optionalNonNullable"\)\s+@get:JsonInclude\(JsonInclude.Include.NON_NULL\)/
+    );
+    expect(result).toMatch(
+      /@get:JsonProperty\("optionalNullable"\)\s+@get:JsonInclude\(JsonInclude.Include.NON_NULL\)/
+    );
+  });
+
+  test('should keep a standalone discriminator property readable', async () => {
+    const doc = {
+      $id: 'Standalone',
+      type: 'object',
+      discriminator: 'kind',
+      properties: {
+        kind: { type: 'string' }
+      },
+      required: ['kind']
+    };
+
+    const models = await generator.generate(doc);
+
+    expect(models[0].result).toContain('@get:JsonProperty("kind")');
+    expect(models[0].result).not.toContain('JsonProperty.Access.WRITE_ONLY');
   });
 
   test('should render Jackson serialization and deserialization annotations for enum', async () => {
@@ -42,8 +83,38 @@ describe('KOTLIN_JACKSON_PRESET', () => {
     expect(models).toHaveLength(1);
     expect(models[0].result.replace(/[ \t]+$/gm, '')).toMatchSnapshot();
     expect(models[0].dependencies).toEqual([
-      'import com.fasterxml.jackson.annotation.*'
+      'import com.fasterxml.jackson.annotation.JsonCreator',
+      'import com.fasterxml.jackson.annotation.JsonValue'
     ]);
+    expect(models[0].result).toContain(
+      "Unexpected value '$value' for enum 'OrderStatus'"
+    );
+  });
+
+  test('should not add Jackson polymorphism annotations to union marker interfaces', async () => {
+    const doc = {
+      $id: 'Pet',
+      discriminator: { propertyName: 'kind' },
+      oneOf: [
+        {
+          $id: 'Dog',
+          type: 'object',
+          properties: { kind: { const: 'dog' } }
+        },
+        {
+          $id: 'Cat',
+          type: 'object',
+          properties: { kind: { const: 'cat' } }
+        }
+      ]
+    };
+
+    const models = await generator.generate(doc);
+    const union = models.find((model) => model.modelName === 'Pet');
+
+    expect(union?.result).toContain('sealed interface Pet');
+    expect(union?.result).not.toContain('@JsonTypeInfo');
+    expect(union?.result).not.toContain('@JsonSubTypes');
   });
 
   test('should annotate the default enum value', async () => {

--- a/test/generators/kotlin/presets/__snapshots__/JacksonPreset.spec.ts.snap
+++ b/test/generators/kotlin/presets/__snapshots__/JacksonPreset.spec.ts.snap
@@ -7,9 +7,6 @@ exports[`KOTLIN_JACKSON_PRESET should render Jackson annotations for class prope
     @get:JsonProperty(\\"description\\")
     @get:JsonInclude(JsonInclude.Include.NON_NULL)
     val description: String? = null,
-    @get:JsonAnyGetter
-    @field:JsonAnySetter
-    val additionalProperties: MutableMap<String, Any> = mutableMapOf(),
 )"
 `;
 
@@ -23,7 +20,7 @@ exports[`KOTLIN_JACKSON_PRESET should render Jackson serialization and deseriali
         @JsonCreator
         fun forValue(value: String): OrderStatus {
             return values().firstOrNull { it.value == value }
-                ?: throw IllegalArgumentException(\\"Unexpected value '$value'\\")
+                ?: throw IllegalArgumentException(\\"Unexpected value '$value' for enum 'OrderStatus'\\")
         }
     }
 }"

--- a/test/interpreter/unit/InterpretAllOf.spec.ts
+++ b/test/interpreter/unit/InterpretAllOf.spec.ts
@@ -91,6 +91,22 @@ describe('Interpretation of allOf', () => {
     expect(interpreter.interpretAndCombineSchema).not.toHaveBeenCalled();
     expect(JSON.stringify(model)).toEqual(JSON.stringify(new CommonModel()));
   });
+  test('should ignore empty inline object schemas', () => {
+    const model = new CommonModel();
+    const schema = { allOf: [{ type: 'object' }] };
+    const interpreter = new Interpreter();
+
+    interpretAllOf(
+      schema,
+      model,
+      interpreter,
+      interpreterOptionsAllowInheritance
+    );
+
+    expect(interpreter.interpret).not.toHaveBeenCalled();
+    expect(interpreter.interpretAndCombineSchema).not.toHaveBeenCalled();
+  });
+
   test('should extend model', () => {
     const model = new CommonModel();
     const schema = { allOf: [{ type: 'object', $id: 'test' }] };

--- a/test/runtime/runtime-kotlin-inheritance-input.json
+++ b/test/runtime/runtime-kotlin-inheritance-input.json
@@ -1,0 +1,66 @@
+{
+  "asyncapi": "3.0.0",
+  "info": {
+    "title": "Animals",
+    "version": "1.0.0"
+  },
+  "channels": {
+    "animals": {
+      "address": "animals",
+      "messages": {
+        "Dog": { "$ref": "#/components/messages/Dog" },
+        "Cat": { "$ref": "#/components/messages/Cat" }
+      }
+    }
+  },
+  "operations": {
+    "receiveAnimals": {
+      "action": "receive",
+      "channel": { "$ref": "#/channels/animals" },
+      "messages": [
+        { "$ref": "#/channels/animals/messages/Dog" },
+        { "$ref": "#/channels/animals/messages/Cat" }
+      ]
+    }
+  },
+  "components": {
+    "messages": {
+      "Dog": { "payload": { "$ref": "#/components/schemas/Dog" } },
+      "Cat": { "payload": { "$ref": "#/components/schemas/Cat" } }
+    },
+    "schemas": {
+      "Pet": {
+        "type": "object",
+        "discriminator": "kind",
+        "x-discriminator-mapping": {
+          "dog": "#/components/schemas/Dog",
+          "cat": "#/components/schemas/Cat"
+        },
+        "required": ["kind"],
+        "properties": {
+          "kind": { "type": "string" }
+        }
+      },
+      "Dog": {
+        "allOf": [
+          { "$ref": "#/components/schemas/Pet" },
+          { "type": "object" }
+        ],
+        "required": ["bark"],
+        "properties": {
+          "bark": { "type": "boolean" }
+        }
+      },
+      "Cat": {
+        "allOf": [
+          { "$ref": "#/components/schemas/Pet" },
+          { "type": "object" }
+        ],
+        "required": ["lives"],
+        "properties": {
+          "lives": { "type": "integer" }
+        }
+      }
+    }
+  }
+}

--- a/test/runtime/runtime-kotlin.ts
+++ b/test/runtime/runtime-kotlin.ts
@@ -38,6 +38,9 @@ jacksonGenerator.generateToFiles(
 const inheritanceGenerator = new KotlinFileGenerator({
   presets: [KOTLIN_JACKSON_PRESET],
   processorOptions: {
+    asyncapi: {
+      includeComponentSchemas: true
+    },
     jsonSchema: {
       allowInheritance: true
     }

--- a/test/runtime/runtime-kotlin.ts
+++ b/test/runtime/runtime-kotlin.ts
@@ -5,6 +5,7 @@ import {
 } from '../../';
 import path from 'path';
 import input from './generic-input.json';
+import inheritanceInput from './runtime-kotlin-inheritance-input.json';
 
 const defaultGenerator = new KotlinFileGenerator({
   presets: [KOTLIN_DEFAULT_PRESET]
@@ -32,4 +33,23 @@ jacksonGenerator.generateToFiles(
     './runtime-kotlin/src/main/kotlin/com/mycompany/app/jackson'
   ),
   { packageName: 'com.mycompany.app.jackson' }
+);
+
+const inheritanceGenerator = new KotlinFileGenerator({
+  presets: [KOTLIN_JACKSON_PRESET],
+  processorOptions: {
+    jsonSchema: {
+      allowInheritance: true
+    }
+  }
+});
+
+inheritanceGenerator.generateToFiles(
+  inheritanceInput,
+  path.resolve(
+    // eslint-disable-next-line no-undef
+    __dirname,
+    './runtime-kotlin/src/main/kotlin/com/mycompany/app/polymorphism'
+  ),
+  { packageName: 'com.mycompany.app.polymorphism' }
 );

--- a/test/runtime/runtime-kotlin/src/test/kotlin/com/mycompany/app/polymorphism/PolymorphismTest.kt
+++ b/test/runtime/runtime-kotlin/src/test/kotlin/com/mycompany/app/polymorphism/PolymorphismTest.kt
@@ -1,0 +1,54 @@
+package com.mycompany.app.polymorphism
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Test
+
+class PolymorphismTest {
+    private val objectMapper = jacksonObjectMapper()
+
+    data class AnimalEnvelope(val animal: Animals)
+
+    @Test
+    fun shouldDeserializeDiscriminatorMappingIntoConcreteType() {
+        val pet = objectMapper.readValue<Pet>("""{"kind":"dog","bark":true}""")
+
+        assertInstanceOf(Dog::class.java, pet)
+        assertEquals("dog", pet.kind)
+        assertEquals(true, (pet as Dog).bark)
+    }
+
+    @Test
+    fun shouldSerializeConcreteTypeThroughParentInterface() {
+        val pet: Pet = Cat(lives = 9, kind = "cat")
+
+        assertEquals(
+            """{"kind":"cat","lives":9}""",
+            objectMapper.writeValueAsString(pet)
+        )
+    }
+
+    @Test
+    fun shouldRoundTripThroughSealedUnionType() {
+        val animal: Animals = Dog(bark = true, kind = "dog")
+
+        val json = objectMapper.writerFor(Animals::class.java).writeValueAsString(animal)
+        val deserialized = objectMapper.readValue<Animals>(json)
+
+        assertEquals("""{"kind":"dog","bark":true}""", json)
+        assertInstanceOf(Dog::class.java, deserialized)
+    }
+
+    @Test
+    fun shouldRoundTripFieldTypedAsSealedUnion() {
+        val envelope = AnimalEnvelope(Cat(lives = 9, kind = "cat"))
+
+        val json = objectMapper.writeValueAsString(envelope)
+        val deserialized = objectMapper.readValue<AnimalEnvelope>(json)
+
+        assertEquals("""{"animal":{"kind":"cat","lives":9}}""", json)
+        assertInstanceOf(Cat::class.java, deserialized.animal)
+    }
+}


### PR DESCRIPTION
## Description
Add `requiredPropertiesFirst` to the Kotlin generator.

When enabled, Modelina renders required constructor properties before optional properties. This allows callers to pass required values positionally instead of using named arguments after a default value.

```ts
const generator = new KotlinGenerator({
  requiredPropertiesFirst: true
});
```

Sorting is stable, so properties keep their schema order within the required and optional groups. The option defaults to `false`, so existing output does not change.

## Testing

Added tests for ordering, stable sorting, and default behavior.

## Related issue

<!-- Add the tracking issue. -->

## Checklist

- [x] Code is linted.
- [x] Tests cover the changes.
- [ ] Documentation is updated in PR 5.
- [x] Tests pass locally.

PR 4 of 5.