### PR TITLE
chore(deps): patch security-flagged deps in examples and modelina-cli

### DIFF
--- a/.claude/commands/describe_pr.md
+++ b/.claude/commands/describe_pr.md
@@ -1,0 +1,92 @@
+---
+description: Generate comprehensive PR descriptions following repository templates
+---
+
+# Generate PR Description
+
+You are tasked with generating a comprehensive pull request description following the repository's standard template.
+
+## Steps to follow:
+
+1. **Read the PR description template:**
+   - Read the template at `.claude/templates/pr_description.md` to understand all sections and requirements
+
+2. **Identify the PR to describe:**
+   - Check if the current branch has an associated PR: `gh pr view --json url,number,title,state 2>/dev/null`
+   - If no PR exists for the current branch, or if on main/master, list open PRs: `gh pr list --limit 10 --json number,title,headRefName,author`
+   - Ask the user which PR they want to describe
+
+3. **Check for existing description:**
+   - Check if `thoughts/shared/prs/{number}_description.md` already exists
+   - If it exists, read it and inform the user you'll be updating it
+   - Consider what has changed since the last description was written
+
+4. **Check for related GitHub issues:**
+   - Search for research/plan files in `thoughts/` subdirectories (e.g., `thoughts/*/research.md`, `thoughts/*/plan.md`) that might be related to this PR
+   - Read the first 30 lines of the most recent files to look for `github_issue_url:` in the frontmatter or `**Related Issue**:` in the document body
+   - Extract the GitHub issue URL if found
+   - If multiple files exist, prioritize the most recent one or the one matching the PR branch name
+
+5. **Gather comprehensive PR information:**
+   - Get the full PR diff: `gh pr diff {number}`
+   - If you get an error about no default remote repository, instruct the user to run `gh repo set-default` and select the appropriate repository
+   - Get commit history: `gh pr view {number} --json commits`
+   - Review the base branch: `gh pr view {number} --json baseRefName`
+   - Get PR metadata: `gh pr view {number} --json url,title,number,state`
+
+6. **Analyze the changes thoroughly:** (ultrathink about the code changes, their architectural implications, and potential impacts)
+   - Read through the entire diff carefully
+   - For context, read any files that are referenced but not shown in the diff
+   - Understand the purpose and impact of each change
+   - Identify user-facing changes vs internal implementation details
+   - Look for breaking changes or migration requirements
+
+7. **Handle verification requirements:**
+   - Look for any checklist items in the "How to verify it" section of the template
+   - For each verification step:
+     - If it's a command you can run (like `make check test`, `npm test`, etc.), run it
+     - If it passes, mark the checkbox as checked: `- [x]`
+     - If it fails, keep it unchecked and note what failed: `- [ ]` with explanation
+     - If it requires manual testing (UI interactions, external services), leave unchecked and note for user
+   - Document any verification steps you couldn't complete
+
+8. **Generate the description:**
+   - Fill out each section from the template thoroughly:
+     - If a GitHub issue URL was found in step 4, add it at the top of the description as: `**Related Issue**: [GH-XXXX](url)`
+     - Answer each question/section based on your analysis
+     - Be specific about problems solved and changes made
+     - Focus on user impact where relevant
+     - Include technical details in appropriate sections
+     - Write a concise changelog entry
+   - Ensure all checklist items are addressed (checked or explained)
+
+9. **Save and sync the description:**
+   - Write the completed description to `thoughts/shared/prs/{number}_description.md`
+   - Run `git add thoughts` to stage the thoughts directory
+   - Show the user the generated description
+
+10. **Update the PR:**
+   - Update the PR description directly: `gh pr edit {number} --body-file thoughts/shared/prs/{number}_description.md`
+   - Confirm the update was successful
+   - If any verification steps remain unchecked, remind the user to complete them before merging
+
+## When to Stop and Ask
+
+You should work autonomously as much as possible, but stop and ask when:
+- Cannot find or access the PR (wrong repo, permissions issue)
+- PR template is missing or malformed
+- PR diff is too large to analyze effectively (1000+ files changed)
+- Verification commands require credentials or access you don't have
+- Breaking changes are unclear and you need user input on migration strategy
+- Can't determine which related research/plan documents correspond to this PR
+
+When blocked, explain what you've gathered so far and what's preventing completion.
+
+## Important notes:
+- This command works across different repositories - always read the local template
+- Be thorough but concise - descriptions should be scannable
+- Focus on the "why" as much as the "what"
+- Include any breaking changes or migration notes prominently
+- If the PR touches multiple components, organize the description accordingly
+- Always attempt to run verification commands when possible
+- Clearly communicate which verification steps need manual testing

