### PR TITLE
chore: repair Docker build broken by upstream image/repo removals

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,16 @@
-FROM eclipse-temurin:21-jdk-bookworm
+FROM debian:bookworm
 
 # Install updates
 RUN apt-get update -yq \
-    && apt-get install -yq curl
+    && apt-get install -yq curl wget gnupg ca-certificates apt-transport-https
+
+# Install Eclipse Temurin JDK 21 (eclipse-temurin no longer ships Debian
+# Bookworm images, so install it via Adoptium's apt repo instead)
+RUN mkdir -p /etc/apt/keyrings \
+    && wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | tee /etc/apt/keyrings/adoptium.asc \
+    && echo "deb [signed-by=/etc/apt/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb bookworm main" | tee /etc/apt/sources.list.d/adoptium.list \
+    && apt-get update -yq \
+    && apt-get install -yq temurin-21-jdk
 
 # Install C++ compiler
 RUN apt-get install -yq build-essential
@@ -16,12 +24,10 @@ ARG TARGETARCH
 RUN curl -fsSL "https://go.dev/dl/go1.22.4.linux-${TARGETARCH}.tar.gz" | tar -C /usr/local -xz
 ENV PATH="${PATH}:/usr/local/go/bin"
 
-# Install dotnet SDK
-RUN apt install apt-transport-https dirmngr gnupg ca-certificates -yq  \
-    && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
-    && echo "deb https://download.mono-project.com/repo/debian stable-bookworm main" | tee /etc/apt/sources.list.d/mono-official-stable.list \
-    && apt update -yq  \
-    && apt install mono-devel -yq
+# Install dotnet SDK (mono-devel is available directly from Debian's own
+# repos; the third-party mono-project apt repo no longer publishes bookworm
+# packages)
+RUN apt-get install -yq mono-devel
 
 # Install rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y


### PR DESCRIPTION
## Summary
The Docker build workflow has been failing on `next` since at least early July: https://github.com/asyncapi/modelina/actions/runs/33488050619/job/99792689070

- `eclipse-temurin:21-jdk-bookworm` no longer exists — Eclipse Temurin dropped Debian Bookworm images entirely in favor of Ubuntu (noble/resolute) tags, so the base image pull 404s.
- This was masking a second, pre-existing failure: the third-party `download.mono-project.com` apt repo no longer serves a Debian Bookworm release either (the mono-project apt hosting appears effectively abandoned/broken for anything past Buster/Focal).

## Fix
- Switch the base image to `debian:bookworm` and install Temurin JDK 21 via Adoptium's own apt repo, which still supports Bookworm.
- Drop the third-party mono-project apt repo and install `mono-devel` directly from Debian's own repos (it's shipped there natively), avoiding the broken third-party source altogether.

## Test plan
- [x] `docker build -f Dockerfile .` completes successfully locally (arm64)
- [x] Verified inside the built image: `java -version`, `node -v`, `go version`, `mono --version`, `python3 --version`, `kotlinc -version`, `php -v`, `chromium --version` all work
- [ ] CI Docker build workflow passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6gVFF7PvsBDwHURarj18b