--- a/.claude/commands/handle_dependabot.md
+++ b/.claude/commands/handle_dependabot.md
@@ -1,0 +1,147 @@
+---
+description: Consolidate open Dependabot PRs and security alerts into a single npm upgrade branch, validate against the full test suite, and open one PR
+argument-hint: "[--skip-tests]"
+---
+
+# Handle Dependabot PRs
+
+Consolidate open Dependabot PRs and security alerts into one upgrade branch.
+
+**Workflow:** Research (subagent) → Plan & confirm → Execute → Validate → PR
+
+**Scope:** `.github/dependabot.yml` configures **npm at the repo root only** (monthly, excluding `examples/**` and `test/**`). There is one manifest (`package.json`) and one lockfile (`package-lock.json`). The nested `mcp-server/` and `website/` packages and the runtime fixture in `test/runtime/typescript/` are **not** covered by Dependabot — leave them alone unless the user asks. No Python, no GitHub Actions ecosystem.
+
+**Artifacts:**
+- Research: `.claude/thoughts/shared/research/{date}-dependabot-upgrade.json`
+- Plan: `.claude/thoughts/shared/plans/{date}-dependabot-upgrade.md`
+
+## Phase 1: Research (subagent)
+
+Spawn a `general-purpose` subagent with these instructions:
+
+> **Research Dependabot upgrades for this repo. Write findings to `.claude/thoughts/shared/research/{date}-dependabot-upgrade.json`.**
+>
+> 1. **Open Dependabot PRs:**
+>    ```bash
+>    gh pr list --author "app/dependabot" --json number,title,headRefName,url --state open --limit 100
+>    ```
+>    If none and no open alerts, write `{ "empty": true }` and stop.
+>
+> 2. **Open security alerts**, cross-referenced with those PRs:
+>    ```bash
+>    gh api repos/{owner}/{repo}/dependabot/alerts --paginate --jq '[.[] | select(.state == "open")]'
+>    ```
+>    An alert is *uncovered* if no PR bumps that package to at least the fix version.
+>
+> 3. **For each PR:**
+>    - Parse package + target version from the title.
+>    - Read the **actual** current version from `package.json` — PR titles go stale.
+>    - Resolve the newest release: `npm view {package} version`. Dependabot often proposes only the minimum fix version.
+>    - Record dep type (`dependencies` / `devDependencies` / `peerDependencies`).
+>    - Compute bump type from **latest** vs current.
+>    - Check the package's `engines.node` against this repo's `>=22.0.0`.
+>
+> 4. **Stale PRs:** package no longer in `package.json`, or the bump is already satisfied → mark stale with a reason.
+>
+> 5. **Uncovered alerts on transitive deps:** find the parent chain with `npm ls {package}`. Record the parent to upgrade; never install a transitive dep directly.
+>
+> 6. **Major bumps — deep research.** WebSearch for "{package} v{major} migration guide" and its changelog. Classify each breaking change:
+>    - **User-visible** — changes the *generated output* of the CLI or the config surface. `@asyncapi/modelina`, `@asyncapi/parser`, the OpenAPI/JSON-Schema parsers, and `oclif` all fall here: their output ends up in users' generated code or in the CLI's command interface.
+>    - **Internal-only** — build, lint, or test tooling with no effect on emitted artifacts (typescript, jest, eslint, prettier, rimraf, ts-node).
+>
+>    Decision rule: internal-only → `upgrade: true` with migration steps. Any user-visible break → `upgrade: true` **only if** the output delta is intended and reviewable; otherwise `upgrade: false` with a reason. Note effort: trivial / moderate / significant.
+>
+> 7. **Record any `overrides` entries** in `package.json` (npm's equivalent of yarn `resolutions`) for later reconciliation. There are none today — flag it if that changed.
+>
+> **Output JSON:**
+> ```json
+> {
+>   "production": [{ "pr": 123, "package": "...", "current": "...", "target": "...", "latest": "...", "bump": "patch" }],
+>   "development": [...],
+>   "stale": [{ "pr": 123, "package": "...", "reason": "..." }],
+>   "uncovered_alerts": [{ "alert": 1, "package": "...", "fix": "...", "severity": "...", "cve": "...", "direct": true, "parent": null }],
+>   "major_bumps": [{ "package": "...", "from": "...", "to": "...", "upgrade": true, "breaking_changes": [{ "description": "...", "impact": "internal|user-visible" }], "migration_steps": "...", "effort": "trivial", "skip_reason": null }],
+>   "overrides": {}
+> }
+> ```
+
+## Phase 2: Plan & confirm
+
+Read the research file. If `empty: true`, report "No open Dependabot PRs or alerts" and stop.
+
+Write the plan to `.claude/thoughts/shared/plans/{date}-dependabot-upgrade.md`:
+- Tables for production deps, dev deps, uncovered alerts, stale PRs
+- Major-bump decisions with reasoning, split by user-visible vs internal
+- Upgrade order: TypeScript and build tooling → `@types/*` → jest/eslint/prettier → `@asyncapi/*` and parsers → everything else
+- Expected snapshot/generated-output churn, and which upgrades cause it
+- Risks and likely manual-review items
+
+Present it and ask: **Upgrade all / Select specific / Cancel.**
+
+## Phase 3: Execute
+
+### 3a. Branch
+
+```bash
+git status --porcelain            # must be clean
+git fetch origin main && git checkout main && git pull origin main
+git checkout -b "chore/upgrade-dependencies-$(date +%Y-%m-%d)"
+```
+
+### 3b. Upgrade
+
+Skip anything with `upgrade: false` and close its Dependabot PR with a comment explaining why.
+
+Always install the **`latest`** version from the research file, not Dependabot's `target`. If `latest` crosses a major boundary the research didn't analyse, stop and analyse it before installing.
+
+```bash
+npm install {package}@{latest}                # dependencies
+npm install --save-dev {package}@{latest}     # devDependencies
+```
+
+Batch by group where versions are independent; install one at a time for anything with peer-dependency pressure, and upgrade the peer alongside it. Watch `npm install` output for `ERESOLVE` and peer warnings — do not paper over them with `--force` or `--legacy-peer-deps`.
+
+For transitive-only alerts, upgrade the recorded parent, then confirm with `npm ls {package}` that the vulnerable version is gone. If no parent release satisfies the fix, note it for manual review — reach for an `overrides` entry only as a last resort, and say so in the PR.
+
+### 3c. Reconcile overrides
+
+If `package.json` has `overrides`, check each against the upgraded versions: bump when every consumer accepts the newer version, scope it (`"parent>package": "version"`) when consumers disagree, remove it only when the pin is fully obsolete. Removing a security override can silently re-expose the vulnerability through another consumer. Re-run `npm install` and verify with `npm ls {package}`.
+
+## Phase 4: Validate (unless `--skip-tests`)
+
+Run in order, fixing before moving on. Do **not** run `npm run prepare:pr` as one shot here — its `runtime:typescript:generate` step runs `npm ci` in `test/runtime/typescript` and fails on pre-existing lockfile drift unrelated to the upgrade. Run the steps directly:
+
+1. `npm run build` — tsc + oclif manifest.
+2. `npm run typecheck` and `npm run typecheck:test`.
+3. `npm run lint:fix` — must end clean at `--max-warnings 0`.
+4. `npm run generate:assets` — regenerates `schemas/`, `docs/`, README TOC, `examples/`. Any diff here is real drift and belongs in the commit.
+5. `npm test` — if a parser or Modelina bump changed emitted code, review the snapshot diff **before** accepting it, then `npm run test:update`. A snapshot diff is the user-visible output delta; never blind-update it.
+6. `npm run test:blackbox` — required for any `@asyncapi/*`, parser, or Modelina bump; it type-checks generated output.
+7. Runtime tier — only when a broker client (`nats`, `kafkajs`, `mqtt`, `amqplib`) or Modelina was bumped:
+   ```bash
+   npm run runtime:services:start && npm run runtime:typescript
+   npm run runtime:services:stop
+   ```
+   Regenerating runtime code overwrites hand-written expected-output surfaces in `test/runtime/typescript/src` — inspect that diff, don't just commit it.
+
+Delegate independent fixes across different files to parallel `general-purpose` subagents. Anything that needs a design decision goes on the manual-review list instead.
+
+## Phase 5: Commit & PR
+
+Two commits:
+
+1. `chore(deps): upgrade dependencies` — `package.json`, `package-lock.json`. Reference each PR as `Ref #{pr_number}` in the body.
+2. Follow-up fixes, if any — code changes and regenerated assets/snapshots, with a body explaining *what output changed and why*.
+
+Open the PR with `gh pr create`. The title must satisfy `lint-pr-title.yml` (conventional commits) — use `chore(deps): ...`. Body: upgrade summary, validation results per tier, skipped majors with reasons, manual-review items, and `Closes #{pr_number}` for each Dependabot PR consolidated. **Never auto-merge.**
+
+Report a final summary with counts, per-tier validation status, skips, and open questions.
+
+## Gotchas
+
+- **Modelina bumps change generated output.** `@asyncapi/modelina` next-releases have changed serialization behaviour (`toJson`/`fromJson`, `JSON.stringify` spacing, `additionalProperties` as `Record` vs `Map`). A bump cascades into unit snapshots, blackbox output, runtime expected-output surfaces, and `examples/`. Budget for it; review each diff.
+- **`prepare:pr` is not a safe validation shortcut here** — see Phase 4.
+- **Regenerating runtime code clobbers hand-edited surfaces.** `test/runtime/typescript/src` is written by the generator; expected-output files there are the design surface, not build waste.
+- **PR title versions are unreliable.** Always read the real version from `package.json`.
+- **`npm view {package} version` returns the `latest` dist-tag**, which for some `@asyncapi` packages lags behind a `next` tag. Do not pull a `next` build unless the repo already depends on one.
+- **Yanked versions or alerts with no fix available:** skip, and note them for manual tracking rather than forcing an upgrade.

--- a/examples/integrate-with-maven/maven-project/pom.xml
+++ b/examples/integrate-with-maven/maven-project/pom.xml
@@ -28,12 +28,12 @@
     <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>2.15.0</version>
+        <version>2.22.2</version>
     </dependency>
     <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.15.0</version>
+        <version>2.22.2</version>
     </dependency>
     <!-- https://mvnrepository.com/artifact/org.hamcrest/hamcrest-all -->
     <dependency>

--- a/examples/integrate-with-next/package-lock.json
+++ b/examples/integrate-with-next/package-lock.json
@@ -9197,15 +9197,16 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/nanoid": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
-      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },

--- a/examples/integrate-with-next/package.json
+++ b/examples/integrate-with-next/package.json
@@ -28,5 +28,8 @@
     "babel-jest": "^29.4.2",
     "jest": "^28.1.0",
     "jest-environment-jsdom": "28.1.0"
+  },
+  "overrides": {
+    "nanoid": "3.3.18"
   }
 }

--- a/examples/integrate-with-react/package-lock.json
+++ b/examples/integrate-with-react/package-lock.json
@@ -4774,9 +4774,10 @@
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -7526,9 +7527,10 @@
       }
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -11067,15 +11069,16 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
-      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },

--- a/examples/integrate-with-react/package.json
+++ b/examples/integrate-with-react/package.json
@@ -11,6 +11,13 @@
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4"
   },
+  "overrides": {
+    "nanoid": "3.3.18",
+    "brace-expansion": "1.1.18",
+    "filelist": {
+      "brace-expansion": "2.1.4"
+    }
+  },
   "scripts": {
     "preinstall": "cd ../.. && npm i && npm run build",
     "start": "react-scripts start",

--- a/modelina-cli/package-lock.json
+++ b/modelina-cli/package-lock.json
@@ -8352,9 +8352,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
       "funding": [
         {
           "type": "github",

--- a/modelina-cli/package.json
+++ b/modelina-cli/package.json
@@ -21,6 +21,9 @@
     "js-yaml": "^4.1.0",
     "node-fetch": "^2.0.0"
   },
+  "overrides": {
+    "fast-uri": "3.1.6"
+  },
   "devDependencies": {
     "@oclif/prettier-config": "^0.2.1",
     "@oclif/test": "^3.2.8",


### PR DESCRIPTION
## Summary
Consolidates and redoes the fixes from 5 open Dependabot security-update PRs, which were all opened against `master`, against `next` instead — `next`'s lockfiles had drifted (in one case, `jackson-databind` was 7 minor versions further behind than the PRs assumed), so the original PR diffs could not be applied cleanly and were redone from scratch.

- `examples/integrate-with-next`: `nanoid` (transitive, via `postcss`) → `3.3.18`
- `examples/integrate-with-react`: `nanoid` (transitive, via `postcss`) → `3.3.18`; `brace-expansion` (transitive, two separate resolution paths) → `1.1.18` / `2.1.4`
- `modelina-cli`: `fast-uri` (transitive, via `ajv`) → `3.1.6` (one patch ahead of the closed PR's `3.1.5` target — newer patch was available)
- `examples/integrate-with-maven/maven-project`: `jackson-databind` / `jackson-annotations` (direct) → `2.22.2` (one patch ahead of the closed PR's `2.22.1` target)

All bumps applied via each sub-project's own `overrides` field (npm) or direct pom.xml version bump (Maven), scoped to that sub-project only — root `package.json`/`package-lock.json` is untouched, none of these packages appear there.

Closes #2652
Closes #2648
Closes #2635
Closes #2634
Closes #2604

## Validation
- `modelina-cli`: `npm install`, `npm ls fast-uri` (confirms override applied), `npm run build`, `npm run lint` — all pass.
- `examples/integrate-with-next`: `npm install --ignore-scripts`, `npm ls nanoid` (confirms override applied), `npm run build` — passes (Next.js production build succeeds).
- `examples/integrate-with-react`: `npm install --ignore-scripts`, `npm ls nanoid brace-expansion` (confirms overrides applied). `npm run build` fails, but this is **pre-existing and unrelated** — confirmed by reproducing the same failure on the pre-change code (`react-scripts build` rejects the example's `import { TypeScriptGenerator } from '../../../'` as outside `src/`, since this example's build normally depends on the full monorepo `preinstall` symlink/build step which isn't exercised by CI and wasn't run here).
- `examples/integrate-with-maven/maven-project`: pom.xml edited directly; Maven isn't available in this environment to run a local build, so this hasn't been build-verified beyond correctness of the version bump. Recommend CI or a manual `mvn compile` confirms it.

## Out of scope
There are 188 open Dependabot alerts on this repo in total; only 15 were covered by the 5 PRs above. The remaining 173 (js-yaml, postcss, ajv, lodash duplicates, webpack-dev-server, tar, svgo, uuid, serialize-javascript, `@babel/core`, `http-proxy-middleware`, `@tootallnate/once`, `@actions/core`, a GitHub Actions `setup-php` alert, and a second Maven manifest at `test/runtime/runtime-java/pom.xml`) have no existing PR and were intentionally left untouched — this PR only consolidates the 5 PRs that already existed. Happy to scope a follow-up pass for the rest if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)